### PR TITLE
[AA-1091] - Phase out direct usage of HttpPostedFileBase in the Management project

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ClaimSetFileImportCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ClaimSetFileImportCommandTests.cs
@@ -11,6 +11,7 @@ using System.Web;
 using NUnit.Framework;
 using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
 using EdFi.Ods.AdminApp.Management.Database.Queries;
+using EdFi.Ods.AdminApp.Web.Helpers;
 using Shouldly;
 using Application = EdFi.Security.DataAccess.Models.Application;
 using ClaimSet = EdFi.Security.DataAccess.Models.ClaimSet;
@@ -73,6 +74,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             }";
 
             var importModel = GetImportModel(testJSON);
+            var importSharingModel = importModel.ImportFile.DeserializeToSharingModel();
 
             var getResourceByClaimSetIdQuery = new GetResourcesByClaimSetIdQuery(TestContext, GetMapper());
             var addClaimSetCommand = new AddClaimSetCommand(TestContext);
@@ -80,7 +82,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             var editResourceOnClaimSetCommand = new EditResourceOnClaimSetCommand(TestContext);
 
             var command = new ClaimSetFileImportCommand(addClaimSetCommand, editResourceOnClaimSetCommand, getResourceClaimsQuery);
-            command.Execute(importModel);
+            command.Execute(importSharingModel);
 
             var testClaimSet = TestContext.ClaimSets.SingleOrDefault(x => x.ClaimSetName == "Test Claimset");
             testClaimSet.ShouldNotBeNull();

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/ClaimSetFileImportCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/ClaimSetFileImportCommand.cs
@@ -5,7 +5,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Web;
 using EdFi.Ods.AdminApp.Management.Database.Queries;
 
 namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
@@ -23,10 +22,9 @@ namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
             _getResourceClaimsQuery = getResourceClaimsQuery;
         }
 
-        public void Execute(IClaimSetFileImportModel model)
+        public void Execute(SharingModel model)
         {
-            var sharingModel = SharingModel.Deserialize(model.ImportFile);
-            var sharingClaimSets = sharingModel.Template.ClaimSets;
+            var sharingClaimSets = model.Template.ClaimSets;
             var allResources = GetDbResources();
             foreach (var claimSet in sharingClaimSets)
             {
@@ -78,11 +76,6 @@ namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
 
             return allResources;
         }
-    }
-
-    public interface IClaimSetFileImportModel
-    {
-        HttpPostedFileBase ImportFile { get; }
     }
 
     public class AddClaimSetModel: IAddClaimSetModel

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/SharingModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/SharingModel.cs
@@ -4,11 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Collections.Generic;
-using System.IO;
-using System.Web;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Newtonsoft.Json.Serialization;
 
 namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
 {
@@ -16,35 +12,6 @@ namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
     {
         public string Title { get; set; }
         public SharingTemplate Template { get; set; }
-
-        public string Serialize()
-        {
-            return JsonConvert.SerializeObject(this, UsingIndentedCamelCase());
-        }
-
-        public static SharingModel Deserialize(HttpPostedFileBase json)
-        {
-            var streamCopy = new MemoryStream();
-            json.InputStream.CopyTo(streamCopy);
-            json.InputStream.Position = streamCopy.Position = 0;
-            using (var stream = streamCopy)
-            using (var streamReader = new StreamReader(stream))
-            using (JsonReader jsonReader = new JsonTextReader(streamReader))
-            {
-                return JsonSerializer
-                    .Create(UsingIndentedCamelCase())
-                    .Deserialize<SharingModel>(jsonReader);
-            }
-        }
-
-        private static JsonSerializerSettings UsingIndentedCamelCase()
-        {
-            return new JsonSerializerSettings
-            {
-                ContractResolver = new CamelCasePropertyNamesContractResolver(),
-                Formatting = Formatting.Indented
-            };
-        }
     }
 
     public class SharingTemplate

--- a/Application/EdFi.Ods.AdminApp.Management/Instances/BulkRegisterOdsInstancesCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Instances/BulkRegisterOdsInstancesCommand.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Web;
 using EdFi.Ods.AdminApp.Management.Configuration.Claims;
 using log4net;
 
@@ -53,10 +52,6 @@ namespace EdFi.Ods.AdminApp.Management.Instances
 
             return results;
         }
-    }
-    public interface IBulkRegisterOdsInstancesModel
-    {
-        HttpPostedFileBase OdsInstancesFile { get; }
     }
 
     public class BulkRegisterOdsInstancesResult

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ClaimSetsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ClaimSetsController.cs
@@ -12,6 +12,7 @@ using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
 using EdFi.Ods.AdminApp.Management.Database.Models;
 using EdFi.Ods.AdminApp.Management.Database.Queries;
 using EdFi.Ods.AdminApp.Web.ActionFilters;
+using EdFi.Ods.AdminApp.Web.Helpers;
 using EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets;
 using Newtonsoft.Json;
 using AddClaimSetModel = EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets.AddClaimSetModel;
@@ -268,7 +269,8 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         [HttpPost]
         public ActionResult FileImport(ClaimSetFileImportModel claimSetFileImportModel)
         {
-            _claimSetFileImportCommand.Execute(claimSetFileImportModel);
+            var sharingModel = claimSetFileImportModel.ImportFile.DeserializeToSharingModel();
+            _claimSetFileImportCommand.Execute(sharingModel);
             return RedirectToAction("ClaimSets", "GlobalSettings");
         }
 
@@ -280,7 +282,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
             var exportClaimSetModel = new ExportClaimSetPreviewModel
             {
                 DownLoadFileTitle = $"{exports.Title}({currentDate})",
-                ExportPreviewString = exports.Serialize()
+                ExportPreviewString = InputFileExtensions.SerializeFromSharingModel(exports)
             };
             return PartialView("_ExportClaimSetPreview", exportClaimSetModel);
         }

--- a/Application/EdFi.Ods.AdminApp.Web/Helpers/InputFileExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Helpers/InputFileExtensions.cs
@@ -9,7 +9,10 @@ using System.IO;
 using System.Linq;
 using System.Web;
 using CsvHelper;
+using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
 using EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstances;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace EdFi.Ods.AdminApp.Web.Helpers
 {
@@ -67,5 +70,32 @@ namespace EdFi.Ods.AdminApp.Web.Helpers
 
             return missingHeaders;
         }
+
+        public static string SerializeFromSharingModel(SharingModel model)
+        {
+            return JsonConvert.SerializeObject(model, UsingIndentedCamelCase());
+        }
+
+        public static SharingModel DeserializeToSharingModel(this HttpPostedFileBase json)
+        {
+            using (var stream = GetMemoryStream(json))
+                using (var streamReader = new StreamReader(stream))
+                    using (JsonReader jsonReader = new JsonTextReader(streamReader))
+                    {
+                        return JsonSerializer
+                            .Create(UsingIndentedCamelCase())
+                            .Deserialize<SharingModel>(jsonReader);
+                    }
+        }
+
+        private static JsonSerializerSettings UsingIndentedCamelCase()
+        {
+            return new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                Formatting = Formatting.Indented
+            };
+        }
+
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/ClaimSetFileImportModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/ClaimSetFileImportModel.cs
@@ -9,6 +9,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Web;
 using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
+using EdFi.Ods.AdminApp.Web.Helpers;
 using EdFi.Ods.AdminApp.Web.Infrastructure;
 using EdFi.Security.DataAccess.Contexts;
 using FluentValidation;
@@ -35,7 +36,7 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
                         .SafeCustom((model, context) =>
                         {
                             var validator = new SharingModelValidator(securityContext, context.PropertyName);
-                            var sharingModel = SharingModel.Deserialize(model);
+                            var sharingModel = model.DeserializeToSharingModel();
                             context.AddFailures(validator.Validate(sharingModel));
                         });
                 });

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/ClaimSetFileImportModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/ClaimSetFileImportModel.cs
@@ -17,7 +17,7 @@ using log4net;
 
 namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
 {
-    public class ClaimSetFileImportModel: IClaimSetFileImportModel
+    public class ClaimSetFileImportModel
     {
         [DisplayName("Import File")]
         [Accept(".json")]

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/OdsInstances/BulkRegisterOdsInstancesModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/OdsInstances/BulkRegisterOdsInstancesModel.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Web;
 using EdFi.Ods.AdminApp.Management.Database;
 using EdFi.Ods.AdminApp.Management.Database.Ods;
-using EdFi.Ods.AdminApp.Management.Instances;
 using EdFi.Ods.AdminApp.Management.OdsInstanceServices;
 using EdFi.Ods.AdminApp.Web.Helpers;
 using EdFi.Ods.AdminApp.Web.Infrastructure;
@@ -19,7 +18,7 @@ using FluentValidation.Validators;
 
 namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstances
 {
-    public class BulkRegisterOdsInstancesModel : IBulkRegisterOdsInstancesModel
+    public class BulkRegisterOdsInstancesModel
     {
         [Accept(".csv")]
         [Display(Name = "Instances Data File")]


### PR DESCRIPTION
**Description**
-  Removed IBulkRegisterOdsInstancesModel as the interface is not being used in the BulkRegisterOdsInstancesCommand. Removed usage of IbulkRegisterOdsInstancesModel. Removed unused using directives.
- Refactored to move the SharingModel methods to InputFileExtensions and renamed to make the connection to SharingModel more explicit. Refactored the Deserialize method to use the GetMemoryStream method available in InputFileExtensions.
- Refactored to remove IClaimSetFileImportModel and corresponding usages to pass only the SharingModel content to the Execute method of the ClaimSetFielImportCommand.
- Refactored ClaimSetsController FileImport and FileExport actions to use the refactored import model and  new InputFileExtensions methods. Refactored ClaimSetFileIMportModel to use InputFileExtensions methods.
- Refactored the ClaimSetFielImportCommandTests to use the updated import model and InputFileExtensions.