### PR TITLE
[AA-1065] Preserve intended JSON body on failing requests.

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web/ActionFilters/HandleAjaxErrorAttribute.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/ActionFilters/HandleAjaxErrorAttribute.cs
@@ -26,6 +26,7 @@ namespace EdFi.Ods.AdminApp.Web.ActionFilters
                 _logger.Error(filterContext.Exception);
                 filterContext.ExceptionHandled = true;
                 filterContext.HttpContext.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+                filterContext.HttpContext.Response.TrySkipIisCustomErrors = true;
                 if (filterContext.Controller is ReportsController && filterContext.Exception is SqlException)
                     filterContext.HttpContext.Response.Write("An error occurred trying to access the SQL views for reports.");
                 else

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/OdsInstanceSettingsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/OdsInstanceSettingsController.cs
@@ -385,6 +385,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
                 {
                     var errorMessage = string.Join(",", validationResult.Errors.Select(x => x.ErrorMessage));
                     Response.StatusCode = (int) HttpStatusCode.BadRequest;
+                    Response.TrySkipIisCustomErrors = true;
                     return Json(new {Result = new {Errors = new[] {new {ErrorMessage = errorMessage}}}});
                 }
             }


### PR DESCRIPTION
Set TrySkipIisCustomErrors = true for AJAX failues, so that the intended JSON body is not hidden by IIS. Note that we do this already in JsonValidationFilter and SetupController, and the base HandleErrorAttribute also does so.