### PR TITLE
[AA-971] - Final Installer 2.0.0 Version Bumps

### DIFF
--- a/EdFi.Suite3.Installer.AdminApp/install.ps1
+++ b/EdFi.Suite3.Installer.AdminApp/install.ps1
@@ -3,6 +3,7 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
+import-module -force "$PSScriptRoot/Install-EdFiOdsAdminApp.psm1"
 
 <#
 Review and edit the following connection information for your database server

--- a/EdFi.Suite3.Installer.AdminApp/install.ps1
+++ b/EdFi.Suite3.Installer.AdminApp/install.ps1
@@ -63,7 +63,7 @@ $p = @{
     ToolsPath = "C:/temp/tools"
     DbConnectionInfo = $dbConnectionInfo
     OdsApiUrl = ""
-    PackageVersion = '2.0.0-pre0042'
+    PackageVersion = '2.0.0'
     AdminAppFeatures = $adminAppFeatures
 }
 

--- a/EdFi.Suite3.Installer.AdminApp/test.ps1
+++ b/EdFi.Suite3.Installer.AdminApp/test.ps1
@@ -11,7 +11,7 @@ Param(
 
 import-module -force "$PSScriptRoot/Install-EdFiOdsAdminApp.psm1"
 
-$PackageVersion = '2.0.0-pre0037'
+$PackageVersion = '2.0.0'
 
 function Invoke-InstallSqlServer {
 


### PR DESCRIPTION
Final PR for 2.0.0 release that will bump version of AA web nupkg used in the installer. This PR might also contain small changes found during RC testing that didn't deserve to go through RC testing again

edited: removed merge warning and now ready for review/merge