### PR TITLE
[AA-1010] - Bump AppCommon to Include Version With New UrlRewrite Download Link

### DIFF
--- a/EdFi.Suite3.Installer.AdminApp/prep-installer-package.ps1
+++ b/EdFi.Suite3.Installer.AdminApp/prep-installer-package.ps1
@@ -14,7 +14,7 @@ $ErrorActionPreference = "Stop"
 Push-Location $PackageDirectory
 
 $dependencyVersions = @{
-    AppCommon = "1.0.0-pre1089"
+    AppCommon = "1.0.0-pre1094"
 }
 
 # This is a hack for TeamCity - create empty ODS and Implementation directories so that


### PR DESCRIPTION
AppCommon build [1094](https://intedfitools1.msdf.org/buildConfiguration/SharedLibraries_EdFiInstallerAppCommon/86578) includes change for urlrewrite broken link. Package build locally on my machine and verified the updated link showed in the prerequisites.psm1 file.