### PR TITLE
[AA-1016] Pessimistic simultaneous API calls against ODS 3.x

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web.Tests/Controllers/OdsInstanceSettingsController/WhenRunningBulkUpload.cs
+++ b/Application/EdFi.Ods.AdminApp.Web.Tests/Controllers/OdsInstanceSettingsController/WhenRunningBulkUpload.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -178,10 +178,13 @@ namespace EdFi.Ods.AdminApp.Web.Tests.Controllers.OdsInstanceSettingsController
         }
 
         [Test]
-        public async Task When_Perform_Post_Request_To_BulkFileUpload_With_Valid_File_Job_Should_Enqueued()
+        public async Task When_Perform_Post_Request_To_BulkFileUpload_With_Valid_File_Job_Should_Be_Enqueued()
         {
+            const string odsApiVersion = "5.0.0";
             const string edfiStandardVersion = "3.2.0-c";
-            InferOdsApiVersion.Setup(x => x.EdFiStandardVersion(It.IsAny<string>())).Returns(edfiStandardVersion);
+            InferOdsApiVersion.Setup(x => x.Version("http://example.com")).Returns(odsApiVersion);
+            InferOdsApiVersion.Setup(x => x.EdFiStandardVersion("http://example.com")).Returns(edfiStandardVersion);
+
             var schemaBasePath = HostingEnvironment.MapPath(ConfigurationManager.AppSettings["XsdFolder"]);
             var schemaPath = $"{schemaBasePath}\\{edfiStandardVersion}";
 
@@ -205,7 +208,8 @@ namespace EdFi.Ods.AdminApp.Web.Tests.Controllers.OdsInstanceSettingsController
                     () => actual.DependenciesUrl.ShouldBe(_connectionInformation.DependenciesUrl),
                     () => actual.MetadataUrl.ShouldBe(_connectionInformation.MetadataUrl),
                     () => actual.OauthUrl.ShouldBe(_connectionInformation.OAuthUrl),
-                    () => actual.SchemaPath.ShouldBe(schemaPath)
+                    () => actual.SchemaPath.ShouldBe(schemaPath),
+                    () => actual.MaxSimultaneousRequests.ShouldBe(20)
                 );
                 return true;
             };
@@ -221,8 +225,45 @@ namespace EdFi.Ods.AdminApp.Web.Tests.Controllers.OdsInstanceSettingsController
         }
 
         [Test]
+        public async Task When_Perform_Post_Request_To_BulkFileUpload_Against_ODS3_Job_Should_Be_Enqueued_With_Pessimistic_Throttling()
+        {
+            const string odsApiVersion = "3.4.0";
+            const string edfiStandardVersion = "3.2.0-b";
+            InferOdsApiVersion.Setup(x => x.Version("http://example.com")).Returns(odsApiVersion);
+            InferOdsApiVersion.Setup(x => x.EdFiStandardVersion("http://example.com")).Returns(edfiStandardVersion);
+
+            var model = SetupBulkUpload(out var fileUploadResult);
+
+            BulkUploadJob.Setup(x => x.IsJobRunning()).Returns(false);
+            BulkUploadJob.Setup(x => x.IsSameOdsInstance(OdsInstanceContext.Id, typeof(BulkUploadJobContext))).Returns(true);
+
+            var result = (PartialViewResult)await SystemUnderTest.BulkFileUpload(model);
+
+            // Assert
+            Func<BulkUploadJobContext, bool> bulkUploadJobEnqueueVerifier = actual =>
+            {
+                actual.MaxSimultaneousRequests.ShouldBe(1);
+                return true;
+            };
+            result.ShouldNotBeNull();
+            result.ViewName.ShouldBe("_SignalRStatus_BulkLoad");
+            result.Model.ShouldNotBeNull();
+            var settingsModel = (OdsInstanceSettingsModel)result.Model;
+            settingsModel.BulkFileUploadModel.ShouldNotBeNull();
+            settingsModel.BulkFileUploadModel.IsSameOdsInstance.ShouldBeTrue();
+            BulkUploadJob.Verify(
+                x => x.EnqueueJob(It.Is<BulkUploadJobContext>(y => bulkUploadJobEnqueueVerifier(y))),
+                Times.Once);
+        }
+
+        [Test]
         public async Task When_Job_Is_Already_Running_New_Job_Should_Not_Be_Enqueued()
         {
+            const string odsApiVersion = "3.4.0";
+            const string edfiStandardVersion = "3.2.0-b";
+            InferOdsApiVersion.Setup(x => x.Version("http://example.com")).Returns(odsApiVersion);
+            InferOdsApiVersion.Setup(x => x.EdFiStandardVersion("http://example.com")).Returns(edfiStandardVersion);
+
             var model = SetupBulkUpload(out var fileUploadResult);
 
             BulkUploadJob.Setup(x => x.IsJobRunning()).Returns(true);

--- a/Application/EdFi.Ods.AdminApp.Web.Tests/Controllers/OdsInstanceSettingsController/WhenRunningBulkUpload.cs
+++ b/Application/EdFi.Ods.AdminApp.Web.Tests/Controllers/OdsInstanceSettingsController/WhenRunningBulkUpload.cs
@@ -231,21 +231,6 @@ namespace EdFi.Ods.AdminApp.Web.Tests.Controllers.OdsInstanceSettingsController
             var result = (PartialViewResult)await SystemUnderTest.BulkFileUpload(model);
 
             // Assert
-            Func<BulkUploadJobContext, bool> bulkUploadJobEnqueueVerifier = actual =>
-            {
-                actual.ShouldSatisfyAllConditions(
-                    () => actual.Environment.ShouldBe(CloudOdsEnvironment.Production.Value),
-                    () => actual.DataDirectoryFullPath.ShouldBe(fileUploadResult.Directory),
-                    () => actual.OdsInstanceId.ShouldBe(OdsInstanceContext.Id),
-                    () => actual.ApiBaseUrl.ShouldBe(_connectionInformation.ApiBaseUrl),
-                    () => actual.ClientKey.ShouldBe(_connectionInformation.ClientKey),
-                    () => actual.ClientSecret.ShouldBe(_connectionInformation.ClientSecret),
-                    () => actual.DependenciesUrl.ShouldBe(_connectionInformation.DependenciesUrl),
-                    () => actual.MetadataUrl.ShouldBe(_connectionInformation.MetadataUrl),
-                    () => actual.OauthUrl.ShouldBe(_connectionInformation.OAuthUrl)
-                );
-                return true;
-            };
             result.ShouldNotBeNull();
             result.ViewName.ShouldBe("_SignalRStatus_BulkLoad");
             result.Model.ShouldNotBeNull();
@@ -254,7 +239,7 @@ namespace EdFi.Ods.AdminApp.Web.Tests.Controllers.OdsInstanceSettingsController
             settingsModel.BulkFileUploadModel.IsJobRunning.ShouldBeTrue();
             settingsModel.BulkFileUploadModel.IsSameOdsInstance.ShouldBeTrue();
             BulkUploadJob.Verify(
-                x => x.EnqueueJob(It.Is<BulkUploadJobContext>(y => bulkUploadJobEnqueueVerifier(y))),
+                x => x.EnqueueJob(It.IsAny<BulkUploadJobContext>()),
                 Times.Never);
         }
 

--- a/Application/EdFi.Ods.AdminApp.Web.Tests/Infrastructure/IO/WhenConfiguringFileImport.cs
+++ b/Application/EdFi.Ods.AdminApp.Web.Tests/Infrastructure/IO/WhenConfiguringFileImport.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -83,6 +83,19 @@ namespace EdFi.Ods.AdminApp.Web.Tests.Infrastructure.IO
             new FileImportConfiguration(string.Empty, expected, null, _connectionInfo.ApiBaseUrl, _connectionInfo.ClientKey, _connectionInfo.ClientSecret, _connectionInfo.OAuthUrl, _connectionInfo.MetadataUrl, _connectionInfo.DependenciesUrl)
                 .WorkingFolder
                 .ShouldBe(expected);
+        }
+
+        [Test]
+        public void GivenMaxSimultaneousRequestsConstructorArg_ThenAllThrottlingPropertiesShouldTakeThatValue()
+        {
+            const int expected = 13;
+
+            var configuration = new FileImportConfiguration(string.Empty, string.Empty, null, _connectionInfo.ApiBaseUrl, _connectionInfo.ClientKey, _connectionInfo.ClientSecret, _connectionInfo.OAuthUrl, _connectionInfo.MetadataUrl, _connectionInfo.DependenciesUrl,
+                maxSimultaneousRequests: expected);
+
+            configuration.TaskCapacity.ShouldBe(expected);
+            configuration.ConnectionLimit.ShouldBe(expected);
+            configuration.MaxSimultaneousRequests.ShouldBe(expected);
         }
 
         [Test]

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/OdsInstanceSettingsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/OdsInstanceSettingsController.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -384,7 +384,8 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
                 DependenciesUrl = connectionInformation.DependenciesUrl,
                 ClientKey = config.BulkUploadCredential?.ApiKey ?? string.Empty,
                 ClientSecret = config.BulkUploadCredential?.ApiSecret ?? string.Empty,
-                SchemaPath = $"{schemaBasePath}\\{standardVersion}"
+                SchemaPath = $"{schemaBasePath}\\{standardVersion}",
+                MaxSimultaneousRequests = 20
             };
 
             if (!_bulkUploadJob.IsJobRunning())

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/OdsInstanceSettingsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/OdsInstanceSettingsController.cs
@@ -371,6 +371,14 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
 
             var schemaBasePath = HostingEnvironment.MapPath(ConfigurationManager.AppSettings["XsdFolder"]);
             var standardVersion = _inferOdsApiVersion.EdFiStandardVersion(connectionInformation.ApiServerUrl);
+            var odsApiVersion = _inferOdsApiVersion.Version(connectionInformation.ApiServerUrl);
+
+            const int IdealSimultaneousRequests = 20;
+            const int PessimisticSimultaneousRequests = 1;
+
+            var maxSimultaneousRequests = odsApiVersion.StartsWith("3.")
+                ? PessimisticSimultaneousRequests
+                : IdealSimultaneousRequests;
 
             var jobContext = new BulkUploadJobContext
             {
@@ -385,7 +393,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
                 ClientKey = config.BulkUploadCredential?.ApiKey ?? string.Empty,
                 ClientSecret = config.BulkUploadCredential?.ApiSecret ?? string.Empty,
                 SchemaPath = $"{schemaBasePath}\\{standardVersion}",
-                MaxSimultaneousRequests = 20
+                MaxSimultaneousRequests = maxSimultaneousRequests
             };
 
             if (!_bulkUploadJob.IsJobRunning())

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/IO/BulkImportService.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/IO/BulkImportService.cs
@@ -147,7 +147,17 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure.IO
 
         private static FileImportConfiguration GetFileImportConfig(BulkUploadJobContext bulkUploadJobContext, string workingFolderPath)
         {
-            return new FileImportConfiguration(bulkUploadJobContext.DataDirectoryFullPath, workingFolderPath, bulkUploadJobContext.SchoolYear, apiBaseUrl: bulkUploadJobContext.ApiBaseUrl, clientKey: bulkUploadJobContext.ClientKey, clientSecret: bulkUploadJobContext.ClientSecret, oauthUrl: bulkUploadJobContext.OauthUrl, metadataUrl: bulkUploadJobContext.MetadataUrl, dependenciesUrl: bulkUploadJobContext.DependenciesUrl, schemaPath: bulkUploadJobContext.SchemaPath);
+            return new FileImportConfiguration(
+                bulkUploadJobContext.DataDirectoryFullPath,
+                workingFolderPath,
+                bulkUploadJobContext.SchoolYear,
+                apiBaseUrl: bulkUploadJobContext.ApiBaseUrl,
+                clientKey: bulkUploadJobContext.ClientKey,
+                clientSecret: bulkUploadJobContext.ClientSecret,
+                oauthUrl: bulkUploadJobContext.OauthUrl,
+                metadataUrl: bulkUploadJobContext.MetadataUrl,
+                dependenciesUrl: bulkUploadJobContext.DependenciesUrl,
+                schemaPath: bulkUploadJobContext.SchemaPath);
         }
 
         public void CleanUp(BulkUploadJobContext jobContext)

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/IO/BulkImportService.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/IO/BulkImportService.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -157,7 +157,8 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure.IO
                 oauthUrl: bulkUploadJobContext.OauthUrl,
                 metadataUrl: bulkUploadJobContext.MetadataUrl,
                 dependenciesUrl: bulkUploadJobContext.DependenciesUrl,
-                schemaPath: bulkUploadJobContext.SchemaPath);
+                schemaPath: bulkUploadJobContext.SchemaPath,
+                maxSimultaneousRequests: bulkUploadJobContext.MaxSimultaneousRequests);
         }
 
         public void CleanUp(BulkUploadJobContext jobContext)

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/IO/FileImportConfiguration.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/IO/FileImportConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -12,7 +12,7 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure.IO
         public FileImportConfiguration(string dataDirectoryFullPath,
             string workingFolderPath, int? schoolYear = null, string apiBaseUrl = null, string clientKey = null,
             string clientSecret = null, string oauthUrl = null, string metadataUrl = null,
-            string dependenciesUrl = null, string schemaPath = null)
+            string dependenciesUrl = null, string schemaPath = null, int maxSimultaneousRequests = 20)
         {
             Require(apiBaseUrl);
             Require(clientKey);
@@ -21,7 +21,7 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure.IO
             Require(metadataUrl);
             Require(dependenciesUrl);
 
-            SetConfiguration(dataDirectoryFullPath, workingFolderPath, apiBaseUrl, clientKey, clientSecret, oauthUrl, metadataUrl, dependenciesUrl, schoolYear, schemaPath);
+            SetConfiguration(dataDirectoryFullPath, workingFolderPath, apiBaseUrl, clientKey, clientSecret, oauthUrl, metadataUrl, dependenciesUrl, schoolYear, schemaPath, maxSimultaneousRequests);
         }
 
         private void Require(string connectionInformationArgument)
@@ -32,7 +32,8 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure.IO
             }
         }
 
-        private void SetConfiguration(string dataDirectoryFullPath, string workingFolderPath, string apiBaseUrl, string clientKey, string clientSecret, string oauthUrl, string metadataUrl, string dependenciesUrl, int? schoolYear, string schemaPath)
+        private void SetConfiguration(string dataDirectoryFullPath, string workingFolderPath, string apiBaseUrl, string clientKey, string clientSecret, string oauthUrl, string metadataUrl, string dependenciesUrl, int? schoolYear, string schemaPath,
+            int maxSimultaneousRequests)
         {
             DataFolder = dataDirectoryFullPath;
             WorkingFolder = workingFolderPath;
@@ -45,9 +46,9 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure.IO
             InterchangeOrderFolder = schemaPath;
             Retries = 3;
             SchoolYear = schoolYear;
-            ConnectionLimit = 20;
-            TaskCapacity = 20;
-            MaxSimultaneousRequests = 20;
+            ConnectionLimit = maxSimultaneousRequests;
+            TaskCapacity = maxSimultaneousRequests;
+            MaxSimultaneousRequests = maxSimultaneousRequests;
             DependenciesUrl = dependenciesUrl;
         }
     }

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/Jobs/BulkUploadJob.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/Jobs/BulkUploadJob.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -60,6 +60,7 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure.Jobs
         public string MetadataUrl { get; set; }
         public string DependenciesUrl { get; set; }
         public string SchemaPath { get; set; }
+        public int MaxSimultaneousRequests { get; set; }
     }
 }
 


### PR DESCRIPTION
Per discussion on this and related tickets, ODS 3.x experiences multithreading issues under high load such as during Learning Standards and Bulk Load operations. ODS 5.x is understood to be safe from this issue. To mitigate the problem when running these two high load operations from Admin App, the guidance was to throttle the number of simultaneous connections. Thankfully we can do so only against 3.x, allowing the original intended degree of parallelism to remain in place for ODS 5+ users.

Note that we are particularly pessimistic here in our exception handling for the Learning Standards aspect, because the setting is selected during Admin App's own startup process, and we need to be as polite as possible during startup to allow the system to come up at all. Here we favor a pessimistic fallback in the even that we cannot determine the ODS version during startup, such as when the ODS happens to be inaccessible in that moment, favoring a usable system over a difficult-to-diagnose failure to start up.

This is probably easiest to review commit-by-commit, especially for the affected unit tests. Viewing the whole diff at once on the unit tests can appear misleading depending on your diff tool's behavior, so commit by commit review will likely go faster.