### PR TITLE
[AA-901] - Latest platform nuget packages(.net core 3.1 compatible) update on admin app

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Commands/EditApplicationCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Commands/EditApplicationCommandTests.cs
@@ -80,8 +80,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Database.Commands
 
             _application.ApiClients.Add(_apiClient);
             _application.Profiles.Add(_profile);
-            _application.CreateEducationOrganizationAssociation(12345);
-            _application.CreateEducationOrganizationAssociation(67890);
+            _application.ApplicationEducationOrganizations.Add(_application.CreateApplicationEducationOrganization(12345));
+            _application.ApplicationEducationOrganizations.Add(_application.CreateApplicationEducationOrganization(67890));
 
             Save(_vendor, _otherVendor, _user, _otherUser, _profile, _otherProfile, _application);
         }

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
@@ -79,8 +79,8 @@
     <Reference Include="EdFi.Ods.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Ods.Common.5.0.0\lib\net48\EdFi.Ods.Common.dll</HintPath>
     </Reference>
-    <Reference Include="EdFi.Security.DataAccess, Version=3.4.0.1012, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EdFi.Security.DataAccess.3.4.0\lib\net48\EdFi.Security.DataAccess.dll</HintPath>
+    <Reference Include="EdFi.Security.DataAccess, Version=5.0.0.5, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EdFi.Suite3.Security.DataAccess.5.0.0\lib\net48\EdFi.Security.DataAccess.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.4.0\lib\net45\EntityFramework.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
@@ -70,11 +70,14 @@
     <Reference Include="Dapper, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Dapper.2.0.30\lib\net461\Dapper.dll</HintPath>
     </Reference>
-    <Reference Include="EdFi.Admin.DataAccess, Version=3.4.0.11, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EdFi.Admin.DataAccess.3.4.0\lib\net48\EdFi.Admin.DataAccess.dll</HintPath>
+    <Reference Include="EdFi.Admin.DataAccess, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EdFi.Suite3.Admin.DataAccess.5.0.0\lib\net48\EdFi.Admin.DataAccess.dll</HintPath>
     </Reference>
-    <Reference Include="EdFi.Common, Version=3.4.0.98, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EdFi.Common.3.4.0\lib\net48\EdFi.Common.dll</HintPath>
+    <Reference Include="EdFi.Common, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EdFi.Common.5.0.0\lib\net48\EdFi.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="EdFi.Ods.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EdFi.Ods.Common.5.0.0\lib\net48\EdFi.Ods.Common.dll</HintPath>
     </Reference>
     <Reference Include="EdFi.Security.DataAccess, Version=3.4.0.1012, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Security.DataAccess.3.4.0\lib\net48\EdFi.Security.DataAccess.dll</HintPath>
@@ -89,7 +92,7 @@
       <HintPath>..\packages\EntityFramework6.Npgsql.3.2.1.1\lib\net45\EntityFramework6.Npgsql.dll</HintPath>
     </Reference>
     <Reference Include="FluentValidation, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7de548da2fbae0f0, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentValidation.8.1.3\lib\net45\FluentValidation.dll</HintPath>
+      <HintPath>..\packages\FluentValidation.8.6.0\lib\net45\FluentValidation.dll</HintPath>
     </Reference>
     <Reference Include="Hyak.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Hyak.Common.1.0.2\lib\net45\Hyak.Common.dll</HintPath>
@@ -164,7 +167,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Npgsql, Version=4.1.3.1, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
       <HintPath>..\packages\Npgsql.4.1.3.1\lib\net461\Npgsql.dll</HintPath>
@@ -176,6 +179,9 @@
     <Reference Include="Respawn, Version=0.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Respawn.0.2.0\lib\net45\Respawn.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="Sandwych.QuickGraph.Core, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sandwych.QuickGraph.Core.1.0.0\lib\net45\Sandwych.QuickGraph.Core.dll</HintPath>
     </Reference>
     <Reference Include="Shouldly, Version=3.0.1.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
       <HintPath>..\packages\Shouldly.3.0.1\lib\net451\Shouldly.dll</HintPath>
@@ -201,6 +207,9 @@
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Data.OracleClient" />
+    <Reference Include="System.Data.SqlClient, Version=4.6.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.SqlClient.4.8.0\lib\net461\System.Data.SqlClient.dll</HintPath>
+    </Reference>
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.6.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
@@ -74,7 +74,7 @@
       <HintPath>..\packages\EdFi.Suite3.Admin.DataAccess.5.0.0\lib\net48\EdFi.Admin.DataAccess.dll</HintPath>
     </Reference>
     <Reference Include="EdFi.Common, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EdFi.Common.5.0.0\lib\net48\EdFi.Common.dll</HintPath>
+      <HintPath>..\packages\EdFi.Suite3.Common.5.0.0\lib\net48\EdFi.Common.dll</HintPath>
     </Reference>
     <Reference Include="EdFi.Ods.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Ods.Common.5.0.0\lib\net48\EdFi.Ods.Common.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
@@ -6,8 +6,8 @@
   <package id="Dapper" version="2.0.30" targetFramework="net48" />
   <package id="EdFi.Common" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Ods.Common" version="5.0.0" targetFramework="net48" />
-  <package id="EdFi.Security.DataAccess" version="3.4.0" targetFramework="net48" />
   <package id="EdFi.Suite3.Admin.DataAccess" version="5.0.0" targetFramework="net48" />
+  <package id="EdFi.Suite3.Security.DataAccess" version="5.0.0" targetFramework="net48" />
   <package id="EntityFramework" version="6.4.0" targetFramework="net48" />
   <package id="EntityFramework6.Npgsql" version="3.2.1.1" targetFramework="net48" />
   <package id="FluentValidation" version="8.6.0" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
@@ -4,12 +4,13 @@
   <package id="Castle.Core" version="4.4.0" targetFramework="net48" />
   <package id="Castle.Windsor" version="5.0.1" targetFramework="net48" />
   <package id="Dapper" version="2.0.30" targetFramework="net48" />
-  <package id="EdFi.Admin.DataAccess" version="3.4.0" targetFramework="net48" />
-  <package id="EdFi.Common" version="3.4.0" targetFramework="net48" />
+  <package id="EdFi.Common" version="5.0.0" targetFramework="net48" />
+  <package id="EdFi.Ods.Common" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Security.DataAccess" version="3.4.0" targetFramework="net48" />
+  <package id="EdFi.Suite3.Admin.DataAccess" version="5.0.0" targetFramework="net48" />
   <package id="EntityFramework" version="6.4.0" targetFramework="net48" />
   <package id="EntityFramework6.Npgsql" version="3.2.1.1" targetFramework="net48" />
-  <package id="FluentValidation" version="8.1.3" targetFramework="net48" />
+  <package id="FluentValidation" version="8.6.0" targetFramework="net48" />
   <package id="Hyak.Common" version="1.0.2" targetFramework="net48" />
   <package id="log4net" version="2.0.8" targetFramework="net48" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.2.3" targetFramework="net48" />
@@ -35,11 +36,12 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net48" />
   <package id="Microsoft.Win32.Primitives" version="4.0.1" targetFramework="net48" />
   <package id="Moq" version="4.10.0" targetFramework="net48" />
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
   <package id="Npgsql" version="4.1.3.1" targetFramework="net48" />
   <package id="NUnit" version="3.11.0" targetFramework="net48" />
   <package id="NUnit3TestAdapter" version="3.11.0" targetFramework="net48" />
   <package id="Respawn" version="0.2.0" targetFramework="net48" />
+  <package id="Sandwych.QuickGraph.Core" version="1.0.0" targetFramework="net48" />
   <package id="Shouldly" version="3.0.1" targetFramework="net48" />
   <package id="System.Buffers" version="4.5.0" targetFramework="net48" />
   <package id="System.Collections" version="4.0.11" targetFramework="net48" />
@@ -47,6 +49,9 @@
   <package id="System.ComponentModel.Annotations" version="4.4.1" targetFramework="net48" />
   <package id="System.ComponentModel.Primitives" version="4.3.0" targetFramework="net48" />
   <package id="System.Configuration.ConfigurationManager" version="4.7.0" targetFramework="net48" />
+  <package id="System.Data.DataSetExtensions" version="4.5.0" targetFramework="net48" />
+  <package id="System.Data.SqlClient" version="4.8.0" targetFramework="net48" />
+  <package id="System.Diagnostics.Contracts" version="4.3.0" targetFramework="net48" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net48" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.6.0" targetFramework="net48" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
@@ -7,6 +7,7 @@
   <package id="EdFi.Common" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Ods.Common" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Suite3.Admin.DataAccess" version="5.0.0" targetFramework="net48" />
+  <package id="EdFi.Suite3.Common" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Suite3.Security.DataAccess" version="5.0.0" targetFramework="net48" />
   <package id="EntityFramework" version="6.4.0" targetFramework="net48" />
   <package id="EntityFramework6.Npgsql" version="3.2.1.1" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Management/Database/Commands/EditApplicationCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/Commands/EditApplicationCommand.cs
@@ -54,7 +54,7 @@ namespace EdFi.Ods.AdminApp.Management.Database.Commands
             }
 
             application.ApplicationEducationOrganizations.Clear();
-            model.EducationOrganizationIds.ToList().ForEach(id => application.CreateEducationOrganizationAssociation(id));
+            model.EducationOrganizationIds.ToList().ForEach(id => application.ApplicationEducationOrganizations.Add(application.CreateApplicationEducationOrganization(id)));
 
             if (application.Profiles == null)
             {

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -17,9 +17,9 @@
     <PackageReference Include="dbup-core" Version="4.2.0" />
     <PackageReference Include="dbup-postgresql" Version="4.2.0" />
     <PackageReference Include="dbup-sqlserver" Version="4.2.0" />
-    <PackageReference Include="EdFi.Admin.DataAccess" Version="3.4.0" />
-    <PackageReference Include="EdFi.Common" Version="3.4.0" />
+    <PackageReference Include="EdFi.Common" Version="5.0.0" />
     <PackageReference Include="EdFi.Security.DataAccess" Version="3.4.0" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.0.0" />
     <PackageReference Include="EntityFramework" Version="6.4.0" />
     <PackageReference Include="Flurl" Version="2.8.2" />
     <PackageReference Include="log4net" Version="2.0.8" />

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="dbup-sqlserver" Version="4.2.0" />
     <PackageReference Include="EdFi.Common" Version="5.0.0" />
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.0.0" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.0.0" />
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.0.0" />
     <PackageReference Include="EntityFramework" Version="6.4.0" />
     <PackageReference Include="Flurl" Version="2.8.2" />

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="dbup-postgresql" Version="4.2.0" />
     <PackageReference Include="dbup-sqlserver" Version="4.2.0" />
     <PackageReference Include="EdFi.Common" Version="5.0.0" />
-    <PackageReference Include="EdFi.Security.DataAccess" Version="3.4.0" />
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.0.0" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.0.0" />
     <PackageReference Include="EntityFramework" Version="6.4.0" />
     <PackageReference Include="Flurl" Version="2.8.2" />
     <PackageReference Include="log4net" Version="2.0.8" />

--- a/Application/EdFi.Ods.AdminApp.Web.Tests/EdFi.Ods.AdminApp.Web.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Tests/EdFi.Ods.AdminApp.Web.Tests.csproj
@@ -68,8 +68,8 @@
     <Reference Include="EdFi.Common, Version=3.4.0.98, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Common.3.4.0\lib\net48\EdFi.Common.dll</HintPath>
     </Reference>
-    <Reference Include="EdFi.LoadTools, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EdFi.LoadTools.3.4.0-pre83\lib\net48\EdFi.LoadTools.dll</HintPath>
+    <Reference Include="EdFi.LoadTools, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EdFi.Suite3.LoadTools.5.0.0\lib\net48\EdFi.LoadTools.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Web.Tests/EdFi.Ods.AdminApp.Web.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Tests/EdFi.Ods.AdminApp.Web.Tests.csproj
@@ -65,8 +65,8 @@
     <Reference Include="Castle.Windsor, Version=5.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Windsor.5.0.1\lib\net45\Castle.Windsor.dll</HintPath>
     </Reference>
-    <Reference Include="EdFi.Common, Version=3.4.0.98, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EdFi.Common.3.4.0\lib\net48\EdFi.Common.dll</HintPath>
+    <Reference Include="EdFi.Common, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EdFi.Common.5.0.0\lib\net48\EdFi.Common.dll</HintPath>
     </Reference>
     <Reference Include="EdFi.LoadTools, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Suite3.LoadTools.5.0.0\lib\net48\EdFi.LoadTools.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Web.Tests/EdFi.Ods.AdminApp.Web.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Tests/EdFi.Ods.AdminApp.Web.Tests.csproj
@@ -66,7 +66,7 @@
       <HintPath>..\packages\Castle.Windsor.5.0.1\lib\net45\Castle.Windsor.dll</HintPath>
     </Reference>
     <Reference Include="EdFi.Common, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EdFi.Common.5.0.0\lib\net48\EdFi.Common.dll</HintPath>
+      <HintPath>..\packages\EdFi.Suite3.Common.5.0.0\lib\net48\EdFi.Common.dll</HintPath>
     </Reference>
     <Reference Include="EdFi.LoadTools, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Suite3.LoadTools.5.0.0\lib\net48\EdFi.LoadTools.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Web.Tests/EdFi.Ods.AdminApp.Web.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Tests/EdFi.Ods.AdminApp.Web.Tests.csproj
@@ -94,7 +94,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.11.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Web.Tests/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Web.Tests/packages.config
@@ -4,7 +4,7 @@
   <package id="Castle.Core" version="4.4.0" targetFramework="net48" />
   <package id="Castle.Windsor" version="5.0.1" targetFramework="net48" />
   <package id="EdFi.Common" version="3.4.0" targetFramework="net48" />
-  <package id="EdFi.LoadTools" version="3.4.0-pre83" targetFramework="net48" />
+  <package id="EdFi.Suite3.LoadTools" version="5.0.0" targetFramework="net48" />
   <package id="log4net" version="2.0.8" targetFramework="net48" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.4" targetFramework="net48" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Web.Tests/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Web.Tests/packages.config
@@ -3,7 +3,7 @@
   <package id="AutoMapper" version="5.1.1" targetFramework="net48" />
   <package id="Castle.Core" version="4.4.0" targetFramework="net48" />
   <package id="Castle.Windsor" version="5.0.1" targetFramework="net48" />
-  <package id="EdFi.Common" version="3.4.0" targetFramework="net48" />
+  <package id="EdFi.Common" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Suite3.LoadTools" version="5.0.0" targetFramework="net48" />
   <package id="log4net" version="2.0.8" targetFramework="net48" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.4" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Web.Tests/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Web.Tests/packages.config
@@ -17,7 +17,7 @@
   <package id="Microsoft.NET.Test.Sdk" version="16.4.0" targetFramework="net48" />
   <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net48" />
   <package id="Moq" version="4.10.0" targetFramework="net48" />
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
   <package id="NUnit" version="3.11.0" targetFramework="net48" />
   <package id="NUnit3TestAdapter" version="3.11.0" targetFramework="net48" />
   <package id="QuickGraph" version="3.6.61119.7" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Web.Tests/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Web.Tests/packages.config
@@ -4,6 +4,7 @@
   <package id="Castle.Core" version="4.4.0" targetFramework="net48" />
   <package id="Castle.Windsor" version="5.0.1" targetFramework="net48" />
   <package id="EdFi.Common" version="5.0.0" targetFramework="net48" />
+  <package id="EdFi.Suite3.Common" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Suite3.LoadTools" version="5.0.0" targetFramework="net48" />
   <package id="log4net" version="2.0.8" targetFramework="net48" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.4" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -72,17 +72,20 @@
     <Reference Include="Dapper, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Dapper.2.0.30\lib\net461\Dapper.dll</HintPath>
     </Reference>
-    <Reference Include="EdFi.Admin.DataAccess, Version=3.4.0.11, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EdFi.Admin.DataAccess.3.4.0\lib\net48\EdFi.Admin.DataAccess.dll</HintPath>
+    <Reference Include="EdFi.Admin.DataAccess, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EdFi.Suite3.Admin.DataAccess.5.0.0\lib\net48\EdFi.Admin.DataAccess.dll</HintPath>
     </Reference>
     <Reference Include="EdFi.Admin.LearningStandards.Core, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Admin.LearningStandards.Core.1.1.0\lib\netstandard2.0\EdFi.Admin.LearningStandards.Core.dll</HintPath>
     </Reference>
-    <Reference Include="EdFi.Common, Version=3.4.0.98, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EdFi.Common.3.4.0\lib\net48\EdFi.Common.dll</HintPath>
+    <Reference Include="EdFi.Common, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EdFi.Common.5.0.0\lib\net48\EdFi.Common.dll</HintPath>
     </Reference>
     <Reference Include="EdFi.LoadTools, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.LoadTools.3.4.0-pre83\lib\net48\EdFi.LoadTools.dll</HintPath>
+    </Reference>
+    <Reference Include="EdFi.Ods.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EdFi.Ods.Common.5.0.0\lib\net48\EdFi.Ods.Common.dll</HintPath>
     </Reference>
     <Reference Include="EdFi.Security.DataAccess, Version=3.4.0.1012, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Security.DataAccess.3.4.0\lib\net48\EdFi.Security.DataAccess.dll</HintPath>
@@ -97,7 +100,7 @@
       <HintPath>..\packages\EntityFramework6.Npgsql.3.2.1.1\lib\net45\EntityFramework6.Npgsql.dll</HintPath>
     </Reference>
     <Reference Include="FluentValidation, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7de548da2fbae0f0, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentValidation.8.1.3\lib\net45\FluentValidation.dll</HintPath>
+      <HintPath>..\packages\FluentValidation.8.6.0\lib\net45\FluentValidation.dll</HintPath>
     </Reference>
     <Reference Include="FluentValidation.Mvc, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7de548da2fbae0f0, processorArchitecture=MSIL">
       <HintPath>..\packages\FluentValidation.Mvc5.8.1.2\lib\net45\FluentValidation.Mvc.dll</HintPath>
@@ -266,7 +269,7 @@
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Diagnostics, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Npgsql, Version=4.1.3.1, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
       <HintPath>..\packages\Npgsql.4.1.3.1\lib\net461\Npgsql.dll</HintPath>
@@ -295,6 +298,9 @@
     <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.105.2.3\lib\net46\RestSharp.dll</HintPath>
     </Reference>
+    <Reference Include="Sandwych.QuickGraph.Core, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sandwych.QuickGraph.Core.1.0.0\lib\net45\Sandwych.QuickGraph.Core.dll</HintPath>
+    </Reference>
     <Reference Include="SimpleInjector, Version=4.1.0.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
       <HintPath>..\packages\SimpleInjector.4.1.0\lib\net45\SimpleInjector.dll</HintPath>
     </Reference>
@@ -317,6 +323,9 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data.OracleClient" />
+    <Reference Include="System.Data.SqlClient, Version=4.6.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.SqlClient.4.8.0\lib\net461\System.Data.SqlClient.dll</HintPath>
+    </Reference>
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.6.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -87,8 +87,8 @@
     <Reference Include="EdFi.Ods.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Ods.Common.5.0.0\lib\net48\EdFi.Ods.Common.dll</HintPath>
     </Reference>
-    <Reference Include="EdFi.Security.DataAccess, Version=3.4.0.1012, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EdFi.Security.DataAccess.3.4.0\lib\net48\EdFi.Security.DataAccess.dll</HintPath>
+    <Reference Include="EdFi.Security.DataAccess, Version=5.0.0.5, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EdFi.Suite3.Security.DataAccess.5.0.0\lib\net48\EdFi.Security.DataAccess.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.4.0\lib\net45\EntityFramework.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -81,8 +81,8 @@
     <Reference Include="EdFi.Common, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Common.5.0.0\lib\net48\EdFi.Common.dll</HintPath>
     </Reference>
-    <Reference Include="EdFi.LoadTools, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EdFi.LoadTools.3.4.0-pre83\lib\net48\EdFi.LoadTools.dll</HintPath>
+    <Reference Include="EdFi.LoadTools, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EdFi.Suite3.LoadTools.5.0.0\lib\net48\EdFi.LoadTools.dll</HintPath>
     </Reference>
     <Reference Include="EdFi.Ods.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Ods.Common.5.0.0\lib\net48\EdFi.Ods.Common.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -79,7 +79,7 @@
       <HintPath>..\packages\EdFi.Admin.LearningStandards.Core.1.1.0\lib\netstandard2.0\EdFi.Admin.LearningStandards.Core.dll</HintPath>
     </Reference>
     <Reference Include="EdFi.Common, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EdFi.Common.5.0.0\lib\net48\EdFi.Common.dll</HintPath>
+      <HintPath>..\packages\EdFi.Suite3.Common.5.0.0\lib\net48\EdFi.Common.dll</HintPath>
     </Reference>
     <Reference Include="EdFi.LoadTools, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Suite3.LoadTools.5.0.0\lib\net48\EdFi.LoadTools.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Web/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Web/packages.config
@@ -12,8 +12,8 @@
   <package id="EdFi.Common" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.LoadTools" version="3.4.0-pre83" targetFramework="net48" />
   <package id="EdFi.Ods.Common" version="5.0.0" targetFramework="net48" />
-  <package id="EdFi.Security.DataAccess" version="3.4.0" targetFramework="net48" />
   <package id="EdFi.Suite3.Admin.DataAccess" version="5.0.0" targetFramework="net48" />
+  <package id="EdFi.Suite3.Security.DataAccess" version="5.0.0" targetFramework="net48" />
   <package id="EntityFramework" version="6.4.0" targetFramework="net48" />
   <package id="EntityFramework6.Npgsql" version="3.2.1.1" targetFramework="net48" />
   <package id="FluentValidation" version="8.6.0" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Web/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Web/packages.config
@@ -10,9 +10,9 @@
   <package id="Dapper" version="2.0.30" targetFramework="net48" />
   <package id="EdFi.Admin.LearningStandards.Core" version="1.1.0" targetFramework="net48" />
   <package id="EdFi.Common" version="5.0.0" targetFramework="net48" />
-  <package id="EdFi.LoadTools" version="3.4.0-pre83" targetFramework="net48" />
   <package id="EdFi.Ods.Common" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Suite3.Admin.DataAccess" version="5.0.0" targetFramework="net48" />
+  <package id="EdFi.Suite3.LoadTools" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Suite3.Security.DataAccess" version="5.0.0" targetFramework="net48" />
   <package id="EntityFramework" version="6.4.0" targetFramework="net48" />
   <package id="EntityFramework6.Npgsql" version="3.2.1.1" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Web/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Web/packages.config
@@ -8,14 +8,15 @@
   <package id="Castle.Facilities.AspNet.SystemWeb" version="5.0.1" targetFramework="net48" />
   <package id="Castle.Windsor" version="5.0.1" targetFramework="net48" />
   <package id="Dapper" version="2.0.30" targetFramework="net48" />
-  <package id="EdFi.Admin.DataAccess" version="3.4.0" targetFramework="net48" />
   <package id="EdFi.Admin.LearningStandards.Core" version="1.1.0" targetFramework="net48" />
-  <package id="EdFi.Common" version="3.4.0" targetFramework="net48" />
+  <package id="EdFi.Common" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.LoadTools" version="3.4.0-pre83" targetFramework="net48" />
+  <package id="EdFi.Ods.Common" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Security.DataAccess" version="3.4.0" targetFramework="net48" />
+  <package id="EdFi.Suite3.Admin.DataAccess" version="5.0.0" targetFramework="net48" />
   <package id="EntityFramework" version="6.4.0" targetFramework="net48" />
   <package id="EntityFramework6.Npgsql" version="3.2.1.1" targetFramework="net48" />
-  <package id="FluentValidation" version="8.1.3" targetFramework="net48" />
+  <package id="FluentValidation" version="8.6.0" targetFramework="net48" />
   <package id="FluentValidation.Mvc5" version="8.1.2" targetFramework="net48" />
   <package id="FluentValidation.ValidatorAttribute" version="8.1.2" targetFramework="net48" />
   <package id="Hangfire" version="1.6.20" targetFramework="net48" />
@@ -86,7 +87,7 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net48" />
   <package id="Microsoft.Win32.Primitives" version="4.0.1" targetFramework="net48" />
   <package id="Modernizr" version="2.8.3" targetFramework="net48" />
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
   <package id="Npgsql" version="4.1.3.1" targetFramework="net48" />
   <package id="Owin" version="1.0" targetFramework="net48" />
   <package id="Polly" version="6.1.0" targetFramework="net48" />
@@ -94,6 +95,7 @@
   <package id="QuickGraph" version="3.6.61119.7" targetFramework="net48" />
   <package id="Respond" version="1.2.0" targetFramework="net48" />
   <package id="RestSharp" version="105.2.3" targetFramework="net48" />
+  <package id="Sandwych.QuickGraph.Core" version="1.0.0" targetFramework="net48" />
   <package id="SimpleInjector" version="4.1.0" targetFramework="net48" />
   <package id="System.Buffers" version="4.5.0" targetFramework="net48" />
   <package id="System.Collections" version="4.0.11" targetFramework="net48" />
@@ -101,6 +103,9 @@
   <package id="System.ComponentModel.Annotations" version="4.5.0" targetFramework="net48" />
   <package id="System.ComponentModel.Primitives" version="4.3.0" targetFramework="net48" />
   <package id="System.Configuration.ConfigurationManager" version="4.7.0" targetFramework="net48" />
+  <package id="System.Data.DataSetExtensions" version="4.5.0" targetFramework="net48" />
+  <package id="System.Data.SqlClient" version="4.8.0" targetFramework="net48" />
+  <package id="System.Diagnostics.Contracts" version="4.3.0" targetFramework="net48" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net48" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.6.0" targetFramework="net48" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Web/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Web/packages.config
@@ -12,6 +12,7 @@
   <package id="EdFi.Common" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Ods.Common" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Suite3.Admin.DataAccess" version="5.0.0" targetFramework="net48" />
+  <package id="EdFi.Suite3.Common" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Suite3.LoadTools" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Suite3.Security.DataAccess" version="5.0.0" targetFramework="net48" />
   <package id="EntityFramework" version="6.4.0" targetFramework="net48" />


### PR DESCRIPTION
**Description**
- Updated EdFi.Admin.DataAccess to EdFi.Suite3.Admin.DataAccess across the solution. The EdFi.Common was specifically updated to 5.0.0 on EdFi.Ods.AdminApp.Management.csproj.
- Updated EdFi.Security.DataAccess to EdFi.Suite3.Security.DataAccess across the solution.
- Updated EdFi.LoadTools to EdFi.Suite3.LoadTools across the solution.
- Updated EdFi.Common 3.4.0 to EdFi.Common 5.0.0 in the Web.Tests project
- Added EdFi.Suite3.Common 5.0.0 in the Web, Web.Tests, Management and Management.Tests project
- Refactored EditApplicationCommand and corresponding tests to use CreateApplicationEducationOrganization instead of CreateEducationOrganizationAssociation instead because of the method being renamed. 
- All the other version and dependency package updates are automatically handled by nuget.