### PR TITLE
[AA-1013] - Bulk Upload works with an unrelated API key and secret

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Commands/BulkUploadValidationTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Commands/BulkUploadValidationTests.cs
@@ -41,15 +41,20 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Database.Commands
 
             SetupApplicationForInstance(odsInstance2);
 
-            var bulkUploadModel = new BulkFileUploadModel
+            var saveBulkUploadCredentialsModel = new SaveBulkUploadCredentialsModel
             {
                 ApiKey = apiClientForInstance1.Key,
-                ApiSecret = apiClientForInstance1.Secret,
-                OdsInstanceName = odsInstance1.Name
+                ApiSecret = apiClientForInstance1.Secret
             };
 
-            var validator = new BulkFileUploadModelValidator(TestContext);
-            var validationResults = validator.Validate(bulkUploadModel);
+            var instanceContext = new InstanceContext
+            {
+                Id = odsInstance1.OdsInstanceId,
+                Name = odsInstance1.Name
+            };
+
+            var validator = new SaveBulkUploadCredentialsModelValidator(TestContext, instanceContext);
+            var validationResults = validator.Validate(saveBulkUploadCredentialsModel);
             validationResults.IsValid.ShouldBe(true);
         }
 
@@ -78,15 +83,20 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Database.Commands
 
             SetupApplicationForInstance(odsInstance2);
 
-            var bulkUploadModel = new BulkFileUploadModel
+            var saveBulkUploadCredentialsModel = new SaveBulkUploadCredentialsModel
             {
                 ApiKey = apiClientForInstance1.Key,
-                ApiSecret = apiClientForInstance1.Secret,
-                OdsInstanceName = odsInstance2.Name
+                ApiSecret = apiClientForInstance1.Secret
             };
 
-            var validator = new BulkFileUploadModelValidator(TestContext);
-            var validationResults = validator.Validate(bulkUploadModel);
+            var instanceContext = new InstanceContext
+            {
+                Id = odsInstance2.OdsInstanceId,
+                Name = odsInstance2.Name
+            };
+
+            var validator = new SaveBulkUploadCredentialsModelValidator(TestContext, instanceContext);
+            var validationResults = validator.Validate(saveBulkUploadCredentialsModel);
             validationResults.IsValid.ShouldBe(false);
             validationResults.Errors.Select(x => x.ErrorMessage).ShouldContain("The Api key provided is not associated with the currently selected ODS instance.");
         }

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Commands/BulkUploadValidationTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Commands/BulkUploadValidationTests.cs
@@ -98,7 +98,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Database.Commands
             var validator = new SaveBulkUploadCredentialsModelValidator(TestContext, instanceContext);
             var validationResults = validator.Validate(saveBulkUploadCredentialsModel);
             validationResults.IsValid.ShouldBe(false);
-            validationResults.Errors.Select(x => x.ErrorMessage).ShouldContain("The Api key provided is not associated with the currently selected ODS instance.");
+            validationResults.Errors.Select(x => x.ErrorMessage).ShouldContain("The Api Key provided is not associated with the currently selected ODS instance.");
         }
 
         [Test]

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Commands/BulkUploadValidationTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Commands/BulkUploadValidationTests.cs
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using EdFi.Admin.DataAccess.Models;
+using EdFi.Ods.AdminApp.Management.Database.Commands;
+using EdFi.Ods.AdminApp.Web.Models.ViewModels;
+using NUnit.Framework;
+using Shouldly;
+
+namespace EdFi.Ods.AdminApp.Management.Tests.Database.Commands
+{
+    [TestFixture]
+    public class BulkUploadValidationTests : AdminDataTestBase
+    {
+        [Test]
+        public void ShouldAllowBulkLoadCredentialsFromTheSameInstance()
+        {
+            var odsInstance1 = new OdsInstance
+            {
+                Name = "Test Instance 1",
+                InstanceType = "Ods",
+                IsExtended = false,
+                Status = "OK",
+                Version = "1.0.0"
+            };
+
+            var apiClientForInstance1 = SetupApplicationForInstance(odsInstance1);
+
+            var odsInstance2 = new OdsInstance
+            {
+                Name = "Test Instance 2",
+                InstanceType = "Ods",
+                IsExtended = false,
+                Status = "OK",
+                Version = "1.0.0"
+            };
+
+            SetupApplicationForInstance(odsInstance2);
+
+            var bulkUploadModel = new BulkFileUploadModel
+            {
+                ApiKey = apiClientForInstance1.Key,
+                ApiSecret = apiClientForInstance1.Secret,
+                OdsInstanceName = odsInstance1.Name
+            };
+
+            var validator = new BulkFileUploadModelValidator(TestContext);
+            var validationResults = validator.Validate(bulkUploadModel);
+            validationResults.IsValid.ShouldBe(true);
+        }
+
+        [Test]
+        public void ShouldNotAllowBulkLoadCredentialsFromADifferentInstance()
+        {
+            var odsInstance1 = new OdsInstance
+            {
+                Name = "Test Instance 1",
+                InstanceType = "Ods",
+                IsExtended = false,
+                Status = "OK",
+                Version = "1.0.0"
+            };
+
+            var apiClientForInstance1 = SetupApplicationForInstance(odsInstance1);
+
+            var odsInstance2 = new OdsInstance
+            {
+                Name = "Test Instance 2",
+                InstanceType = "Ods",
+                IsExtended = false,
+                Status = "OK",
+                Version = "1.0.0"
+            };
+
+            SetupApplicationForInstance(odsInstance2);
+
+            var bulkUploadModel = new BulkFileUploadModel
+            {
+                ApiKey = apiClientForInstance1.Key,
+                ApiSecret = apiClientForInstance1.Secret,
+                OdsInstanceName = odsInstance2.Name
+            };
+
+            var validator = new BulkFileUploadModelValidator(TestContext);
+            var validationResults = validator.Validate(bulkUploadModel);
+            validationResults.IsValid.ShouldBe(false);
+            validationResults.Errors.Select(x => x.ErrorMessage).ShouldContain("The Api key provided is not associated with the currently selected ODS instance.");
+        }
+
+        private ApiClient SetupApplicationForInstance(OdsInstance instance)
+        {
+            var vendor = new Vendor
+            {
+                VendorNamespacePrefixes = new List<VendorNamespacePrefix> { new VendorNamespacePrefix { NamespacePrefix = "http://tests.com" } },
+                VendorName = "Integration Tests"
+            };
+
+            var user = new Admin.DataAccess.Models.User
+            {
+                Email = "nobody@nowhere.com",
+                FullName = "Integration Tests",
+                Vendor = vendor
+            };
+
+            var profile = new Profile
+            {
+                ProfileName = "Test Profile"
+            };
+
+            Save(vendor, user, profile, instance);
+
+            var instanceContext = new InstanceContext
+            {
+                Id = instance.OdsInstanceId,
+                Name = instance.Name
+            };
+
+            var command = new AddApplicationCommand(SetupContext, instanceContext);
+            var newApplication = new TestApplication
+            {
+                Environment = CloudOdsEnvironment.Production,
+                ApplicationName = "Test Application",
+                ClaimSetName = "FakeClaimSet",
+                ProfileId = profile.ProfileId,
+                VendorId = vendor.VendorId,
+                EducationOrganizationIds = new List<int> { 12345, 67890 }
+            };
+
+            var result = command.Execute(newApplication);
+
+            var persistedApplication = TestContext.Applications.Single(a => a.ApplicationId == result.ApplicationId);
+
+            persistedApplication.ApiClients.Count.ShouldBe(1);
+            var apiClient = persistedApplication.ApiClients.First();
+            apiClient.Name.ShouldBe(CloudOdsApplicationName.GetPersistedName("Test Application", CloudOdsEnvironment.Production));
+            apiClient.ApplicationEducationOrganizations.All(o => o.EducationOrganizationId == 12345 || o.EducationOrganizationId == 67890).ShouldBeTrue();
+            apiClient.Key.ShouldBe(result.Key);
+            apiClient.Secret.ShouldBe(result.Secret);
+
+            persistedApplication.OdsInstance.ShouldNotBeNull();
+            persistedApplication.OdsInstance.Name.ShouldBe(instance.Name);
+
+            return apiClient;
+        }
+        
+
+        private class TestApplication : IAddApplicationModel
+        {
+            public CloudOdsEnvironment Environment { get; set; }
+            public string ApplicationName { get; set; }
+            public int VendorId { get; set; }
+            public string ClaimSetName { get; set; }
+            public int? ProfileId { get; set; }
+            public IEnumerable<int> EducationOrganizationIds { get; set; }
+        }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Commands/BulkUploadValidationTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Commands/BulkUploadValidationTests.cs
@@ -101,6 +101,31 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Database.Commands
             validationResults.Errors.Select(x => x.ErrorMessage).ShouldContain("The Api key provided is not associated with the currently selected ODS instance.");
         }
 
+        [Test]
+        public void ShouldNotAllowEmptyBulkLoadCredentials()
+        {
+            var saveBulkUploadCredentialsModel = new SaveBulkUploadCredentialsModel
+            {
+                ApiKey = "",
+                ApiSecret = ""
+            };
+
+            var instanceContext = new InstanceContext
+            {
+                Id = 1,
+                Name = "Test Instance"
+            };
+
+            var validator = new SaveBulkUploadCredentialsModelValidator(TestContext, instanceContext);
+            var validationResults = validator.Validate(saveBulkUploadCredentialsModel);
+            validationResults.IsValid.ShouldBe(false);
+            validationResults.Errors.Select(x => x.ErrorMessage).ShouldBe(new List<string>
+            {
+                "'Api Key' must not be empty.",
+                "'Api Secret' must not be empty."
+            });
+        }
+
         private ApiClient SetupApplicationForInstance(OdsInstance instance)
         {
             var vendor = new Vendor

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
@@ -348,6 +348,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssertionExtensions.cs" />
+    <Compile Include="Database\Commands\BulkUploadValidationTests.cs" />
     <Compile Include="Database\Models\RolePermissionTests.cs" />
     <Compile Include="Instance\GetOdsInstanceRegistrationsByUserIdQueryTests.cs" />
     <Compile Include="Instance\DeregisterOdsInstanceCommandTests.cs" />

--- a/Application/EdFi.Ods.AdminApp.Web.Tests/Controllers/OdsInstanceSettingsController/WhenRunningBulkUpload.cs
+++ b/Application/EdFi.Ods.AdminApp.Web.Tests/Controllers/OdsInstanceSettingsController/WhenRunningBulkUpload.cs
@@ -302,13 +302,10 @@ namespace EdFi.Ods.AdminApp.Web.Tests.Controllers.OdsInstanceSettingsController
             // Arrange
             const string expectedKey = "key";
             const string expectedSecret = "secret";
-            var model = new OdsInstanceSettingsModel
+            var model = new SaveBulkUploadCredentialsModel
             {
-                BulkFileUploadModel = new BulkFileUploadModel
-                {
-                    ApiKey = expectedKey,
-                    ApiSecret = expectedSecret
-                }
+                ApiKey = expectedKey,
+                ApiSecret = expectedSecret
             };
           
             OdsSecretConfigurationProvider.Setup(x => x.GetSecretConfiguration(It.IsAny<int>()))

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/OdsInstanceSettingsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/OdsInstanceSettingsController.cs
@@ -331,8 +331,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
                 {
                     ApiKey = config.BulkUploadCredential?.ApiKey ?? string.Empty,
                     ApiSecret = config.BulkUploadCredential?.ApiSecret ?? string.Empty,
-                    CloudOdsEnvironment = CloudOdsEnvironment.Production,
-                    OdsInstanceName = _instanceContext.Name
+                    CloudOdsEnvironment = CloudOdsEnvironment.Production
                 },
                 OdsInstance = _instanceContext
             };

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/OdsInstanceSettingsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/OdsInstanceSettingsController.cs
@@ -331,7 +331,8 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
                 {
                     ApiKey = config.BulkUploadCredential?.ApiKey ?? string.Empty,
                     ApiSecret = config.BulkUploadCredential?.ApiSecret ?? string.Empty,
-                    CloudOdsEnvironment = CloudOdsEnvironment.Production
+                    CloudOdsEnvironment = CloudOdsEnvironment.Production,
+                    OdsInstanceName = _instanceContext.Name
                 },
                 OdsInstance = _instanceContext
             };

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/OdsInstanceSettingsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/OdsInstanceSettingsController.cs
@@ -400,12 +400,12 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         }
 
         [HttpPost]
-        public async Task<ActionResult> SaveBulkLoadCredentials(OdsInstanceSettingsModel model)
+        public async Task<ActionResult> SaveBulkLoadCredentials(SaveBulkUploadCredentialsModel model)
         {
             var config = await _odsSecretConfigurationProvider.GetSecretConfiguration(_instanceContext.Id);
             if (config == null) return JsonError(_missingOdsSecretConfig);
-            config.BulkUploadCredential = new BulkUploadCredential { ApiKey = model.BulkFileUploadModel.ApiKey,
-                ApiSecret = model.BulkFileUploadModel.ApiSecret };
+            config.BulkUploadCredential = new BulkUploadCredential { ApiKey = model.ApiKey,
+                ApiSecret = model.ApiSecret };
             await _odsSecretConfigurationProvider.SetSecretConfiguration(config, _instanceContext.Id);
             return JsonSuccess("Credentials successfully saved");
         }

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -1083,6 +1083,7 @@
     <Content Include="Views\User\_DeleteUserModal.cshtml" />
     <Content Include="Views\Shared\_SignalRStatus.cshtml" />
     <Content Include="Views\Shared\_SignalRStatus_BulkLoad.cshtml" />
+    <Content Include="Views\OdsInstanceSettings\_SaveBulkUploadCredentialsForm.cshtml" />
     <None Include="Web.base.config" />
     <Content Include="Views\OdsInstances\RegisterOdsInstance.cshtml" />
     <Content Include="Views\OdsInstances\Index.cshtml" />

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/BulkFileUploadModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/BulkFileUploadModel.cs
@@ -62,18 +62,9 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels
                 .Include(x => x.Application.OdsInstance)
                 .SingleOrDefault(x => x.Key == apiKey);
 
-            if (apiClient != null)
-            {        
-                var application = apiClient.Application;
-        
-                if (application != null && application.OdsInstance.Name == _instanceContext.Name)
-                {
-                    return true;
-                }
-        
-            }
-        
-            return false;
+            var odsInstanceNameForGivenKey = apiClient?.Application?.OdsInstance?.Name;
+
+            return odsInstanceNameForGivenKey != null && odsInstanceNameForGivenKey == _instanceContext.Name;
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/BulkFileUploadModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/BulkFileUploadModel.cs
@@ -22,6 +22,7 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels
         public string ApiKey { get; set; }
         [Display(Name = "Api Secret")]
         public string ApiSecret { get; set; }
+        public string OdsInstanceName { get; set; }
         public bool IsJobRunning { get; set; }
         public bool IsSameOdsInstance { get; set; }
     }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/BulkFileUploadModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/BulkFileUploadModel.cs
@@ -30,13 +30,23 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels
         public bool IsSameOdsInstance { get; set; }
     }
 
-    public class BulkFileUploadModelValidator : AbstractValidator<BulkFileUploadModel>
+    public class SaveBulkUploadCredentialsModel
+    {
+        [Display(Name = "Api Key")]
+        public string ApiKey { get; set; }
+        [Display(Name = "Api Secret")]
+        public string ApiSecret { get; set; }
+    }
+
+    public class SaveBulkUploadCredentialsModelValidator : AbstractValidator<SaveBulkUploadCredentialsModel>
     {
         private readonly IUsersContext _usersContext;
+        private readonly InstanceContext _instanceContext;
 
-        public BulkFileUploadModelValidator(IUsersContext usersContext)
+        public SaveBulkUploadCredentialsModelValidator(IUsersContext usersContext, InstanceContext instanceContext)
         {
             _usersContext = usersContext;
+            _instanceContext = instanceContext;
 
             RuleFor(m => m.ApiKey).NotEmpty();
             RuleFor(m => m.ApiSecret).NotEmpty();
@@ -46,7 +56,7 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels
                 .WithMessage("The Api key provided is not associated with the currently selected ODS instance.");
         }
 
-        private bool BeAssociatedToTheSelectedInstance(BulkFileUploadModel model, string apiKey)
+        private bool BeAssociatedToTheSelectedInstance(SaveBulkUploadCredentialsModel model, string apiKey)
         {
             var apiClient = _usersContext.Clients.SingleOrDefault(x => x.Key == apiKey);
         
@@ -55,7 +65,7 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels
                 var application =
                     _usersContext.Applications.SingleOrDefault(x => x.ApplicationId == apiClient.Application.ApplicationId);
         
-                if (application != null && application.OdsInstance.Name == model.OdsInstanceName)
+                if (application != null && application.OdsInstance.Name == _instanceContext.Name)
                 {
                     return true;
                 }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/BulkFileUploadModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/BulkFileUploadModel.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Data.Entity;
 using System.Linq;
 using System.Web;
 using EdFi.Admin.DataAccess.Contexts;
@@ -57,8 +58,10 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels
 
         private bool BeAssociatedToTheSelectedInstance(SaveBulkUploadCredentialsModel model, string apiKey)
         {
-            var apiClient = _usersContext.Clients.SingleOrDefault(x => x.Key == apiKey);
-        
+            var apiClient = _usersContext.Clients
+                .Include(x => x.Application.OdsInstance)
+                .SingleOrDefault(x => x.Key == apiKey);
+
             if (apiClient != null)
             {        
                 var application = apiClient.Application;

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/BulkFileUploadModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/BulkFileUploadModel.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -52,7 +52,7 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels
             RuleFor(m => m.ApiKey)
                 .Must(BeAssociatedToTheSelectedInstance)
                 .When(m => !string.IsNullOrEmpty(m.ApiKey))
-                .WithMessage("The Api key provided is not associated with the currently selected ODS instance.");
+                .WithMessage("The Api Key provided is not associated with the currently selected ODS instance.");
         }
 
         private bool BeAssociatedToTheSelectedInstance(SaveBulkUploadCredentialsModel model, string apiKey)

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/BulkFileUploadModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/BulkFileUploadModel.cs
@@ -25,7 +25,6 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels
         public string ApiKey { get; set; }
         [Display(Name = "Api Secret")]
         public string ApiSecret { get; set; }
-        public string OdsInstanceName { get; set; }
         public bool IsJobRunning { get; set; }
         public bool IsSameOdsInstance { get; set; }
     }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/BulkFileUploadModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/BulkFileUploadModel.cs
@@ -61,8 +61,7 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels
         
             if (apiClient != null)
             {        
-                var application =
-                    _usersContext.Applications.SingleOrDefault(x => x.ApplicationId == apiClient.Application.ApplicationId);
+                var application = apiClient.Application;
         
                 if (application != null && application.OdsInstance.Name == _instanceContext.Name)
                 {

--- a/Application/EdFi.Ods.AdminApp.Web/Views/OdsInstanceSettings/BulkLoad.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/OdsInstanceSettings/BulkLoad.cshtml
@@ -22,6 +22,7 @@ See the LICENSE and NOTICES files in the project root for more information.
         using (Html.BeginForm("SaveBulkLoadCredentials", "OdsInstanceSettings", FormMethod.Post, new { enctype = "multipart/form-data", id = "save-credentials-form" }))
         {
             @Html.ValidationBlock()
+            @Html.InputBlock(m => m.BulkFileUploadModel.OdsInstanceName).Hide()
             @Html.InputBlock(m => m.BulkFileUploadModel.ApiKey)
             @Html.InputBlock(m => m.BulkFileUploadModel.ApiSecret)
             <div class="col-xs-4"></div>

--- a/Application/EdFi.Ods.AdminApp.Web/Views/OdsInstanceSettings/BulkLoad.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/OdsInstanceSettings/BulkLoad.cshtml
@@ -19,17 +19,7 @@ See the LICENSE and NOTICES files in the project root for more information.
 <div class="tab-content">
     @if (!Model.BulkFileUploadModel.CredentialsSaved)
     {
-        using (Html.BeginForm("SaveBulkLoadCredentials", "OdsInstanceSettings", FormMethod.Post, new { enctype = "multipart/form-data", id = "save-credentials-form" }))
-        {
-            @Html.ValidationBlock()
-            @Html.InputBlock(m => m.BulkFileUploadModel.OdsInstanceName).Hide()
-            @Html.InputBlock(m => m.BulkFileUploadModel.ApiKey)
-            @Html.InputBlock(m => m.BulkFileUploadModel.ApiSecret)
-            <div class="col-xs-4"></div>
-            <div class="col-xs-6">
-                @Html.SaveButton("Save credentials").Id("bulk-load-button")
-            </div>
-        }
+        @Html.Partial("_SaveBulkUploadCredentialsForm", Model.BulkFileUploadModel)
     }
     else
     {

--- a/Application/EdFi.Ods.AdminApp.Web/Views/OdsInstanceSettings/_SaveBulkUploadCredentialsForm.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/OdsInstanceSettings/_SaveBulkUploadCredentialsForm.cshtml
@@ -1,0 +1,21 @@
+@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.BulkFileUploadModel
+
+@using (Html.BeginForm("SaveBulkLoadCredentials", "OdsInstanceSettings", FormMethod.Post, new { enctype = "multipart/form-data", id = "save-credentials-form" }))
+{
+    @Html.ValidationBlock()
+    @Html.InputBlock(m => m.ApiKey)
+    @Html.InputBlock(m => m.ApiSecret)
+    <div class="col-xs-4"></div>
+    <div class="col-xs-6">
+        @Html.SaveButton("Save credentials").Id("bulk-load-button")
+    </div>
+}
+


### PR DESCRIPTION
**Description**
- Added a new SaveBulkUploadCredentialsModel with only ApiKey and ApiSecret properties. Added the SaveBulkUploadCredentialsModelValidator and validation rules for the ApiKey and ApiSecret properties.
- Refactored to use SaveBulkUploadCredentialsModel instead of BulkFileUploadModel in the BulkUploadValidationTests, WhenRunningBulkUpload and SaveBulkLoadCredentials.
- Added a partial view SaveBulkUploadCredentialsForm by extracting the form from the BulkLoad view.
- Added BulkUploadValidationTests to the tests project in order to test the new validation rules added to the SaveBulkUploadCredentialsModel.
