### PR TITLE
[AA-1012] - Error creating new instance with non default database name

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Commands/EditApplicationCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Commands/EditApplicationCommandTests.cs
@@ -7,9 +7,11 @@ using System.Collections.Generic;
 using System.Linq;
 using EdFi.Admin.DataAccess.Models;
 using EdFi.Ods.AdminApp.Management.Database.Commands;
+using EdFi.Ods.AdminApp.Web.Models.ViewModels.Application;
 using NUnit.Framework;
 using Shouldly;
 using VendorUser = EdFi.Admin.DataAccess.Models.User;
+using static EdFi.Ods.AdminApp.Management.Tests.TestingHelper;
 
 namespace EdFi.Ods.AdminApp.Management.Tests.Database.Commands
 {
@@ -155,6 +157,28 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Database.Commands
 
             persistedApplication.ApplicationEducationOrganizations.Count.ShouldBe(2);
             persistedApplication.ApplicationEducationOrganizations.ShouldAllBe(aeo => aeo.EducationOrganizationId == 23456 || aeo.EducationOrganizationId == 78901);
+        }
+
+        [Test]
+        public void ShouldNotEditIfNameNotWithinApplicationNameMaxLength()
+        {
+            SetupTestEntities();
+
+            var newApplicationName = Sample("New Application", 50);
+
+            var editApplication = new EditApplicationModel
+            {
+                ApplicationId = _application.ApplicationId,
+                ApplicationName = newApplicationName,
+                ClaimSetName = "DifferentFakeClaimSet",
+                EducationOrganizationIds = new List<int> { 23456, 78901 },
+                Environment = CloudOdsEnvironment.Production,
+                ProfileId = _otherProfile.ProfileId,
+                VendorId = _otherVendor.VendorId
+            };
+
+            new EditApplicationModelValidator()
+                .ShouldNotValidate<EditApplicationModel>(editApplication, $"The Application Name {newApplicationName} would be too long for Admin App to set up necessary Application records. Consider shortening the name by 11 characters.");
         }
 
         private class TestEditApplicationModel : IEditApplicationModel

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Instance/RegisterOdsInstanceCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Instance/RegisterOdsInstanceCommandTests.cs
@@ -126,10 +126,15 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Instance
         [TestCase(-1)]
         public void ShouldBeInvalidDistrictOrEdOrgId(int invalidId)
         {
-            using (var connection = GetDatabaseConnection("Test_Ods_" + invalidId))
+            var invalidInstanceName = "Test_Ods_" + invalidId;
+
+            using (var connection1 = GetDatabaseConnection(invalidInstanceName))
+            using (var connection2 = GetDatabaseConnection(invalidInstanceName))
             {
-                _connectionProvider.Setup(x => x.CreateNewConnection(invalidId, ApiMode.DistrictSpecific))
-                    .Returns(connection);
+                _connectionProvider
+                    .SetupSequence(x => x.CreateNewConnection(invalidId, ApiMode.DistrictSpecific))
+                    .Returns(connection1)
+                    .Returns(connection2);
 
                 _apiModeProvider.Setup(x => x.GetApiMode()).Returns(ApiMode.DistrictSpecific);
 
@@ -150,10 +155,15 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Instance
         [TestCase(1800)]
         public void ShouldBeInvalidSchoolYear(int? invalidSchoolYear)
         {
-            using (var connection = GetDatabaseConnection("Test_Ods_" + invalidSchoolYear))
+            var invalidInstanceName = "Test_Ods_" + invalidSchoolYear;
+
+            using (var connection1 = GetDatabaseConnection(invalidInstanceName))
+            using (var connection2 = GetDatabaseConnection(invalidInstanceName))
             {
-                _connectionProvider.Setup(x => x.CreateNewConnection(invalidSchoolYear ?? 0, ApiMode.YearSpecific))
-                    .Returns(connection);
+                _connectionProvider.SetupSequence(
+                        x => x.CreateNewConnection(invalidSchoolYear ?? 0, ApiMode.YearSpecific))
+                    .Returns(connection1)
+                    .Returns(connection2);
 
                 _apiModeProvider.Setup(x => x.GetApiMode()).Returns(ApiMode.YearSpecific);
                 var newInstance = new RegisterOdsInstanceModel
@@ -178,10 +188,12 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Instance
             SetupOdsInstanceRegistration(instanceName);
             _apiModeProvider.Setup(x => x.GetApiMode()).Returns(ApiMode.YearSpecific);
 
-            using (var connection = GetDatabaseConnection(instanceName))
+            using (var connection1 = GetDatabaseConnection(instanceName))
+            using (var connection2 = GetDatabaseConnection(instanceName))
             {
-                _connectionProvider.Setup(x => x.CreateNewConnection(2020, ApiMode.YearSpecific))
-                    .Returns(connection);
+                _connectionProvider.SetupSequence(x => x.CreateNewConnection(2020, ApiMode.YearSpecific))
+                    .Returns(connection1)
+                    .Returns(connection2);
 
                 var newInstance = new RegisterOdsInstanceModel
                 {
@@ -202,10 +214,13 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Instance
             ResetOdsInstanceRegistrations();
             SetupOdsInstanceRegistration(instanceName);
 
-            using (var connection = GetDatabaseConnection(instanceName))
+            using (var connection1 = GetDatabaseConnection(instanceName))
+            using (var connection2 = GetDatabaseConnection(instanceName))
             {
-                _connectionProvider.Setup(x => x.CreateNewConnection(8787877, ApiMode.DistrictSpecific))
-                    .Returns(connection);
+                _connectionProvider
+                    .SetupSequence(x => x.CreateNewConnection(8787877, ApiMode.DistrictSpecific))
+                    .Returns(connection1)
+                    .Returns(connection2);
 
                 var newInstance = new RegisterOdsInstanceModel
                 {
@@ -232,10 +247,13 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Instance
             mockDatabaseValidationService.Setup(x => x.IsValidDatabase(OdsInstanceNumericSuffix, ApiMode.DistrictSpecific))
                 .Returns(false);
 
-            using (var connection = GetDatabaseConnection(InstanceName))
+            using (var connection1 = GetDatabaseConnection(InstanceName))
+            using (var connection2 = GetDatabaseConnection(InstanceName))
             {
-                _connectionProvider.Setup(x => x.CreateNewConnection(OdsInstanceNumericSuffix, ApiMode.DistrictSpecific))
-                    .Returns(connection);
+                _connectionProvider.SetupSequence(
+                        x => x.CreateNewConnection(OdsInstanceNumericSuffix, ApiMode.DistrictSpecific))
+                    .Returns(connection1)
+                    .Returns(connection2);
 
                 _apiModeProvider.Setup(x => x.GetApiMode()).Returns(ApiMode.DistrictSpecific);
 
@@ -261,10 +279,13 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Instance
             mockDatabaseValidationService.Setup(x => x.IsValidDatabase(OdsInstanceNumericSuffix, ApiMode.YearSpecific))
                 .Returns(false);
 
-            using (var connection = GetDatabaseConnection(InstanceName))
+            using (var connection1 = GetDatabaseConnection(InstanceName))
+            using (var connection2 = GetDatabaseConnection(InstanceName))
             {
-                _connectionProvider.Setup(x => x.CreateNewConnection(OdsInstanceNumericSuffix, ApiMode.YearSpecific))
-                    .Returns(connection);
+                _connectionProvider.SetupSequence(
+                        x => x.CreateNewConnection(OdsInstanceNumericSuffix, ApiMode.YearSpecific))
+                    .Returns(connection1)
+                    .Returns(connection2);
 
                 _apiModeProvider.Setup(x => x.GetApiMode()).Returns(ApiMode.YearSpecific);
                 var newInstance = new RegisterOdsInstanceModel
@@ -285,10 +306,15 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Instance
             ResetOdsInstanceRegistrations();
             var instance = SetupOdsInstanceRegistration("Test_Ods_8787877");
 
-            using (var connection = GetDatabaseConnection("Test_Ods_7878787"))
+            var instanceName = "Test_Ods_7878787";
+
+            using (var connection1 = GetDatabaseConnection(instanceName))
+            using (var connection2 = GetDatabaseConnection(instanceName))
             {
-                _connectionProvider.Setup(x => x.CreateNewConnection(7878787, ApiMode.DistrictSpecific))
-                    .Returns(connection);
+                _connectionProvider
+                    .SetupSequence(x => x.CreateNewConnection(7878787, ApiMode.DistrictSpecific))
+                    .Returns(connection1)
+                    .Returns(connection2);
 
                 _apiModeProvider.Setup(x => x.GetApiMode()).Returns(ApiMode.DistrictSpecific);
 
@@ -308,10 +334,15 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Instance
         {
             ResetOdsInstanceRegistrations();
 
-            using (var connection = GetDatabaseConnection("TestInstance_7878787"))
+            var instanceName = "TestInstance_7878787";
+
+            using (var connection1 = GetDatabaseConnection(instanceName))
+            using (var connection2 = GetDatabaseConnection(instanceName))
             {
-                _connectionProvider.Setup(x => x.CreateNewConnection(7878787, ApiMode.DistrictSpecific))
-                    .Returns(connection);
+                _connectionProvider
+                    .SetupSequence(x => x.CreateNewConnection(7878787, ApiMode.DistrictSpecific))
+                    .Returns(connection1)
+                    .Returns(connection2);
 
                 _apiModeProvider.Setup(x => x.GetApiMode()).Returns(ApiMode.DistrictSpecific);
 
@@ -331,10 +362,14 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Instance
         {
             ResetOdsInstanceRegistrations();
 
-            using (var connection = GetDatabaseConnection("TestInstance_2020"))
+            var instanceName = "TestInstance_2020";
+
+            using (var connection1 = GetDatabaseConnection(instanceName))
+            using (var connection2 = GetDatabaseConnection(instanceName))
             {
-                _connectionProvider.Setup(x => x.CreateNewConnection(2020, ApiMode.YearSpecific))
-                    .Returns(connection);
+                _connectionProvider.SetupSequence(x => x.CreateNewConnection(2020, ApiMode.YearSpecific))
+                    .Returns(connection1)
+                    .Returns(connection2);
 
                 _apiModeProvider.Setup(x => x.GetApiMode()).Returns(ApiMode.YearSpecific);
 

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/TestingHelper.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/TestingHelper.cs
@@ -65,5 +65,17 @@ namespace EdFi.Ods.AdminApp.Management.Tests
 
         public static string Sample(string prefix)
             => prefix + "-" + Guid.NewGuid();
+
+        public static string Sample(string prefix, int length)
+        {
+            var sampleString = prefix + "-";
+
+            while (sampleString.Length < length)
+            {
+                sampleString += Guid.NewGuid();
+            }
+
+            return sampleString.Substring(0, length);
+        }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Helpers/ApplicationExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Helpers/ApplicationExtensions.cs
@@ -23,5 +23,7 @@ namespace EdFi.Ods.AdminApp.Web.Helpers
                 application.Vendor.IsSystemReservedVendor()
             );
         }
+
+        public static int MaximumApplicationNameLength = 50;
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Application/EditApplicationModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Application/EditApplicationModel.cs
@@ -10,6 +10,7 @@ using FluentValidation;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using EdFi.Ods.AdminApp.Web.Helpers;
+using FluentValidation.Validators;
 
 namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.Application
 {
@@ -45,6 +46,10 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.Application
             RuleFor(m => m.ApplicationId).NotEmpty();
             RuleFor(m => m.ApplicationName).NotEmpty();
             RuleFor(m => m.ApplicationName)
+                .Must(BeWithinApplicationNameMaxLength)
+                .When(x => x.ApplicationName != null);
+
+            RuleFor(m => m.ApplicationName)
                 .Must(name => !ApplicationExtensions.IsSystemReservedApplicationName(name))
                 .WithMessage(p => $"'{ p.ApplicationName}' is a reserved name and may not be used. Please choose another name.");
 
@@ -58,6 +63,22 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.Application
 
             RuleFor(m => m.Environment).NotNull();
             RuleFor(m => m.VendorId).NotEmpty();
+        }
+
+        private bool BeWithinApplicationNameMaxLength(EditApplicationModel model, string applicationName, PropertyValidatorContext context)
+        {
+            var persistedName = CloudOdsApplicationName.GetPersistedName(applicationName, CloudOdsEnvironment.Production);
+            var extraCharactersInName = persistedName.Length - ApplicationExtensions.MaximumApplicationNameLength;
+            if (extraCharactersInName <= 0)
+            {
+                return true;
+            }
+
+            context.Rule.MessageBuilder = c
+                => $"The Application Name {applicationName} would be too long for Admin App to set up necessary Application records." +
+                   $" Consider shortening the name by {extraCharactersInName} characters.";
+
+            return false;
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/OdsInstances/RegisterOdsInstanceModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/OdsInstances/RegisterOdsInstanceModel.cs
@@ -92,7 +92,7 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstances
         private static bool BeAUniqueInstanceName(int? newInstanceNumericSuffix)
         {
             var newInstanceDatabaseName = InferInstanceDatabaseName(newInstanceNumericSuffix);
-            return !_database.OdsInstanceRegistrations.Any(x => x.Name == newInstanceDatabaseName);
+            return newInstanceDatabaseName != "" && !_database.OdsInstanceRegistrations.Any(x => x.Name == newInstanceDatabaseName);
         }
 
         private static bool BeWithinApplicationNameMaxLength(RegisterOdsInstanceModel model, int? newInstanceNumericSuffix, PropertyValidatorContext context)


### PR DESCRIPTION
**Description**
- Added MaximumApplicationNameLength property to ApplicationExtensions to have a common place to check for the maximum application name length.
- Added the ApplicaitonNameMaxLength validation rule to RegisterOdsInstanceModel
- Added empty string check for newInstanceDatabaseName in the BeAUniqueInstanceName validation rule to avoid checking uniqueness against an empty string.
- Added an overload for Sample function to take in both a prefix and length to return a random string with the prefix and of the specified length.
- Refactored the RegisterOdsInstanceTests to factor in the disposal of the connection object in the validator in subsequent validation rules. In order to avoid the situation, SetupSequence is used to provide a different connection object for each call to the CreateNewConnection() mock setup.
- Added a unit test to check whether the application name length is within the specified max length.
- Added validation rules to keep the ApplicationName entered while creating/editiing an application to be within the application name max length.Added a unit test to check whether the application name length is within the specified max length while creating as well as editing an application.