### PR TITLE
[AA-1089] - Phase out the Management project's dependency on Microsoft.AspNet.Mvc

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Queries/GetResourceClaimsQueryTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Queries/GetResourceClaimsQueryTests.cs
@@ -12,6 +12,7 @@ using NUnit.Framework;
 using Shouldly;
 using Application = EdFi.Security.DataAccess.Models.Application;
 using ResourceClaim = EdFi.Security.DataAccess.Models.ResourceClaim;
+using static EdFi.Ods.AdminApp.Web.Infrastructure.ResourceClaimSelectListBuilder;
 
 namespace EdFi.Ods.AdminApp.Management.Tests.Database.Queries
 {
@@ -68,7 +69,9 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Database.Queries
             {
                 var query = new GetResourceClaimsQuery(securityContext);
 
-                var results = query.GetSelectListForResourceClaims();
+                var allResourceClaims = query.Execute().ToList();
+
+                var results = GetSelectListForResourceClaims(allResourceClaims);
 
                 // Removing "Please select a value" SelectListItem from the results
                 results.RemoveAt(0);

--- a/Application/EdFi.Ods.AdminApp.Management/Database/Queries/GetResourceClaimsQuery.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/Queries/GetResourceClaimsQuery.cs
@@ -5,7 +5,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Web.Mvc;
 using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
 using EdFi.Security.DataAccess.Contexts;
 
@@ -44,47 +43,6 @@ namespace EdFi.Ods.AdminApp.Management.Database.Queries
                 .Distinct()
                 .OrderBy(x => x.Name)
                 .ToList();
-        }
-
-        public List<SelectListItem> GetSelectListForResourceClaims()
-        {
-            var allResourceClaims = Execute();
-            var selectList = new List<SelectListItem>{
-                new SelectListItem{ Text="Please select a value", Value = "0" , Disabled = true, Selected = true},
-            };
-            var parentGroup = new SelectListGroup
-            {
-                Name = "Groups"
-            };
-            var childGroup = new SelectListGroup
-            {
-                Name = "Resources"
-            };
-            var parentGroupList = new List<SelectListItem>();
-            var childGroupList = new List<SelectListItem>();
-            foreach (var resourceClaim in allResourceClaims)
-            {
-                var item = new SelectListItem
-                {
-                    Text = resourceClaim.Name,
-                    Value = resourceClaim.Id.ToString(),
-                    Group = parentGroup
-                };
-                parentGroupList.Add(item);
-                if (resourceClaim.Children.Count > 0)
-                {
-                    childGroupList.AddRange(resourceClaim.Children.Select(x => new SelectListItem
-                    {
-                        Text = x.Name,
-                        Value = x.Id.ToString(),
-                        Group = childGroup
-                    }));
-                }
-            }
-            parentGroupList = parentGroupList.OrderBy(x => x.Text).ToList();
-            parentGroupList.AddRange(childGroupList.OrderBy(x => x.Text));
-            selectList.AddRange(new SelectList(parentGroupList, "Value", "Text", "Group.Name", -1));
-            return selectList;
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -26,7 +26,6 @@
     <PackageReference Include="log4net" Version="2.0.10" />
     <PackageReference Include="Microsoft.AspNet.Identity.Core" Version="2.2.3" />
     <PackageReference Include="Microsoft.AspNet.Identity.EntityFramework" Version="2.2.3" />
-    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Npgsql" Version="4.1.3.1" />
     <PackageReference Include="RestSharp" Version="106.11.4" />

--- a/Application/EdFi.Ods.AdminApp.Management/LocalFileBasedGetCloudOdsHostedComponentsQuery.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/LocalFileBasedGetCloudOdsHostedComponentsQuery.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Configuration;
 using System.IO;
 using System.Threading.Tasks;
-using System.Web.Helpers;
+using Newtonsoft.Json;
 using System.Web.Hosting;
 
 namespace EdFi.Ods.AdminApp.Management
@@ -30,7 +30,7 @@ namespace EdFi.Ods.AdminApp.Management
             using (var sr = File.OpenText(filePath))
             {
                 var componentsString = await sr.ReadToEndAsync();
-                var odsComponents = Json.Decode<List<OdsComponent>>(componentsString);
+                var odsComponents = JsonConvert.DeserializeObject<List<OdsComponent>>(componentsString);
 
                 return odsComponents;
             }

--- a/Application/EdFi.Ods.AdminApp.Management/OdsSecretConfigurationProvider.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/OdsSecretConfigurationProvider.cs
@@ -84,7 +84,7 @@ namespace EdFi.Ods.AdminApp.Management
                 return JsonConvert.DeserializeObject<OdsSqlConfiguration>(
                     _stringEncryptorService.TryDecrypt(rawValue, out var unencryptedValue)
                         ? unencryptedValue
-                        : rawValue);
+                        : rawValue, GetSerializerSettings());
             }
         }
 
@@ -103,13 +103,13 @@ namespace EdFi.Ods.AdminApp.Management
                 return JsonConvert.DeserializeObject<OdsSecretConfiguration>(
                     _stringEncryptorService.TryDecrypt(rawValue, out var unencryptedValue)
                         ? unencryptedValue
-                        : rawValue);
+                        : rawValue, GetSerializerSettings());
             }
         }
 
         private async Task WriteSecretConfiguration(OdsSecretConfiguration configuration, int? instanceRegistrationId)
         {
-            var stringValue = JsonConvert.SerializeObject(configuration);
+            var stringValue = JsonConvert.SerializeObject(configuration, GetSerializerSettings());
             var encryptedValue = _stringEncryptorService.Encrypt(stringValue);
 
             using (var database = new AdminAppDbContext())
@@ -129,7 +129,7 @@ namespace EdFi.Ods.AdminApp.Management
 
         private async Task WriteSqlConfiguration(OdsSqlConfiguration configuration)
         {
-            var stringValue = JsonConvert.SerializeObject(configuration);
+            var stringValue = JsonConvert.SerializeObject(configuration, GetSerializerSettings());
             var encryptedValue = _stringEncryptorService.Encrypt(stringValue);
             using (var database = new AdminAppDbContext())
             {
@@ -142,6 +142,14 @@ namespace EdFi.Ods.AdminApp.Management
 
                 await database.SaveChangesAsync();
             }
+        }
+
+        private JsonSerializerSettings GetSerializerSettings()
+        {
+            return new JsonSerializerSettings
+            {
+                DateFormatHandling = DateFormatHandling.MicrosoftDateFormat
+            };
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management/OdsSecretConfigurationProvider.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/OdsSecretConfigurationProvider.cs
@@ -8,9 +8,9 @@ using System.Threading.Tasks;
 using EdFi.Ods.AdminApp.Management.Services;
 using System.Runtime.Caching;
 using System.Data.Entity;
-using System.Web.Helpers;
 using EdFi.Ods.AdminApp.Management.Database;
 using EdFi.Ods.AdminApp.Management.Database.Models;
+using Newtonsoft.Json;
 
 namespace EdFi.Ods.AdminApp.Management
 {
@@ -81,7 +81,7 @@ namespace EdFi.Ods.AdminApp.Management
                     return null;
                 }
 
-                return Json.Decode<OdsSqlConfiguration>(
+                return JsonConvert.DeserializeObject<OdsSqlConfiguration>(
                     _stringEncryptorService.TryDecrypt(rawValue, out var unencryptedValue)
                         ? unencryptedValue
                         : rawValue);
@@ -100,7 +100,7 @@ namespace EdFi.Ods.AdminApp.Management
                     return null;
                 }
 
-                return Json.Decode<OdsSecretConfiguration>(
+                return JsonConvert.DeserializeObject<OdsSecretConfiguration>(
                     _stringEncryptorService.TryDecrypt(rawValue, out var unencryptedValue)
                         ? unencryptedValue
                         : rawValue);
@@ -109,7 +109,7 @@ namespace EdFi.Ods.AdminApp.Management
 
         private async Task WriteSecretConfiguration(OdsSecretConfiguration configuration, int? instanceRegistrationId)
         {
-            var stringValue = Json.Encode(configuration);
+            var stringValue = JsonConvert.SerializeObject(configuration);
             var encryptedValue = _stringEncryptorService.Encrypt(stringValue);
 
             using (var database = new AdminAppDbContext())
@@ -129,7 +129,7 @@ namespace EdFi.Ods.AdminApp.Management
 
         private async Task WriteSqlConfiguration(OdsSqlConfiguration configuration)
         {
-            var stringValue = Json.Encode(configuration);
+            var stringValue = JsonConvert.SerializeObject(configuration);
             var encryptedValue = _stringEncryptorService.Encrypt(stringValue);
             using (var database = new AdminAppDbContext())
             {

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ClaimSetsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ClaimSetsController.cs
@@ -20,6 +20,7 @@ using EdFi.Ods.AdminApp.Web.ActionFilters;
 using EdFi.Ods.AdminApp.Web.Helpers;
 using EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets;
 using Newtonsoft.Json;
+using static EdFi.Ods.AdminApp.Web.Infrastructure.ResourceClaimSelectListBuilder;
 using AddClaimSetModel = EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets.AddClaimSetModel;
 
 namespace EdFi.Ods.AdminApp.Web.Controllers
@@ -165,13 +166,14 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         public ActionResult EditClaimSet(int claimSetId)
         {
             var existingClaimSet = _getClaimSetByIdQuery.Execute(claimSetId);
+            var allResourceClaims = _getResourceClaimsQuery.Execute().ToList();
             var model = new EditClaimSetModel
             {
                 ClaimSetName = existingClaimSet.Name,
                 ClaimSetId = claimSetId,
                 Applications = _getApplicationsByClaimSetIdQuery.Execute(claimSetId),
                 ResourceClaims = _getResourcesByClaimSetIdQuery.AllResources(claimSetId),
-                AllResourceClaims = _getResourceClaimsQuery.GetSelectListForResourceClaims()
+                AllResourceClaims = GetSelectListForResourceClaims(allResourceClaims)
             };
   
             return PartialView("_EditClaimSet", model);

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -619,6 +619,7 @@
     <Compile Include="Infrastructure\ValidationExtensions.cs" />
     <Compile Include="Display\DisplayService\AwsTabDisplayService.cs" />
     <Compile Include="Display\DisplayService\AzureTabDisplayService.cs" />
+    <Compile Include="Infrastructure\ResourceClaimSelectListBuilder.cs" />
     <Compile Include="Models\ViewModels\Global\UserIndexModel.cs" />
     <Compile Include="Models\ViewModels\OdsInstances\DeregisterOdsInstanceModel.cs" />
     <Compile Include="Models\ViewModels\OdsInstances\BulkRegisterOdsInstancesModel.cs" />

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/ResourceClaimSelectListBuilder.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/ResourceClaimSelectListBuilder.cs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Web.Mvc;
+using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
+
+namespace EdFi.Ods.AdminApp.Web.Infrastructure
+{
+    public class ResourceClaimSelectListBuilder
+    {
+        public static List<SelectListItem> GetSelectListForResourceClaims(List<ResourceClaim> allResourceClaims)
+        {
+            var selectList = new List<SelectListItem>{
+                new SelectListItem{ Text="Please select a value", Value = "0" , Disabled = true, Selected = true},
+            };
+            var parentGroup = new SelectListGroup
+            {
+                Name = "Groups"
+            };
+            var childGroup = new SelectListGroup
+            {
+                Name = "Resources"
+            };
+            var parentGroupList = new List<SelectListItem>();
+            var childGroupList = new List<SelectListItem>();
+            foreach (var resourceClaim in allResourceClaims)
+            {
+                var item = new SelectListItem
+                {
+                    Text = resourceClaim.Name,
+                    Value = resourceClaim.Id.ToString(),
+                    Group = parentGroup
+                };
+                parentGroupList.Add(item);
+                if (resourceClaim.Children.Count > 0)
+                {
+                    childGroupList.AddRange(resourceClaim.Children.Select(x => new SelectListItem
+                    {
+                        Text = x.Name,
+                        Value = x.Id.ToString(),
+                        Group = childGroup
+                    }));
+                }
+            }
+            parentGroupList = parentGroupList.OrderBy(x => x.Text).ToList();
+            parentGroupList.AddRange(childGroupList.OrderBy(x => x.Text));
+            selectList.AddRange(new SelectList(parentGroupList, "Value", "Text", "Group.Name", -1));
+            return selectList;
+        }
+    }
+}


### PR DESCRIPTION
**Description**
- Refactored to use Newtonsoft.Json instead of System.Web.Helpers.Json. Used JsonConvert.DeserializeObject and JsonConvert.SerializeObject instead of Json.Encode and Decode.
- Refactored to use the MicrosoftDateFormat in JsonSerializerSettings's DateFormatHandling setting to maintain compatibility with System.Web.Helpers.Json.
- Removed the now unused System.Web.Helpers using directives.
- Moved GetSelectListForResourceClaims() method from GetResourceClaimsQuery to the Web project within a new class ResourceClaimSelectListBuilder. Refactored the GetSelectListForResourceClaims to expect a list argument for all resource claims. Removed the now unused using directive for System.Web.Mvc from GetResourceClaimsQuery.
- Refactored the EditClaimSet action to use the newly moved GetSelectListForResourceClaims() in the ClaimSetsController.Refactored the GetResourceClaimsQueryTests to use the newly moved GetSelectListForResourceClaims().
- Uninstalled Microsoft.AspNet.Mvc from EdFi.Ods.AdminApp.Management project.