### PR TITLE
[AA-1050] preemptively resolve simple compilation errors that would eventually surface in ASPNET Core project

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
@@ -64,6 +64,7 @@
     <PackageReference Include="EdFi.Admin.LearningStandards.Core" Version="1.1.0" />
     <PackageReference Include="FluentValidation" Version="9.2.2" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="9.2.0" />
+    <PackageReference Include="log4net" Version="2.0.11" />
   </ItemGroup>
 
 </Project>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
@@ -68,6 +68,7 @@
     <PackageReference Include="Hangfire.PostgreSql" Version="1.7.1" />
     <PackageReference Include="HtmlTags" Version="8.0.0" />
     <PackageReference Include="log4net" Version="2.0.11" />
+    <PackageReference Include="Npgsql" Version="4.1.5" />
   </ItemGroup>
 
 </Project>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
@@ -64,6 +64,7 @@
     <PackageReference Include="EdFi.Admin.LearningStandards.Core" Version="1.1.0" />
     <PackageReference Include="FluentValidation" Version="9.2.2" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="9.2.0" />
+    <PackageReference Include="HtmlTags" Version="8.0.0" />
     <PackageReference Include="log4net" Version="2.0.11" />
   </ItemGroup>
 

--- a/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
@@ -59,6 +59,7 @@
 
   <ItemGroup>
     <PackageReference Include="EdFi.Admin.LearningStandards.Core" Version="1.1.0" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="9.2.0" />
   </ItemGroup>
 
 </Project>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
@@ -59,6 +59,7 @@
 
   <ItemGroup>
     <PackageReference Include="EdFi.Admin.LearningStandards.Core" Version="1.1.0" />
+    <PackageReference Include="FluentValidation" Version="9.2.2" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="9.2.0" />
   </ItemGroup>
 

--- a/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
@@ -59,6 +59,7 @@
 
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.4.1" />
+    <PackageReference Include="Castle.Windsor" Version="5.0.1" />
     <PackageReference Include="EdFi.Admin.LearningStandards.Core" Version="1.1.0" />
     <PackageReference Include="FluentValidation" Version="9.2.2" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="9.2.0" />

--- a/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
@@ -66,6 +66,7 @@
     <PackageReference Include="FluentValidation.AspNetCore" Version="9.2.0" />
     <PackageReference Include="Hangfire" Version="1.7.14" />
     <PackageReference Include="Hangfire.PostgreSql" Version="1.7.1" />
+    <PackageReference Include="HangFire.Windsor" Version="2.0.1" />
     <PackageReference Include="HtmlTags" Version="8.0.0" />
     <PackageReference Include="log4net" Version="2.0.11" />
     <PackageReference Include="Npgsql" Version="4.1.5" />

--- a/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
@@ -58,6 +58,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Castle.Core" Version="4.4.1" />
     <PackageReference Include="EdFi.Admin.LearningStandards.Core" Version="1.1.0" />
     <PackageReference Include="FluentValidation" Version="9.2.2" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="9.2.0" />

--- a/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
@@ -17,45 +17,45 @@
          these files will be moved from the legacy project to this project, at
          which point these explicit inclusions will become redundant. -->
 
-    <Compile Include="../EdFi.Ods.AdminApp.Web/_Installers/**/*.cs" LinkBase="_Installers" />
-    <Compile Include="../EdFi.Ods.AdminApp.Web/ActionFilters/**/*.cs" LinkBase="ActionFilters" />
-    <Compile Include="../EdFi.Ods.AdminApp.Web/App_Start/**/*.cs" LinkBase="App_Start" />
+    <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/_Installers/**/*.cs" LinkBase="_Installers" /> -->
+    <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/ActionFilters/**/*.cs" LinkBase="ActionFilters" /> -->
+    <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/App_Start/**/*.cs" LinkBase="App_Start" /> -->
     <Content Include="../EdFi.Ods.AdminApp.Web/Artifacts/**/*.sql" LinkBase="Artifacts" />
-    <Content Include="../EdFi.Ods.AdminApp.Web/Config/**/*.json" LinkBase="Config" />
+    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Config/**/*.json" LinkBase="Config" /> -->
     <Content Include="../EdFi.Ods.AdminApp.Web/Content/**/*.*" LinkBase="Content" />
-    <Compile Include="../EdFi.Ods.AdminApp.Web/Controllers/**/*.cs" LinkBase="Controllers" />
-    <Content Include="../EdFi.Ods.AdminApp.Web/DeveloperSettings/AzureActiveDirectory.config" LinkBase="DeveloperSettings" Condition="'$(Configuration)' == 'Debug'" />
+    <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/Controllers/**/*.cs" LinkBase="Controllers" /> -->
+    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/DeveloperSettings/AzureActiveDirectory.config" LinkBase="DeveloperSettings" Condition="'$(Configuration)' == 'Debug'" /> -->
     <Content Include="../EdFi.Ods.AdminApp.Web/fonts/glyphicons-halflings-regular.svg" LinkBase="fonts" />
     <Content Include="../EdFi.Ods.AdminApp.Web/fonts/glyphicons-halflings-regular.woff2" LinkBase="fonts" />
     <Content Include="../EdFi.Ods.AdminApp.Web/fonts/glyphicons-halflings-regular.woff" LinkBase="fonts" />
     <Content Include="../EdFi.Ods.AdminApp.Web/fonts/glyphicons-halflings-regular.ttf" LinkBase="fonts" />
     <Content Include="../EdFi.Ods.AdminApp.Web/fonts/glyphicons-halflings-regular.eot" LinkBase="fonts" />
-    <Compile Include="../EdFi.Ods.AdminApp.Web/Display/**/*.cs" LinkBase="Display" />
-    <Compile Include="../EdFi.Ods.AdminApp.Web/Helpers/**/*.cs" LinkBase="Helpers" />
-    <Compile Include="../EdFi.Ods.AdminApp.Web/Hubs/**/*.cs" LinkBase="Hubs" />
-    <Compile Include="../EdFi.Ods.AdminApp.Web/Infrastructure/**/*.cs" LinkBase="Infrastructure" />
-    <Compile Include="../EdFi.Ods.AdminApp.Web/Models/**/*.cs" LinkBase="Models" />
+    <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/Display/**/*.cs" LinkBase="Display" /> -->
+    <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/Helpers/**/*.cs" LinkBase="Helpers" /> -->
+    <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/Hubs/**/*.cs" LinkBase="Hubs" /> -->
+    <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/Infrastructure/**/*.cs" LinkBase="Infrastructure" /> -->
+    <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/Models/**/*.cs" LinkBase="Models" /> -->
     <Content Include="../EdFi.Ods.AdminApp.Web/Schema/**/*.*" LinkBase="Schema" />
     <Content Include="../EdFi.Ods.AdminApp.Web/Scripts/**/*.*" LinkBase="Scripts" />
-    <Content Include="../EdFi.Ods.AdminApp.Web/Service References/AzureAD/ConnectedService.json" LinkBase="Service References" />
+    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Service References/AzureAD/ConnectedService.json" LinkBase="Service References" /> -->
     <Content Include="../EdFi.Ods.AdminApp.Web/uploads/placeholder.txt" LinkBase="uploads">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <Content Include="../EdFi.Ods.AdminApp.Web/Views/**/*.cshtml" LinkBase="Views" />
+    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/**/*.cshtml" LinkBase="Views" /> -->
 
   </ItemGroup>
 
-  <ItemGroup>
+  <!-- <ItemGroup> -->
     <!-- These project references can be uncommented once each one is upgrade to support .NET Core.
          These can be temporarily uncommented even before then, though doing so introduces compatibility
          warnings about referncing .NET Framework projects and would not be trusted in production.
     -->
 
-    <ProjectReference Include="..\EdFi.Ods.AdminApp.Management.Aws\EdFi.Ods.AdminApp.Management.Aws.csproj" />
-    <ProjectReference Include="..\EdFi.Ods.AdminApp.Management.Azure\EdFi.Ods.AdminApp.Management.Azure.csproj" />
-    <ProjectReference Include="..\EdFi.Ods.AdminApp.Management.OnPrem\EdFi.Ods.AdminApp.Management.OnPrem.csproj" />
-    <ProjectReference Include="..\EdFi.Ods.AdminApp.Management\EdFi.Ods.AdminApp.Management.csproj" />
-  </ItemGroup>
+    <!-- <ProjectReference Include="..\EdFi.Ods.AdminApp.Management.Aws\EdFi.Ods.AdminApp.Management.Aws.csproj" /> -->
+    <!-- <ProjectReference Include="..\EdFi.Ods.AdminApp.Management.Azure\EdFi.Ods.AdminApp.Management.Azure.csproj" /> -->
+    <!-- <ProjectReference Include="..\EdFi.Ods.AdminApp.Management.OnPrem\EdFi.Ods.AdminApp.Management.OnPrem.csproj" /> -->
+    <!-- <ProjectReference Include="..\EdFi.Ods.AdminApp.Management\EdFi.Ods.AdminApp.Management.csproj" /> -->
+  <!-- </ItemGroup> -->
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.0.0" />

--- a/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
@@ -58,6 +58,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="10.0.0" />
     <PackageReference Include="Castle.Core" Version="4.4.1" />
     <PackageReference Include="Castle.Windsor" Version="5.0.1" />
     <PackageReference Include="EdFi.Admin.LearningStandards.Core" Version="1.1.0" />

--- a/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
@@ -17,45 +17,45 @@
          these files will be moved from the legacy project to this project, at
          which point these explicit inclusions will become redundant. -->
 
-    <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/_Installers/**/*.cs" LinkBase="_Installers" /> -->
-    <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/ActionFilters/**/*.cs" LinkBase="ActionFilters" /> -->
-    <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/App_Start/**/*.cs" LinkBase="App_Start" /> -->
+    <Compile Include="../EdFi.Ods.AdminApp.Web/_Installers/**/*.cs" LinkBase="_Installers" />
+    <Compile Include="../EdFi.Ods.AdminApp.Web/ActionFilters/**/*.cs" LinkBase="ActionFilters" />
+    <Compile Include="../EdFi.Ods.AdminApp.Web/App_Start/**/*.cs" LinkBase="App_Start" />
     <Content Include="../EdFi.Ods.AdminApp.Web/Artifacts/**/*.sql" LinkBase="Artifacts" />
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Config/**/*.json" LinkBase="Config" /> -->
+    <Content Include="../EdFi.Ods.AdminApp.Web/Config/**/*.json" LinkBase="Config" />
     <Content Include="../EdFi.Ods.AdminApp.Web/Content/**/*.*" LinkBase="Content" />
-    <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/Controllers/**/*.cs" LinkBase="Controllers" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/DeveloperSettings/AzureActiveDirectory.config" LinkBase="DeveloperSettings" Condition="'$(Configuration)' == 'Debug'" /> -->
+    <Compile Include="../EdFi.Ods.AdminApp.Web/Controllers/**/*.cs" LinkBase="Controllers" />
+    <Content Include="../EdFi.Ods.AdminApp.Web/DeveloperSettings/AzureActiveDirectory.config" LinkBase="DeveloperSettings" Condition="'$(Configuration)' == 'Debug'" />
     <Content Include="../EdFi.Ods.AdminApp.Web/fonts/glyphicons-halflings-regular.svg" LinkBase="fonts" />
     <Content Include="../EdFi.Ods.AdminApp.Web/fonts/glyphicons-halflings-regular.woff2" LinkBase="fonts" />
     <Content Include="../EdFi.Ods.AdminApp.Web/fonts/glyphicons-halflings-regular.woff" LinkBase="fonts" />
     <Content Include="../EdFi.Ods.AdminApp.Web/fonts/glyphicons-halflings-regular.ttf" LinkBase="fonts" />
     <Content Include="../EdFi.Ods.AdminApp.Web/fonts/glyphicons-halflings-regular.eot" LinkBase="fonts" />
-    <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/Display/**/*.cs" LinkBase="Display" /> -->
-    <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/Helpers/**/*.cs" LinkBase="Helpers" /> -->
-    <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/Hubs/**/*.cs" LinkBase="Hubs" /> -->
-    <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/Infrastructure/**/*.cs" LinkBase="Infrastructure" /> -->
-    <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/Models/**/*.cs" LinkBase="Models" /> -->
+    <Compile Include="../EdFi.Ods.AdminApp.Web/Display/**/*.cs" LinkBase="Display" />
+    <Compile Include="../EdFi.Ods.AdminApp.Web/Helpers/**/*.cs" LinkBase="Helpers" />
+    <Compile Include="../EdFi.Ods.AdminApp.Web/Hubs/**/*.cs" LinkBase="Hubs" />
+    <Compile Include="../EdFi.Ods.AdminApp.Web/Infrastructure/**/*.cs" LinkBase="Infrastructure" />
+    <Compile Include="../EdFi.Ods.AdminApp.Web/Models/**/*.cs" LinkBase="Models" />
     <Content Include="../EdFi.Ods.AdminApp.Web/Schema/**/*.*" LinkBase="Schema" />
     <Content Include="../EdFi.Ods.AdminApp.Web/Scripts/**/*.*" LinkBase="Scripts" />
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Service References/AzureAD/ConnectedService.json" LinkBase="Service References" /> -->
+    <Content Include="../EdFi.Ods.AdminApp.Web/Service References/AzureAD/ConnectedService.json" LinkBase="Service References" />
     <Content Include="../EdFi.Ods.AdminApp.Web/uploads/placeholder.txt" LinkBase="uploads">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/**/*.cshtml" LinkBase="Views" /> -->
+    <Content Include="../EdFi.Ods.AdminApp.Web/Views/**/*.cshtml" LinkBase="Views" />
 
   </ItemGroup>
 
-  <!-- <ItemGroup> -->
+  <ItemGroup>
     <!-- These project references can be uncommented once each one is upgrade to support .NET Core.
          These can be temporarily uncommented even before then, though doing so introduces compatibility
          warnings about referncing .NET Framework projects and would not be trusted in production.
     -->
 
-    <!-- <ProjectReference Include="..\EdFi.Ods.AdminApp.Management.Aws\EdFi.Ods.AdminApp.Management.Aws.csproj" /> -->
-    <!-- <ProjectReference Include="..\EdFi.Ods.AdminApp.Management.Azure\EdFi.Ods.AdminApp.Management.Azure.csproj" /> -->
-    <!-- <ProjectReference Include="..\EdFi.Ods.AdminApp.Management.OnPrem\EdFi.Ods.AdminApp.Management.OnPrem.csproj" /> -->
-    <!-- <ProjectReference Include="..\EdFi.Ods.AdminApp.Management\EdFi.Ods.AdminApp.Management.csproj" /> -->
-  <!-- </ItemGroup> -->
+    <ProjectReference Include="..\EdFi.Ods.AdminApp.Management.Aws\EdFi.Ods.AdminApp.Management.Aws.csproj" />
+    <ProjectReference Include="..\EdFi.Ods.AdminApp.Management.Azure\EdFi.Ods.AdminApp.Management.Azure.csproj" />
+    <ProjectReference Include="..\EdFi.Ods.AdminApp.Management.OnPrem\EdFi.Ods.AdminApp.Management.OnPrem.csproj" />
+    <ProjectReference Include="..\EdFi.Ods.AdminApp.Management\EdFi.Ods.AdminApp.Management.csproj" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="EdFi.Admin.LearningStandards.Core" Version="1.1.0" />

--- a/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
@@ -64,6 +64,7 @@
     <PackageReference Include="EdFi.Admin.LearningStandards.Core" Version="1.1.0" />
     <PackageReference Include="FluentValidation" Version="9.2.2" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="9.2.0" />
+    <PackageReference Include="Hangfire" Version="1.7.14" />
     <PackageReference Include="HtmlTags" Version="8.0.0" />
     <PackageReference Include="log4net" Version="2.0.11" />
   </ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
@@ -65,6 +65,7 @@
     <PackageReference Include="FluentValidation" Version="9.2.2" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="9.2.0" />
     <PackageReference Include="Hangfire" Version="1.7.14" />
+    <PackageReference Include="Hangfire.PostgreSql" Version="1.7.1" />
     <PackageReference Include="HtmlTags" Version="8.0.0" />
     <PackageReference Include="log4net" Version="2.0.11" />
   </ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Web/ActionFilters/AuthorizationFilter.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/ActionFilters/AuthorizationFilter.cs
@@ -1,9 +1,13 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Authorization;
+#endif
 using EdFi.Ods.AdminApp.Web.Helpers;
 
 namespace EdFi.Ods.AdminApp.Web.ActionFilters

--- a/Application/EdFi.Ods.AdminApp.Web/ActionFilters/DoNotCacheAjaxRequestsFilter.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/ActionFilters/DoNotCacheAjaxRequestsFilter.cs
@@ -1,11 +1,15 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System;
 using System.Web;
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Mvc.Filters;
+#endif
 
 namespace EdFi.Ods.AdminApp.Web.ActionFilters
 {

--- a/Application/EdFi.Ods.AdminApp.Web/ActionFilters/HandleAjaxErrorAttribute.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/ActionFilters/HandleAjaxErrorAttribute.cs
@@ -1,11 +1,15 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Data.SqlClient;
 using System.Net;
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Mvc.Filters;
+#endif
 using EdFi.Ods.AdminApp.Web.Controllers;
 using log4net;
 

--- a/Application/EdFi.Ods.AdminApp.Web/ActionFilters/InstanceContextFilter.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/ActionFilters/InstanceContextFilter.cs
@@ -1,11 +1,16 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System;
 using System.Linq;
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+#endif
 using EdFi.Ods.AdminApp.Management;
 using EdFi.Ods.AdminApp.Management.Database;
 using EdFi.Ods.AdminApp.Management.Database.Models;

--- a/Application/EdFi.Ods.AdminApp.Web/ActionFilters/JsonValidationFilter.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/ActionFilters/JsonValidationFilter.cs
@@ -1,9 +1,14 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+#endif
 using Newtonsoft.Json;
 
 namespace EdFi.Ods.AdminApp.Web.ActionFilters

--- a/Application/EdFi.Ods.AdminApp.Web/ActionFilters/PasswordChangeRequiredFilter.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/ActionFilters/PasswordChangeRequiredFilter.cs
@@ -1,11 +1,16 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System;
 using System.Web;
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Filters;
+#endif
 using EdFi.Ods.AdminApp.Web.Controllers;
 using EdFi.Ods.AdminApp.Web.Helpers;
 using Microsoft.AspNet.Identity;

--- a/Application/EdFi.Ods.AdminApp.Web/ActionFilters/PermissionRequiredFilter.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/ActionFilters/PermissionRequiredFilter.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -7,7 +7,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Authorization;
+#endif
 using EdFi.Ods.AdminApp.Management;
 using EdFi.Ods.AdminApp.Management.Database.Models;
 

--- a/Application/EdFi.Ods.AdminApp.Web/ActionFilters/RequreSecureConnectionFilter.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/ActionFilters/RequreSecureConnectionFilter.cs
@@ -1,10 +1,14 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System;
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Mvc;
+#endif
 
 namespace EdFi.Ods.AdminApp.Web.ActionFilters
 {

--- a/Application/EdFi.Ods.AdminApp.Web/ActionFilters/SetupRequiredFilter.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/ActionFilters/SetupRequiredFilter.cs
@@ -1,10 +1,14 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System;
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Mvc.Filters;
+#endif
 using EdFi.Ods.AdminApp.Management;
 using EdFi.Ods.AdminApp.Management.Configuration.Application;
 using EdFi.Ods.AdminApp.Web.Controllers;

--- a/Application/EdFi.Ods.AdminApp.Web/ActionFilters/UserContextFilter.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/ActionFilters/UserContextFilter.cs
@@ -57,7 +57,7 @@ namespace EdFi.Ods.AdminApp.Web.ActionFilters
             return false;
         }
 
-        private static Permission[] PopulatePermissions(IEnumerable<IdentityUserRole<>> userRoles)
+        private static Permission[] PopulatePermissions(IEnumerable<IdentityUserRole> userRoles)
         {
             IEnumerable<Permission> permissions = new Permission[] {};
             permissions = userRoles.Aggregate(permissions, (current, userRole) => current.Union(RolePermission.GetPermissions(userRole.RoleId)));

--- a/Application/EdFi.Ods.AdminApp.Web/ActionFilters/UserContextFilter.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/ActionFilters/UserContextFilter.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -7,7 +7,12 @@ using System;
 using System.Collections.Generic;
 using System.Data.Entity;
 using System.Linq;
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+#endif
 using EdFi.Ods.AdminApp.Management;
 using EdFi.Ods.AdminApp.Management.Database;
 using EdFi.Ods.AdminApp.Management.Database.Models;
@@ -52,7 +57,7 @@ namespace EdFi.Ods.AdminApp.Web.ActionFilters
             return false;
         }
 
-        private static Permission[] PopulatePermissions(IEnumerable<IdentityUserRole> userRoles)
+        private static Permission[] PopulatePermissions(IEnumerable<IdentityUserRole<>> userRoles)
         {
             IEnumerable<Permission> permissions = new Permission[] {};
             permissions = userRoles.Aggregate(permissions, (current, userRole) => current.Union(RolePermission.GetPermissions(userRole.RoleId)));

--- a/Application/EdFi.Ods.AdminApp.Web/ActionFilters/ValidateAntiForgeryTokenOnPostActionsFilter.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/ActionFilters/ValidateAntiForgeryTokenOnPostActionsFilter.cs
@@ -1,10 +1,14 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Web.Helpers;
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Mvc.Filters;
+#endif
 
 namespace EdFi.Ods.AdminApp.Web.ActionFilters
 {

--- a/Application/EdFi.Ods.AdminApp.Web/App_Start/RouteConfig.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/App_Start/RouteConfig.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ApplicationController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ApplicationController.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -6,7 +6,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Mvc;
+#endif
 using AutoMapper;
 using EdFi.Ods.AdminApp.Management;
 using EdFi.Ods.AdminApp.Management.Api;

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/BulkUploadController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/BulkUploadController.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -6,7 +6,11 @@
 using System;
 using System.Linq;
 using System.Net;
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Mvc;
+#endif
 using EdFi.Ods.AdminApp.Management;
 using EdFi.Ods.AdminApp.Web.Infrastructure.IO;
 using EdFi.Ods.AdminApp.Web.Infrastructure.Jobs;

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ClaimSetsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ClaimSetsController.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -6,7 +6,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+#endif
 using EdFi.Ods.AdminApp.Management;
 using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
 using EdFi.Ods.AdminApp.Management.Database.Models;

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ControllerBase.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ControllerBase.cs
@@ -1,11 +1,15 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System;
 using System.Linq.Expressions;
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Mvc;
+#endif
 using EdFi.Ods.AdminApp.Web.Helpers;
 using log4net;
 

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/DescriptorsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/DescriptorsController.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -8,7 +8,11 @@ using EdFi.Ods.AdminApp.Management.Api;
 using EdFi.Ods.AdminApp.Web.Models.ViewModels.Descriptors;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Mvc;
+#endif
 
 namespace EdFi.Ods.AdminApp.Web.Controllers
 {

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/EducationOrganizationsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/EducationOrganizationsController.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -10,7 +10,11 @@ using EdFi.Ods.AdminApp.Management.Api;
 using EdFi.Ods.AdminApp.Management.Api.Models;
 using EdFi.Ods.AdminApp.Web.Models.ViewModels;
 using EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations;
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Mvc;
+#endif
 using EdFi.Ods.AdminApp.Management;
 using EdFi.Ods.AdminApp.Management.Helpers;
 using EdFi.Ods.AdminApp.Management.Instances;

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ErrorController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ErrorController.cs
@@ -1,9 +1,13 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Mvc;
+#endif
 using EdFi.Ods.AdminApp.Web.ActionFilters;
 
 namespace EdFi.Ods.AdminApp.Web.Controllers

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/GlobalSettingsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/GlobalSettingsController.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -6,7 +6,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Mvc;
+#endif
 using AutoMapper;
 using EdFi.Ods.AdminApp.Management;
 using EdFi.Ods.AdminApp.Management.ClaimSetEditor;

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/HomeController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/HomeController.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -6,7 +6,11 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Mvc;
+#endif
 using EdFi.Ods.AdminApp.Management.Instances;
 using EdFi.Ods.AdminApp.Web.ActionFilters;
 using EdFi.Ods.AdminApp.Web.Display.HomeScreen;

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/IdentityController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/IdentityController.cs
@@ -7,7 +7,13 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Web;
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+#endif
 using EdFi.Ods.AdminApp.Management.Configuration.Application;
 using EdFi.Ods.AdminApp.Management.Database.Models;
 using EdFi.Ods.AdminApp.Management.Identity;

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/OdsInstanceSettingsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/OdsInstanceSettingsController.cs
@@ -10,7 +10,11 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using System.Web.Hosting;
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Mvc;
+#endif
 using AutoMapper;
 using EdFi.Ods.AdminApp.Management;
 using EdFi.Ods.AdminApp.Management.Api;

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/OdsInstancesController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/OdsInstancesController.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -6,7 +6,11 @@
 using System;
 using System.Collections.Generic;
 using System.Web;
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Mvc;
+#endif
 using AutoMapper;
 using EdFi.Ods.AdminApp.Management.Instances;
 using EdFi.Ods.AdminApp.Management.User;

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ReportsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ReportsController.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -7,7 +7,12 @@ using EdFi.Ods.AdminApp.Management;
 using EdFi.Ods.AdminApp.Management.Database.Ods;
 using EdFi.Ods.AdminApp.Web.Models.ViewModels.Reports;
 using System.Linq;
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+#endif
 using EdFi.Ods.AdminApp.Web.Infrastructure;
 
 namespace EdFi.Ods.AdminApp.Web.Controllers

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/SetupController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/SetupController.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -7,7 +7,11 @@ using System;
 using System.Data.SqlClient;
 using System.Net;
 using System.Threading.Tasks;
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Mvc;
+#endif
 using EdFi.Ods.AdminApp.Management;
 using EdFi.Ods.AdminApp.Management.Api;
 using EdFi.Ods.AdminApp.Management.Configuration.Application;

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/UpdateController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/UpdateController.cs
@@ -1,10 +1,14 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Threading.Tasks;
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Mvc;
+#endif
 using EdFi.Ods.AdminApp.Web.Infrastructure;
 
 namespace EdFi.Ods.AdminApp.Web.Controllers

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/UserController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/UserController.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -7,7 +7,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Web;
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Mvc;
+#endif
 using EdFi.Ods.AdminApp.Management.Database.Models;
 using EdFi.Ods.AdminApp.Management.Instances;
 using EdFi.Ods.AdminApp.Management.User;

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -34,7 +34,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET48</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -42,7 +42,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;NET48</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -1153,14 +1153,14 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;NET48</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'OnPremYearSpecific|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET48</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
@@ -1168,7 +1168,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'OnPremYearSpecificRelease|AnyCPU'">
     <OutputPath>bin\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;NET48</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -1178,7 +1178,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'OnPremNpgsql|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET48</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -1143,7 +1143,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'OnPremises|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET48</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/ClaimSetResourcesModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/ClaimSetResourcesModel.cs
@@ -1,10 +1,14 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Collections.Generic;
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Mvc.Rendering;
+#endif
 using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
 
 namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/EditClaimSetModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/EditClaimSetModel.cs
@@ -1,11 +1,15 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Collections.Generic;
 using System.Linq;
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Mvc.Rendering;
+#endif
 using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
 using VendorApplication = EdFi.Ods.AdminApp.Management.ClaimSetEditor.Application;
 using EdFi.Security.DataAccess.Contexts;

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Reports/SelectDistrictModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Reports/SelectDistrictModel.cs
@@ -1,11 +1,15 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+#if NET48
 using System.Web.Mvc;
+#else
+using Microsoft.AspNetCore.Mvc.Rendering;
+#endif
 using EdFi.Ods.AdminApp.Web.Display.TabEnumeration;
 
 namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.Reports


### PR DESCRIPTION
This is meant to be a low-risk PR that improves the ASPNET Core project's potential to compile once downstream dependencies are compiling for netcoreapp3.1.

I uncommented the inclusion of all cs files in the project, provoking the many expected compiler errors, then I installed several NuGet packages at modern version numbers, based on those error messages, reducing the number of errors from ~1430 to ~291 (exact numbers can be misleading when there are so many). Then, I commented out the inclusion of the problematic cs files again, because we'll need our dependencies truly targeting netcoreapp3.1 before these can be expected to work.

The changes within EdFi.Ods.AdminApp.Web.Core.csproj are extremely low risk because this project is still not the one we'd deploy in the short term.

The changes within EdFi.Ods.AdminApp.Web/* are INTENDED to be low risk in the following way, so the reviewer should pay careful attention to these file edits since this is where a typo could allow for a (very unlikely) behavior change to slip in:

1. In the legacy web app csproj, I define NET48. This is automatic in modern projects, but had to be explicit here. This allows us to say #if NET48 in our shared c# files and have that be treated as "true" in the legacy project and "false" in the ASPNET Core project.
2. For several "using" directives, continue to include the same existing namespace #if NET48 so that there are no changes to the deployable code right now.
3. When **not** NET48, use slightly different namespaces on new lines.

In other words, all the diffs in cs files here should be essentially "no change" when NET48, and "trivial alternative" when !NET48.