### PR TITLE
[AA-944] Favor OnPremisesRelease Configuration

### DIFF
--- a/.teamcity/_Self/templates/BuildAndTestTemplate.kt
+++ b/.teamcity/_Self/templates/BuildAndTestTemplate.kt
@@ -28,7 +28,7 @@ object BuildAndTestTemplate : Template({
             executionMode = BuildStep.ExecutionMode.RUN_ON_SUCCESS
             scriptMode = script {
                 content = """
-                    .\build.ps1 -BuildCounter %build.counter% -Command Build -Version "%adminApp.version%"
+                    .\build.ps1 -BuildCounter %build.counter% -Command Build -Version "%adminApp.version%" -BuildConfiguration OnPremisesRelease
                 """.trimIndent()
             }
         }
@@ -43,7 +43,7 @@ object BuildAndTestTemplate : Template({
             executionMode = BuildStep.ExecutionMode.RUN_ON_SUCCESS
             scriptMode = script {
                 content = """
-                    .\build.ps1 -Version %adminApp.version% -BuildCounter %build.counter% -Command Package
+                    .\build.ps1 -Version %adminApp.version% -BuildCounter %build.counter% -Command Package -BuildConfiguration OnPremisesRelease
                 """.trimIndent()
             }
         }
@@ -53,7 +53,7 @@ object BuildAndTestTemplate : Template({
             executionMode = BuildStep.ExecutionMode.RUN_ON_SUCCESS
             scriptMode = script {
                 content = """
-                    .\build.ps1 -Command UnitTest
+                    .\build.ps1 -Command UnitTest -BuildConfiguration OnPremisesRelease
                 """.trimIndent()
             }
         }
@@ -63,7 +63,7 @@ object BuildAndTestTemplate : Template({
             executionMode = BuildStep.ExecutionMode.RUN_ON_SUCCESS
             scriptMode = script {
                 content = """
-                    .\build.ps1 -Command IntegrationTest
+                    .\build.ps1 -Command IntegrationTest -BuildConfiguration OnPremisesRelease
                 """.trimIndent()
             }
         }

--- a/build.ps1
+++ b/build.ps1
@@ -102,6 +102,9 @@ $solution = "Application\Ed-Fi-ODS-Tools.sln"
 if ("Release" -eq $BuildConfiguration) {
     $configuration = "Release"
     $testConfiguration = "Release"
+} elseif ("OnPremisesRelease" -eq $BuildConfiguration) {
+    $configuration = "OnPremisesRelease"
+    $testConfiguration = "Release"
 } else {
     $configuration = "OnPremises"
     $testConfiguration = "Debug"

--- a/build.ps1
+++ b/build.ps1
@@ -70,9 +70,9 @@ param(
     [string]
     $BuildCounter = "1",
 
-    # .NET project build configuration, defaults to "Debug". Options are: Debug, Release.
+    # .NET project build configuration, defaults to "Debug". Options are: Debug, Release, OnPremisesRelease.
     [string]
-    [ValidateSet("Debug", "Release")]
+    [ValidateSet("Debug", "Release", "OnPremisesRelease")]
     $BuildConfiguration = "Debug",
 
     # Optional location of msbuild.exe. If not provided, the script attempts to

--- a/build.ps1
+++ b/build.ps1
@@ -100,10 +100,9 @@ param(
 $solution = "Application\Ed-Fi-ODS-Tools.sln"
 
 if ("Release" -eq $BuildConfiguration) {
-    $configuration = "OnPremisesRelease"
+    $configuration = "Release"
     $testConfiguration = "Release"
-}
-else {
+} else {
     $configuration = "OnPremises"
     $testConfiguration = "Debug"
 }


### PR DESCRIPTION
To meet the behavior of TeamCity builds prior to the creation of the Ed-Fi-Alliance-OSS organization, the TeamCity build favors the OnPremisesRelease configuration.

Note also some adjustments to the build.ps1 script to better reflect the current Build Configurations matrix in the *.sln file itself, to ensure all the intended tests can be found and run.