### PR TITLE
[AA-1050] simple package upgrades

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Aws.Tests/EdFi.Ods.AdminApp.Management.Aws.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Aws.Tests/EdFi.Ods.AdminApp.Management.Aws.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
   </ItemGroup>
 

--- a/Application/EdFi.Ods.AdminApp.Management.Aws.Tests/EdFi.Ods.AdminApp.Management.Aws.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Aws.Tests/EdFi.Ods.AdminApp.Management.Aws.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
   </ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.Aws.Tests/EdFi.Ods.AdminApp.Management.Aws.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Aws.Tests/EdFi.Ods.AdminApp.Management.Aws.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
-    <PackageReference Include="Shouldly" Version="3.0.1" />
+    <PackageReference Include="Shouldly" Version="3.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
-    <PackageReference Include="Moq" Version="4.10.0" />
+    <PackageReference Include="Moq" Version="4.14.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="Moq" Version="4.14.5" />
   </ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="Moq" Version="4.14.5" />

--- a/Application/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
-    <PackageReference Include="Shouldly" Version="3.0.1" />
+    <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="Moq" Version="4.10.0" />
   </ItemGroup>
 

--- a/Application/EdFi.Ods.AdminApp.Management.Azure.UnitTests/EdFi.Ods.AdminApp.Management.Azure.UnitTests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Azure.UnitTests/EdFi.Ods.AdminApp.Management.Azure.UnitTests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
-    <PackageReference Include="Moq" Version="4.10.0" />
+    <PackageReference Include="Moq" Version="4.14.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.Azure.UnitTests/EdFi.Ods.AdminApp.Management.Azure.UnitTests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Azure.UnitTests/EdFi.Ods.AdminApp.Management.Azure.UnitTests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="Moq" Version="4.14.5" />
   </ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.Azure.UnitTests/EdFi.Ods.AdminApp.Management.Azure.UnitTests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Azure.UnitTests/EdFi.Ods.AdminApp.Management.Azure.UnitTests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="Moq" Version="4.14.5" />

--- a/Application/EdFi.Ods.AdminApp.Management.Azure.UnitTests/EdFi.Ods.AdminApp.Management.Azure.UnitTests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Azure.UnitTests/EdFi.Ods.AdminApp.Management.Azure.UnitTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
-    <PackageReference Include="Shouldly" Version="3.0.1" />
+    <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="Moq" Version="4.10.0" />
   </ItemGroup>
 

--- a/Application/EdFi.Ods.AdminApp.Management.Azure/EdFi.Ods.AdminApp.Management.Azure.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Azure/EdFi.Ods.AdminApp.Management.Azure.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EntityFramework" Version="6.4.0" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="1.1.3-preview" />
     <PackageReference Include="Microsoft.Azure.Management.WebSites" Version="1.3.2-preview" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.13.7" />

--- a/Application/EdFi.Ods.AdminApp.Management.OnPrem.Tests/EdFi.Ods.AdminApp.Management.OnPrem.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.OnPrem.Tests/EdFi.Ods.AdminApp.Management.OnPrem.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
   </ItemGroup>
 

--- a/Application/EdFi.Ods.AdminApp.Management.OnPrem.Tests/EdFi.Ods.AdminApp.Management.OnPrem.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.OnPrem.Tests/EdFi.Ods.AdminApp.Management.OnPrem.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
   </ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.OnPrem.Tests/EdFi.Ods.AdminApp.Management.OnPrem.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.OnPrem.Tests/EdFi.Ods.AdminApp.Management.OnPrem.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
-    <PackageReference Include="Shouldly" Version="3.0.1" />
+    <PackageReference Include="Shouldly" Version="3.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/App.config
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/App.config
@@ -93,7 +93,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.8.0" newVersion="2.0.8.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.9.0" newVersion="2.0.9.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Setup/SqlServerCloudOdsDatabaseSecurityConfiguratorTester.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Setup/SqlServerCloudOdsDatabaseSecurityConfiguratorTester.cs
@@ -17,7 +17,10 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Database.Setup
 {
     //See App.config - requires the User named in the "IntegrationTests" connection string to be
     //in the sysadmin role on the database server
-    [Explicit]
+    [Ignore("These tests are intended to be marked [Explicit], but a " +
+            "VS2019 Test Explorer bug prevents that attribute from " +
+            "functioning as intended. To run these tests, temporarily" +
+            "comment out this [Ignore(...)] attribute.")]
     [TestFixture]
     public class SqlServerCloudOdsDatabaseSecurityConfiguratorTester
     {

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" />
   <Import Project="..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props" Condition="Exists('..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props')" />
   <Import Project="..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props" Condition="Exists('..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props')" />
   <Import Project="..\packages\EntityFramework.6.4.0\build\EntityFramework.props" Condition="Exists('..\packages\EntityFramework.6.4.0\build\EntityFramework.props')" />
-  <Import Project="..\packages\NUnit3TestAdapter.3.11.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.11.0\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -462,7 +462,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props'))" />
-    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.11.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.11.0\build\net35\NUnit3TestAdapter.props'))" />
     <Error Condition="!Exists('..\packages\EntityFramework.6.4.0\build\EntityFramework.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\EntityFramework.6.4.0\build\EntityFramework.props'))" />
     <Error Condition="!Exists('..\packages\EntityFramework.6.4.0\build\EntityFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\EntityFramework.6.4.0\build\EntityFramework.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props'))" />
@@ -470,6 +469,7 @@
     <Error Condition="!Exists('..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.targets'))" />
     <Error Condition="!Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.12.0\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props'))" />
   </Target>
   <Import Project="..\packages\EntityFramework.6.4.0\build\EntityFramework.targets" Condition="Exists('..\packages\EntityFramework.6.4.0\build\EntityFramework.targets')" />
   <Import Project="..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets" Condition="Exists('..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets')" />

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
@@ -166,9 +166,8 @@
       <HintPath>..\packages\Microsoft.Win32.Primitives.4.0.1\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Moq, Version=4.10.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.10.0\lib\net45\Moq.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Moq, Version=4.14.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.14.5\lib\net45\Moq.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
@@ -187,9 +187,8 @@
     <Reference Include="Sandwych.QuickGraph.Core, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Sandwych.QuickGraph.Core.1.0.0\lib\net45\Sandwych.QuickGraph.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Shouldly, Version=3.0.1.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
-      <HintPath>..\packages\Shouldly.3.0.1\lib\net451\Shouldly.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Shouldly, Version=3.0.2.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
+      <HintPath>..\packages\Shouldly.3.0.2\lib\net451\Shouldly.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
@@ -102,8 +102,8 @@
       <HintPath>..\packages\Hyak.Common.1.0.2\lib\net45\Hyak.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=2.0.9.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.10\lib\net45\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNet.Identity.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.Identity.Core.2.2.3\lib\net45\Microsoft.AspNet.Identity.Core.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
@@ -56,6 +56,10 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="AutoMapper, Version=5.1.1.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
       <HintPath>..\packages\AutoMapper.5.1.1\lib\net45\AutoMapper.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" />
   <Import Project="..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props" Condition="Exists('..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props')" />
   <Import Project="..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props" Condition="Exists('..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props')" />
   <Import Project="..\packages\EntityFramework.6.4.0\build\EntityFramework.props" Condition="Exists('..\packages\EntityFramework.6.4.0\build\EntityFramework.props')" />
   <Import Project="..\packages\NUnit3TestAdapter.3.11.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.11.0\build\net35\NUnit3TestAdapter.props')" />
-  <Import Project="..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" />
   <Import Project="..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -175,9 +175,8 @@
     <Reference Include="Npgsql, Version=4.1.3.1, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
       <HintPath>..\packages\Npgsql.4.1.3.1\lib\net461\Npgsql.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.11.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.12.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Respawn, Version=0.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Respawn.0.2.0\lib\net45\Respawn.dll</HintPath>
@@ -463,7 +462,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props'))" />
-    <Error Condition="!Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.11.0\build\NUnit.props'))" />
     <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.11.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.11.0\build\net35\NUnit3TestAdapter.props'))" />
     <Error Condition="!Exists('..\packages\EntityFramework.6.4.0\build\EntityFramework.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\EntityFramework.6.4.0\build\EntityFramework.props'))" />
     <Error Condition="!Exists('..\packages\EntityFramework.6.4.0\build\EntityFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\EntityFramework.6.4.0\build\EntityFramework.targets'))" />
@@ -471,6 +469,7 @@
     <Error Condition="!Exists('..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.targets'))" />
+    <Error Condition="!Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.12.0\build\NUnit.props'))" />
   </Target>
   <Import Project="..\packages\EntityFramework.6.4.0\build\EntityFramework.targets" Condition="Exists('..\packages\EntityFramework.6.4.0\build\EntityFramework.targets')" />
   <Import Project="..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets" Condition="Exists('..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets')" />

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
@@ -13,7 +13,7 @@
   <package id="EntityFramework6.Npgsql" version="3.2.1.1" targetFramework="net48" />
   <package id="FluentValidation" version="8.6.0" targetFramework="net48" />
   <package id="Hyak.Common" version="1.0.2" targetFramework="net48" />
-  <package id="log4net" version="2.0.8" targetFramework="net48" />
+  <package id="log4net" version="2.0.10" targetFramework="net48" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.2.3" targetFramework="net48" />
   <package id="Microsoft.AspNet.Identity.EntityFramework" version="2.2.3" targetFramework="net48" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
@@ -43,7 +43,7 @@
   <package id="NUnit3TestAdapter" version="3.11.0" targetFramework="net48" />
   <package id="Respawn" version="0.2.0" targetFramework="net48" />
   <package id="Sandwych.QuickGraph.Core" version="1.0.0" targetFramework="net48" />
-  <package id="Shouldly" version="3.0.1" targetFramework="net48" />
+  <package id="Shouldly" version="3.0.2" targetFramework="net48" />
   <package id="System.Buffers" version="4.5.0" targetFramework="net48" />
   <package id="System.Collections" version="4.0.11" targetFramework="net48" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
@@ -36,7 +36,7 @@
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.1.0" targetFramework="net48" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net48" />
   <package id="Microsoft.Win32.Primitives" version="4.0.1" targetFramework="net48" />
-  <package id="Moq" version="4.10.0" targetFramework="net48" />
+  <package id="Moq" version="4.14.5" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
   <package id="Npgsql" version="4.1.3.1" targetFramework="net48" />
   <package id="NUnit" version="3.11.0" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
@@ -39,7 +39,7 @@
   <package id="Moq" version="4.14.5" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
   <package id="Npgsql" version="4.1.3.1" targetFramework="net48" />
-  <package id="NUnit" version="3.11.0" targetFramework="net48" />
+  <package id="NUnit" version="3.12.0" targetFramework="net48" />
   <package id="NUnit3TestAdapter" version="3.11.0" targetFramework="net48" />
   <package id="Respawn" version="0.2.0" targetFramework="net48" />
   <package id="Sandwych.QuickGraph.Core" version="1.0.0" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
@@ -40,7 +40,7 @@
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
   <package id="Npgsql" version="4.1.3.1" targetFramework="net48" />
   <package id="NUnit" version="3.12.0" targetFramework="net48" />
-  <package id="NUnit3TestAdapter" version="3.11.0" targetFramework="net48" />
+  <package id="NUnit3TestAdapter" version="3.17.0" targetFramework="net48" />
   <package id="Respawn" version="0.2.0" targetFramework="net48" />
   <package id="Sandwych.QuickGraph.Core" version="1.0.0" targetFramework="net48" />
   <package id="Shouldly" version="3.0.2" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Management.UnitTests/EdFi.Ods.AdminApp.Management.UnitTests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.UnitTests/EdFi.Ods.AdminApp.Management.UnitTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
   </ItemGroup>
 

--- a/Application/EdFi.Ods.AdminApp.Management.UnitTests/EdFi.Ods.AdminApp.Management.UnitTests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.UnitTests/EdFi.Ods.AdminApp.Management.UnitTests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
+    <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />

--- a/Application/EdFi.Ods.AdminApp.Management.UnitTests/EdFi.Ods.AdminApp.Management.UnitTests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.UnitTests/EdFi.Ods.AdminApp.Management.UnitTests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Moq" Version="4.14.5" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
   </ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.UnitTests/EdFi.Ods.AdminApp.Management.UnitTests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.UnitTests/EdFi.Ods.AdminApp.Management.UnitTests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Moq" Version="4.10.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
-    <PackageReference Include="Shouldly" Version="3.0.1" />
+    <PackageReference Include="Shouldly" Version="3.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
@@ -167,8 +167,17 @@ namespace EdFi.Ods.AdminApp.Management.Api
             HandleErrorResponse(response);
             var swaggerDocument = JsonConvert.DeserializeObject<JObject>(response.Content);
             var descriptorsList = swaggerDocument["definitions"].ToObject<Dictionary<string, JObject>>();
-            return descriptorsList.Keys.Where(x => x.StartsWith("edFi"))
-                .Select(x => x.Substring(x.IndexOf('_')).ToPascalCase(CultureInfo.InvariantCulture)).ToList();
+
+            return descriptorsList.Keys.Where(x => x.StartsWith("edFi_"))
+                .Select(x => CapitalizeFirstLetter(x.Substring("edFi_".Length))).ToList();
+
+            string CapitalizeFirstLetter(string descriptorName)
+            {
+                if (descriptorName.Length > 0)
+                    return char.ToUpper(descriptorName[0]) + descriptorName.Substring(1);
+
+                return descriptorName;
+            }
         }
 
         public OdsApiResult DeleteResource(string elementPath, string id, bool refreshToken = false)

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.AspNet.WebPages" Version="3.2.4" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Npgsql" Version="4.1.3.1" />
-    <PackageReference Include="RestSharp" Version="105.2.3" />
+    <PackageReference Include="RestSharp" Version="106.11.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -27,7 +27,6 @@
     <PackageReference Include="Microsoft.AspNet.Identity.Core" Version="2.2.3" />
     <PackageReference Include="Microsoft.AspNet.Identity.EntityFramework" Version="2.2.3" />
     <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.3" />
-    <PackageReference Include="Microsoft.AspNet.WebPages" Version="3.2.4" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Npgsql" Version="4.1.3.1" />
     <PackageReference Include="RestSharp" Version="106.11.4" />

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.0.0" />
     <PackageReference Include="EntityFramework" Version="6.4.0" />
     <PackageReference Include="Flurl" Version="2.8.2" />
-    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="log4net" Version="2.0.10" />
     <PackageReference Include="Microsoft.AspNet.Identity.Core" Version="2.2.3" />
     <PackageReference Include="Microsoft.AspNet.Identity.EntityFramework" Version="2.2.3" />
     <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.3" />

--- a/Application/EdFi.Ods.AdminApp.Web.Tests/EdFi.Ods.AdminApp.Web.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Tests/EdFi.Ods.AdminApp.Web.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" />
   <Import Project="..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props" Condition="Exists('..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props')" />
   <Import Project="..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props" Condition="Exists('..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props')" />
   <Import Project="..\packages\NUnit3TestAdapter.3.11.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.11.0\build\net35\NUnit3TestAdapter.props')" />
-  <Import Project="..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -99,9 +99,8 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.11.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.12.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="QuickGraph, Version=3.6.61114.0, Culture=neutral, PublicKeyToken=f3fb40175eec2af3, processorArchitecture=MSIL">
       <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.dll</HintPath>
@@ -222,12 +221,12 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
-    <Error Condition="!Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.11.0\build\NUnit.props'))" />
     <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.11.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.11.0\build\net35\NUnit3TestAdapter.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.targets'))" />
+    <Error Condition="!Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.12.0\build\NUnit.props'))" />
   </Target>
   <Import Project="..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets" Condition="Exists('..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets')" />
   <Import Project="..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.targets" Condition="Exists('..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.targets')" />

--- a/Application/EdFi.Ods.AdminApp.Web.Tests/EdFi.Ods.AdminApp.Web.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Tests/EdFi.Ods.AdminApp.Web.Tests.csproj
@@ -93,9 +93,8 @@
     <Reference Include="Microsoft.VisualStudio.CodeCoverage.Shim, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeCoverage.16.4.0\lib\net45\Microsoft.VisualStudio.CodeCoverage.Shim.dll</HintPath>
     </Reference>
-    <Reference Include="Moq, Version=4.10.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.10.0\lib\net45\Moq.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Moq, Version=4.14.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.14.5\lib\net45\Moq.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Web.Tests/EdFi.Ods.AdminApp.Web.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Tests/EdFi.Ods.AdminApp.Web.Tests.csproj
@@ -114,8 +114,8 @@
     <Reference Include="QuickGraph.Serialization, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.Serialization.dll</HintPath>
     </Reference>
-    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.105.2.3\lib\net46\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=106.11.4.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.11.4\lib\net452\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="Shouldly, Version=3.0.2.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
       <HintPath>..\packages\Shouldly.3.0.2\lib\net451\Shouldly.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Web.Tests/EdFi.Ods.AdminApp.Web.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Tests/EdFi.Ods.AdminApp.Web.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" />
   <Import Project="..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props" Condition="Exists('..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props')" />
   <Import Project="..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props" Condition="Exists('..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props')" />
-  <Import Project="..\packages\NUnit3TestAdapter.3.11.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.11.0\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -221,12 +221,12 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
-    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.11.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.11.0\build\net35\NUnit3TestAdapter.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.targets'))" />
     <Error Condition="!Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.12.0\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props'))" />
   </Target>
   <Import Project="..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets" Condition="Exists('..\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets')" />
   <Import Project="..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.targets" Condition="Exists('..\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.targets')" />

--- a/Application/EdFi.Ods.AdminApp.Web.Tests/EdFi.Ods.AdminApp.Web.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Tests/EdFi.Ods.AdminApp.Web.Tests.csproj
@@ -54,6 +54,10 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="AutoMapper, Version=5.1.1.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
       <HintPath>..\packages\AutoMapper.5.1.1\lib\net45\AutoMapper.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Web.Tests/EdFi.Ods.AdminApp.Web.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Tests/EdFi.Ods.AdminApp.Web.Tests.csproj
@@ -119,9 +119,8 @@
     <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.105.2.3\lib\net46\RestSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Shouldly, Version=3.0.1.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
-      <HintPath>..\packages\Shouldly.3.0.1\lib\net451\Shouldly.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Shouldly, Version=3.0.2.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
+      <HintPath>..\packages\Shouldly.3.0.2\lib\net451\Shouldly.dll</HintPath>
     </Reference>
     <Reference Include="SimpleInjector, Version=4.1.0.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
       <HintPath>..\packages\SimpleInjector.4.1.0\lib\net45\SimpleInjector.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Web.Tests/EdFi.Ods.AdminApp.Web.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Tests/EdFi.Ods.AdminApp.Web.Tests.csproj
@@ -75,8 +75,8 @@
     <Reference Include="EdFi.LoadTools, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Suite3.LoadTools.5.0.0\lib\net48\EdFi.LoadTools.dll</HintPath>
     </Reference>
-    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=2.0.9.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.10\lib\net45\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Web.Tests/app.config
+++ b/Application/EdFi.Ods.AdminApp.Web.Tests/app.config
@@ -73,7 +73,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.8.0" newVersion="2.0.8.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.9.0" newVersion="2.0.9.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Application/EdFi.Ods.AdminApp.Web.Tests/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Web.Tests/packages.config
@@ -18,7 +18,7 @@
   <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net48" />
   <package id="Moq" version="4.14.5" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
-  <package id="NUnit" version="3.11.0" targetFramework="net48" />
+  <package id="NUnit" version="3.12.0" targetFramework="net48" />
   <package id="NUnit3TestAdapter" version="3.11.0" targetFramework="net48" />
   <package id="QuickGraph" version="3.6.61119.7" targetFramework="net48" />
   <package id="RestSharp" version="105.2.3" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Web.Tests/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Web.Tests/packages.config
@@ -6,7 +6,7 @@
   <package id="EdFi.Common" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Suite3.Common" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Suite3.LoadTools" version="5.0.0" targetFramework="net48" />
-  <package id="log4net" version="2.0.8" targetFramework="net48" />
+  <package id="log4net" version="2.0.10" targetFramework="net48" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.4" targetFramework="net48" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net48" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Web.Tests/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Web.Tests/packages.config
@@ -21,7 +21,7 @@
   <package id="NUnit" version="3.12.0" targetFramework="net48" />
   <package id="NUnit3TestAdapter" version="3.17.0" targetFramework="net48" />
   <package id="QuickGraph" version="3.6.61119.7" targetFramework="net48" />
-  <package id="RestSharp" version="105.2.3" targetFramework="net48" />
+  <package id="RestSharp" version="106.11.4" targetFramework="net48" />
   <package id="Shouldly" version="3.0.2" targetFramework="net48" />
   <package id="SimpleInjector" version="4.1.0" targetFramework="net48" />
   <package id="System.Configuration.ConfigurationManager" version="4.7.0" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Web.Tests/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Web.Tests/packages.config
@@ -19,7 +19,7 @@
   <package id="Moq" version="4.14.5" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
   <package id="NUnit" version="3.12.0" targetFramework="net48" />
-  <package id="NUnit3TestAdapter" version="3.11.0" targetFramework="net48" />
+  <package id="NUnit3TestAdapter" version="3.17.0" targetFramework="net48" />
   <package id="QuickGraph" version="3.6.61119.7" targetFramework="net48" />
   <package id="RestSharp" version="105.2.3" targetFramework="net48" />
   <package id="Shouldly" version="3.0.2" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Web.Tests/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Web.Tests/packages.config
@@ -22,7 +22,7 @@
   <package id="NUnit3TestAdapter" version="3.11.0" targetFramework="net48" />
   <package id="QuickGraph" version="3.6.61119.7" targetFramework="net48" />
   <package id="RestSharp" version="105.2.3" targetFramework="net48" />
-  <package id="Shouldly" version="3.0.1" targetFramework="net48" />
+  <package id="Shouldly" version="3.0.2" targetFramework="net48" />
   <package id="SimpleInjector" version="4.1.0" targetFramework="net48" />
   <package id="System.Configuration.ConfigurationManager" version="4.7.0" targetFramework="net48" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.0" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Web.Tests/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Web.Tests/packages.config
@@ -16,7 +16,7 @@
   <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="net48" />
   <package id="Microsoft.NET.Test.Sdk" version="16.4.0" targetFramework="net48" />
   <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net48" />
-  <package id="Moq" version="4.10.0" targetFramework="net48" />
+  <package id="Moq" version="4.14.5" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
   <package id="NUnit" version="3.11.0" targetFramework="net48" />
   <package id="NUnit3TestAdapter" version="3.11.0" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -129,8 +129,8 @@
     <Reference Include="JsonSubTypes, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\JsonSubTypes.1.2.0\lib\net47\JsonSubTypes.dll</HintPath>
     </Reference>
-    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=2.0.9.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.10\lib\net45\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.ApplicationInsights.Agent.Intercept.2.4.0\lib\net45\Microsoft.AI.Agent.Intercept.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\EntityFramework.6.4.0\build\EntityFramework.props" Condition="Exists('..\packages\EntityFramework.6.4.0\build\EntityFramework.props')" />
   <Import Project="..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.9.0\build\Microsoft.Net.Compilers.props')" />
@@ -301,8 +301,8 @@
     <Reference Include="QuickGraph.Serialization, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.Serialization.dll</HintPath>
     </Reference>
-    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.105.2.3\lib\net46\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=106.11.4.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.11.4\lib\net452\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="Sandwych.QuickGraph.Core, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Sandwych.QuickGraph.Core.1.0.0\lib\net45\Sandwych.QuickGraph.Core.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Web/Web.base.config
+++ b/Application/EdFi.Ods.AdminApp.Web/Web.base.config
@@ -181,7 +181,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="log4net" publicKeyToken="669E0DDF0BB1AA2A" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.0.8.0" newVersion="2.0.8.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.0.9.0" newVersion="2.0.9.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed"/>

--- a/Application/EdFi.Ods.AdminApp.Web/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Web/packages.config
@@ -97,7 +97,7 @@
   <package id="Polly.Extensions.Http" version="2.0.1" targetFramework="net48" />
   <package id="QuickGraph" version="3.6.61119.7" targetFramework="net48" />
   <package id="Respond" version="1.2.0" targetFramework="net48" />
-  <package id="RestSharp" version="105.2.3" targetFramework="net48" />
+  <package id="RestSharp" version="106.11.4" targetFramework="net48" />
   <package id="Sandwych.QuickGraph.Core" version="1.0.0" targetFramework="net48" />
   <package id="SimpleInjector" version="4.1.0" targetFramework="net48" />
   <package id="System.Buffers" version="4.5.0" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Web/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Web/packages.config
@@ -31,7 +31,7 @@
   <package id="jQuery.Validation" version="1.15.0" targetFramework="net48" />
   <package id="JsonSubTypes" version="1.2.0" targetFramework="net48" />
   <package id="lodash" version="4.15.0" targetFramework="net48" />
-  <package id="log4net" version="2.0.8" targetFramework="net48" />
+  <package id="log4net" version="2.0.10" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights" version="2.13.1" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.13.1" targetFramework="net48" />


### PR DESCRIPTION
Opening this PR in order to witness the CI build. I'll update this description when it is ready for review.

.NET Core work will involve a lot of dependency upgrades. This PR simply gets the simplest and safest upgradable dependencies upgraded so that they are out of the way once .NET Core upgrade work itself truly begins.

We'll also want to be consistently working across the team with VS2019, so this also addresses the fact that VS Test Explorer's own breaking changes changed the behavior of NUnit `[Explicit]` attributes such that they are unusable until a future NUnit release addresses that problem.