### PR TITLE
[AA-1103] upgrade platform dependencies

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/App.config
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/App.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/App.config
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/App.config
@@ -118,6 +118,14 @@
         <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.4.0" newVersion="4.0.4.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.3.0" newVersion="3.1.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.3.0" newVersion="3.1.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <startup>

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/App.config
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/App.config
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
-  <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 --></configSections>
+  </configSections>
   <connectionStrings>
     <!--Clear is needed because there is always a SQLExpress default connection.-->
     <clear />
@@ -18,11 +18,11 @@
       <add key="apiStartup:type" value="sandbox" />
   </appSettings>
   <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
     <providers>
       <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
       <provider invariantName="Npgsql" type="Npgsql.NpgsqlServices, EntityFramework6.Npgsql" />
     </providers>
-    <defaultConnectionFactory type="Npgsql.NpgsqlConnectionFactory, EntityFramework6.Npgsql" />
   </entityFramework>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -135,9 +135,4 @@
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
   </startup>
-<system.data>
-    <DbProviderFactories>
-      <remove invariant="Npgsql" />
-      <add name="Npgsql Provider" invariant="Npgsql" description=".NET Framework Data Provider for PostgreSQL" type="Npgsql.NpgsqlFactory, Npgsql, Version=4.1.3.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7" />
-    </DbProviderFactories>
-  </system.data></configuration>
+</configuration>

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/App.config
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/App.config
@@ -126,6 +126,10 @@
         <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.1.3.0" newVersion="3.1.3.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Antlr3.Runtime" publicKeyToken="eb42632606e9261f" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <startup>

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/App.config
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/App.config
@@ -3,7 +3,7 @@
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
-  </configSections>
+  <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 --></configSections>
   <connectionStrings>
     <!--Clear is needed because there is always a SQLExpress default connection.-->
     <clear />
@@ -18,11 +18,11 @@
       <add key="apiStartup:type" value="sandbox" />
   </appSettings>
   <entityFramework>
-    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
     <providers>
       <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
       <provider invariantName="Npgsql" type="Npgsql.NpgsqlServices, EntityFramework6.Npgsql" />
     </providers>
+    <defaultConnectionFactory type="Npgsql.NpgsqlConnectionFactory, EntityFramework6.Npgsql" />
   </entityFramework>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -135,4 +135,9 @@
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
   </startup>
-</configuration>
+<system.data>
+    <DbProviderFactories>
+      <remove invariant="Npgsql" />
+      <add name="Npgsql Provider" invariant="Npgsql" description=".NET Framework Data Provider for PostgreSQL" type="Npgsql.NpgsqlFactory, Npgsql, Version=4.1.3.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7" />
+    </DbProviderFactories>
+  </system.data></configuration>

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
@@ -79,8 +79,8 @@
     <Reference Include="EdFi.Admin.DataAccess, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Suite3.Admin.DataAccess.5.0.0\lib\net48\EdFi.Admin.DataAccess.dll</HintPath>
     </Reference>
-    <Reference Include="EdFi.Common, Version=5.1.0.12, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EdFi.Common.5.1.0-pre0017\lib\net48\EdFi.Common.dll</HintPath>
+    <Reference Include="EdFi.Common, Version=5.1.0.13, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EdFi.Suite3.Common.5.1.0-pre0013\lib\net48\EdFi.Common.dll</HintPath>
     </Reference>
     <Reference Include="EdFi.LoadTools, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Suite3.LoadTools.5.0.0\lib\net48\EdFi.LoadTools.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
@@ -61,6 +61,9 @@
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f, processorArchitecture=MSIL">
+      <HintPath>..\packages\Antlr3.Runtime.3.5.1\lib\net40-client\Antlr3.Runtime.dll</HintPath>
+    </Reference>
     <Reference Include="AutoMapper, Version=10.0.0.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
       <HintPath>..\packages\AutoMapper.10.0.0\lib\net461\AutoMapper.dll</HintPath>
     </Reference>
@@ -82,8 +85,8 @@
     <Reference Include="EdFi.LoadTools, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Suite3.LoadTools.5.0.0\lib\net48\EdFi.LoadTools.dll</HintPath>
     </Reference>
-    <Reference Include="EdFi.Ods.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EdFi.Ods.Common.5.0.0\lib\net48\EdFi.Ods.Common.dll</HintPath>
+    <Reference Include="EdFi.Ods.Common, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EdFi.Ods.Common.5.1.0-pre0007\lib\net48\EdFi.Ods.Common.dll</HintPath>
     </Reference>
     <Reference Include="EdFi.Security.DataAccess, Version=5.0.0.5, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Suite3.Security.DataAccess.5.0.0\lib\net48\EdFi.Security.DataAccess.dll</HintPath>
@@ -103,6 +106,9 @@
     <Reference Include="Hyak.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Hyak.Common.1.0.2\lib\net45\Hyak.Common.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.11.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.11\lib\net45\log4net.dll</HintPath>
@@ -180,6 +186,9 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="NHibernate, Version=5.2.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHibernate.5.2.7\lib\net461\NHibernate.dll</HintPath>
+    </Reference>
     <Reference Include="Npgsql, Version=4.1.5.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
       <HintPath>..\packages\Npgsql.4.1.5\lib\net461\Npgsql.dll</HintPath>
     </Reference>
@@ -197,6 +206,12 @@
     </Reference>
     <Reference Include="QuickGraph.Serialization, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.Serialization.dll</HintPath>
+    </Reference>
+    <Reference Include="Remotion.Linq, Version=2.2.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Remotion.Linq.2.2.0\lib\net45\Remotion.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="Remotion.Linq.EagerFetching, Version=2.2.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Remotion.Linq.EagerFetching.2.2.0\lib\net45\Remotion.Linq.EagerFetching.dll</HintPath>
     </Reference>
     <Reference Include="Respawn, Version=0.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Respawn.0.2.0\lib\net45\Respawn.dll</HintPath>
@@ -332,6 +347,7 @@
     <Reference Include="System.Security.Principal.Windows, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Principal.Windows.4.7.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
+    <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceProcess" />
     <Reference Include="System.Text.Encodings.Web, Version=4.0.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Text.Encodings.Web.4.6.0\lib\netstandard2.0\System.Text.Encodings.Web.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
@@ -88,8 +88,8 @@
     <Reference Include="EdFi.Ods.Common, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Ods.Common.5.1.0-pre0007\lib\net48\EdFi.Ods.Common.dll</HintPath>
     </Reference>
-    <Reference Include="EdFi.Security.DataAccess, Version=5.0.0.5, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EdFi.Suite3.Security.DataAccess.5.0.0\lib\net48\EdFi.Security.DataAccess.dll</HintPath>
+    <Reference Include="EdFi.Security.DataAccess, Version=5.1.0.7, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EdFi.Suite3.Security.DataAccess.5.1.0-pre0007\lib\net48\EdFi.Security.DataAccess.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.4.0\lib\net45\EntityFramework.dll</HintPath>
@@ -231,7 +231,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Annotations, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ComponentModel.Annotations.4.4.1\lib\net461\System.ComponentModel.Annotations.dll</HintPath>
@@ -266,7 +266,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.4.5.3\lib\netstandard2.0\System.Memory.dll</HintPath>
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http, Version=4.1.1.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -363,7 +363,7 @@
       <HintPath>..\packages\Microsoft.Tpl.Dataflow.4.5.24\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.3\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Transactions" />
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
@@ -79,8 +79,8 @@
     <Reference Include="EdFi.Admin.DataAccess, Version=5.1.0.17, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Suite3.Admin.DataAccess.5.1.0-pre0017\lib\net48\EdFi.Admin.DataAccess.dll</HintPath>
     </Reference>
-    <Reference Include="EdFi.Common, Version=5.1.0.13, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EdFi.Suite3.Common.5.1.0-pre0013\lib\net48\EdFi.Common.dll</HintPath>
+    <Reference Include="EdFi.Common, Version=5.1.0.12, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EdFi.Suite3.Common.5.1.0-pre0012\lib\net48\EdFi.Common.dll</HintPath>
     </Reference>
     <Reference Include="EdFi.LoadTools, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Suite3.LoadTools.5.0.0\lib\net48\EdFi.LoadTools.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
@@ -76,8 +76,8 @@
     <Reference Include="EdFi.Admin.DataAccess, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Suite3.Admin.DataAccess.5.0.0\lib\net48\EdFi.Admin.DataAccess.dll</HintPath>
     </Reference>
-    <Reference Include="EdFi.Common, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EdFi.Suite3.Common.5.0.0\lib\net48\EdFi.Common.dll</HintPath>
+    <Reference Include="EdFi.Common, Version=5.1.0.12, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EdFi.Common.5.1.0-pre0017\lib\net48\EdFi.Common.dll</HintPath>
     </Reference>
     <Reference Include="EdFi.LoadTools, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Suite3.LoadTools.5.0.0\lib\net48\EdFi.LoadTools.dll</HintPath>
@@ -131,6 +131,12 @@
     </Reference>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=3.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.3.1.3\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=3.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Primitives.3.1.3\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=3.13.7.964, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.13.7\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
@@ -228,8 +234,8 @@
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Data.OracleClient" />
-    <Reference Include="System.Data.SqlClient, Version=4.6.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Data.SqlClient.4.8.0\lib\net461\System.Data.SqlClient.dll</HintPath>
+    <Reference Include="System.Data.SqlClient, Version=4.6.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.SqlClient.4.8.1\lib\net461\System.Data.SqlClient.dll</HintPath>
     </Reference>
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.6.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
@@ -280,7 +286,7 @@
     </Reference>
     <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.1\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.Extensions.4.1.0\lib\net462\System.Runtime.Extensions.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
@@ -76,8 +76,8 @@
     <Reference Include="Dapper, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Dapper.2.0.30\lib\net461\Dapper.dll</HintPath>
     </Reference>
-    <Reference Include="EdFi.Admin.DataAccess, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EdFi.Suite3.Admin.DataAccess.5.0.0\lib\net48\EdFi.Admin.DataAccess.dll</HintPath>
+    <Reference Include="EdFi.Admin.DataAccess, Version=5.1.0.17, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EdFi.Suite3.Admin.DataAccess.5.1.0-pre0017\lib\net48\EdFi.Admin.DataAccess.dll</HintPath>
     </Reference>
     <Reference Include="EdFi.Common, Version=5.1.0.13, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Suite3.Common.5.1.0-pre0013\lib\net48\EdFi.Common.dll</HintPath>
@@ -97,8 +97,8 @@
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.4.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
-    <Reference Include="EntityFramework6.Npgsql, Version=3.2.1.1, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
-      <HintPath>..\packages\EntityFramework6.Npgsql.3.2.1.1\lib\net45\EntityFramework6.Npgsql.dll</HintPath>
+    <Reference Include="EntityFramework6.Npgsql, Version=6.4.1.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework6.Npgsql.6.4.1\lib\net461\EntityFramework6.Npgsql.dll</HintPath>
     </Reference>
     <Reference Include="FluentValidation, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7de548da2fbae0f0, processorArchitecture=MSIL">
       <HintPath>..\packages\FluentValidation.8.6.3\lib\net45\FluentValidation.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
@@ -10,7 +10,7 @@
   <package id="EdFi.Suite3.Admin.DataAccess" version="5.1.0-pre0017" targetFramework="net48" />
   <package id="EdFi.Suite3.Common" version="5.1.0-pre0013" targetFramework="net48" />
   <package id="EdFi.Suite3.LoadTools" version="5.0.0" targetFramework="net48" />
-  <package id="EdFi.Suite3.Security.DataAccess" version="5.0.0" targetFramework="net48" />
+  <package id="EdFi.Suite3.Security.DataAccess" version="5.1.0-pre0007" targetFramework="net48" />
   <package id="EntityFramework" version="6.4.0" targetFramework="net48" />
   <package id="EntityFramework6.Npgsql" version="6.4.1" targetFramework="net48" />
   <package id="FluentValidation" version="8.6.3" targetFramework="net48" />
@@ -58,7 +58,7 @@
   <package id="Sandwych.QuickGraph.Core" version="1.0.0" targetFramework="net48" />
   <package id="Shouldly" version="3.0.2" targetFramework="net48" />
   <package id="SimpleInjector" version="4.1.0" targetFramework="net48" />
-  <package id="System.Buffers" version="4.5.0" targetFramework="net48" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
   <package id="System.Collections" version="4.0.11" targetFramework="net48" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net48" />
   <package id="System.ComponentModel.Annotations" version="4.4.1" targetFramework="net48" />
@@ -72,7 +72,7 @@
   <package id="System.Globalization" version="4.0.11" targetFramework="net48" />
   <package id="System.IO" version="4.3.0" targetFramework="net48" />
   <package id="System.Linq" version="4.1.0" targetFramework="net48" />
-  <package id="System.Memory" version="4.5.3" targetFramework="net48" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net48" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net48" />
   <package id="System.Net.Primitives" version="4.0.11" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
@@ -98,7 +98,7 @@
   <package id="System.Text.RegularExpressions" version="4.1.0" targetFramework="net48" />
   <package id="System.Threading" version="4.0.11" targetFramework="net48" />
   <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net48" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.3" targetFramework="net48" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
   <package id="System.Xml.ReaderWriter" version="4.0.11" targetFramework="net48" />
   <package id="System.Xml.XDocument" version="4.0.11" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
@@ -4,7 +4,7 @@
   <package id="Castle.Core" version="4.4.0" targetFramework="net48" />
   <package id="Castle.Windsor" version="5.0.1" targetFramework="net48" />
   <package id="Dapper" version="2.0.30" targetFramework="net48" />
-  <package id="EdFi.Common" version="5.0.0" targetFramework="net48" />
+  <package id="EdFi.Common" version="5.1.0-pre0017" targetFramework="net48" />
   <package id="EdFi.Ods.Common" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Suite3.Admin.DataAccess" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Suite3.Common" version="5.0.0" targetFramework="net48" />
@@ -31,6 +31,8 @@
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net48" />
   <package id="Microsoft.CodeCoverage" version="16.4.0" targetFramework="net48" />
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="3.1.3" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Primitives" version="3.1.3" targetFramework="net48" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.13.7" targetFramework="net48" />
   <package id="Microsoft.Net.Compilers" version="2.9.0" targetFramework="net48" developmentDependency="true" />
   <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="net48" />
@@ -58,7 +60,7 @@
   <package id="System.ComponentModel.Primitives" version="4.3.0" targetFramework="net48" />
   <package id="System.Configuration.ConfigurationManager" version="4.7.0" targetFramework="net48" />
   <package id="System.Data.DataSetExtensions" version="4.5.0" targetFramework="net48" />
-  <package id="System.Data.SqlClient" version="4.8.0" targetFramework="net48" />
+  <package id="System.Data.SqlClient" version="4.8.1" targetFramework="net48" />
   <package id="System.Diagnostics.Contracts" version="4.3.0" targetFramework="net48" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net48" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.6.0" targetFramework="net48" />
@@ -72,7 +74,7 @@
   <package id="System.Reflection" version="4.1.0" targetFramework="net48" />
   <package id="System.Reflection.Extensions" version="4.0.1" targetFramework="net48" />
   <package id="System.Runtime" version="4.3.1" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net48" />
   <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net48" />
   <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net48" />
   <package id="System.Runtime.Serialization.Json" version="4.0.2" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
@@ -8,7 +8,7 @@
   <package id="EdFi.Common" version="5.1.0-pre0017" targetFramework="net48" />
   <package id="EdFi.Ods.Common" version="5.1.0-pre0007" targetFramework="net48" />
   <package id="EdFi.Suite3.Admin.DataAccess" version="5.0.0" targetFramework="net48" />
-  <package id="EdFi.Suite3.Common" version="5.0.0" targetFramework="net48" />
+  <package id="EdFi.Suite3.Common" version="5.1.0-pre0013" targetFramework="net48" />
   <package id="EdFi.Suite3.LoadTools" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Suite3.Security.DataAccess" version="5.0.0" targetFramework="net48" />
   <package id="EntityFramework" version="6.4.0" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
@@ -7,12 +7,12 @@
   <package id="Dapper" version="2.0.30" targetFramework="net48" />
   <package id="EdFi.Common" version="5.1.0-pre0017" targetFramework="net48" />
   <package id="EdFi.Ods.Common" version="5.1.0-pre0007" targetFramework="net48" />
-  <package id="EdFi.Suite3.Admin.DataAccess" version="5.0.0" targetFramework="net48" />
+  <package id="EdFi.Suite3.Admin.DataAccess" version="5.1.0-pre0017" targetFramework="net48" />
   <package id="EdFi.Suite3.Common" version="5.1.0-pre0013" targetFramework="net48" />
   <package id="EdFi.Suite3.LoadTools" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Suite3.Security.DataAccess" version="5.0.0" targetFramework="net48" />
   <package id="EntityFramework" version="6.4.0" targetFramework="net48" />
-  <package id="EntityFramework6.Npgsql" version="3.2.1.1" targetFramework="net48" />
+  <package id="EntityFramework6.Npgsql" version="6.4.1" targetFramework="net48" />
   <package id="FluentValidation" version="8.6.3" targetFramework="net48" />
   <package id="Hyak.Common" version="1.0.2" targetFramework="net48" />
   <package id="Iesi.Collections" version="4.0.4" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
@@ -8,7 +8,7 @@
   <package id="EdFi.Common" version="5.1.0-pre0017" targetFramework="net48" />
   <package id="EdFi.Ods.Common" version="5.1.0-pre0007" targetFramework="net48" />
   <package id="EdFi.Suite3.Admin.DataAccess" version="5.1.0-pre0017" targetFramework="net48" />
-  <package id="EdFi.Suite3.Common" version="5.1.0-pre0013" targetFramework="net48" />
+  <package id="EdFi.Suite3.Common" version="5.1.0-pre0012" targetFramework="net48" />
   <package id="EdFi.Suite3.LoadTools" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Suite3.Security.DataAccess" version="5.1.0-pre0007" targetFramework="net48" />
   <package id="EntityFramework" version="6.4.0" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net48" />
   <package id="AutoMapper" version="10.0.0" targetFramework="net48" />
   <package id="Castle.Core" version="4.4.0" targetFramework="net48" />
   <package id="Castle.Windsor" version="5.0.1" targetFramework="net48" />
   <package id="Dapper" version="2.0.30" targetFramework="net48" />
   <package id="EdFi.Common" version="5.1.0-pre0017" targetFramework="net48" />
-  <package id="EdFi.Ods.Common" version="5.0.0" targetFramework="net48" />
+  <package id="EdFi.Ods.Common" version="5.1.0-pre0007" targetFramework="net48" />
   <package id="EdFi.Suite3.Admin.DataAccess" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Suite3.Common" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Suite3.LoadTools" version="5.0.0" targetFramework="net48" />
@@ -14,6 +15,7 @@
   <package id="EntityFramework6.Npgsql" version="3.2.1.1" targetFramework="net48" />
   <package id="FluentValidation" version="8.6.3" targetFramework="net48" />
   <package id="Hyak.Common" version="1.0.2" targetFramework="net48" />
+  <package id="Iesi.Collections" version="4.0.4" targetFramework="net48" />
   <package id="log4net" version="2.0.11" targetFramework="net48" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.2.3" targetFramework="net48" />
   <package id="Microsoft.AspNet.Identity.EntityFramework" version="2.2.3" targetFramework="net48" />
@@ -44,10 +46,13 @@
   <package id="Microsoft.Win32.Primitives" version="4.0.1" targetFramework="net48" />
   <package id="Moq" version="4.14.5" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
+  <package id="NHibernate" version="5.2.7" targetFramework="net48" />
   <package id="Npgsql" version="4.1.5" targetFramework="net48" />
   <package id="NUnit" version="3.12.0" targetFramework="net48" />
   <package id="NUnit3TestAdapter" version="3.17.0" targetFramework="net48" />
   <package id="QuickGraph" version="3.6.61119.7" targetFramework="net48" />
+  <package id="Remotion.Linq" version="2.2.0" targetFramework="net48" />
+  <package id="Remotion.Linq.EagerFetching" version="2.2.0" targetFramework="net48" />
   <package id="Respawn" version="0.2.0" targetFramework="net48" />
   <package id="RestSharp" version="105.2.3" targetFramework="net48" />
   <package id="Sandwych.QuickGraph.Core" version="1.0.0" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="dbup-core" Version="4.2.0" />
     <PackageReference Include="dbup-postgresql" Version="4.2.0" />
     <PackageReference Include="dbup-sqlserver" Version="4.2.0" />
-    <PackageReference Include="EdFi.Common" Version="5.0.0" />
+    <PackageReference Include="EdFi.Common" Version="5.1.0-pre0017" />
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.0.0" />
     <PackageReference Include="EdFi.Suite3.Common" Version="5.0.0" />
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.0.0" />

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="EdFi.Common" Version="5.1.0-pre0017" />
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.1.0-pre0017" />
     <PackageReference Include="EdFi.Suite3.Common" Version="5.1.0-pre0013" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.0.0" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.1.0-pre0007" />
     <PackageReference Include="EntityFramework" Version="6.4.0" />
     <PackageReference Include="Flurl" Version="2.8.2" />
     <PackageReference Include="log4net" Version="2.0.11" />

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="dbup-sqlserver" Version="4.2.0" />
     <PackageReference Include="EdFi.Common" Version="5.1.0-pre0017" />
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.0.0" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.0.0" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.1.0-pre0013" />
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.0.0" />
     <PackageReference Include="EntityFramework" Version="6.4.0" />
     <PackageReference Include="Flurl" Version="2.8.2" />

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="dbup-postgresql" Version="4.2.0" />
     <PackageReference Include="dbup-sqlserver" Version="4.2.0" />
     <PackageReference Include="EdFi.Common" Version="5.1.0-pre0017" />
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.0.0" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.1.0-pre0017" />
     <PackageReference Include="EdFi.Suite3.Common" Version="5.1.0-pre0013" />
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.0.0" />
     <PackageReference Include="EntityFramework" Version="6.4.0" />

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="dbup-sqlserver" Version="4.2.0" />
     <PackageReference Include="EdFi.Common" Version="5.1.0-pre0017" />
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.1.0-pre0017" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.1.0-pre0013" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.1.0-pre0012" />
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.1.0-pre0007" />
     <PackageReference Include="EntityFramework" Version="6.4.0" />
     <PackageReference Include="Flurl" Version="2.8.2" />

--- a/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
@@ -62,6 +62,7 @@
     <PackageReference Include="Castle.Core" Version="4.4.1" />
     <PackageReference Include="Castle.Windsor" Version="5.0.1" />
     <PackageReference Include="EdFi.Admin.LearningStandards.Core" Version="1.1.0" />
+    <PackageReference Include="EdFi.Suite3.LoadTools" Version="5.1.0-pre0014" />
     <PackageReference Include="FluentValidation" Version="9.2.2" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="9.2.0" />
     <PackageReference Include="Hangfire" Version="1.7.14" />

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -75,8 +75,8 @@
     <Reference Include="Dapper, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Dapper.2.0.30\lib\net461\Dapper.dll</HintPath>
     </Reference>
-    <Reference Include="EdFi.Admin.DataAccess, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EdFi.Suite3.Admin.DataAccess.5.0.0\lib\net48\EdFi.Admin.DataAccess.dll</HintPath>
+    <Reference Include="EdFi.Admin.DataAccess, Version=5.1.0.17, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EdFi.Suite3.Admin.DataAccess.5.1.0-pre0017\lib\net48\EdFi.Admin.DataAccess.dll</HintPath>
     </Reference>
     <Reference Include="EdFi.Admin.LearningStandards.Core, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Admin.LearningStandards.Core.1.1.0\lib\netstandard2.0\EdFi.Admin.LearningStandards.Core.dll</HintPath>
@@ -99,8 +99,8 @@
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.4.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
-    <Reference Include="EntityFramework6.Npgsql, Version=3.2.1.1, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
-      <HintPath>..\packages\EntityFramework6.Npgsql.3.2.1.1\lib\net45\EntityFramework6.Npgsql.dll</HintPath>
+    <Reference Include="EntityFramework6.Npgsql, Version=6.4.1.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework6.Npgsql.6.4.1\lib\net461\EntityFramework6.Npgsql.dll</HintPath>
     </Reference>
     <Reference Include="FluentValidation, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7de548da2fbae0f0, processorArchitecture=MSIL">
       <HintPath>..\packages\FluentValidation.8.6.3\lib\net45\FluentValidation.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -81,8 +81,8 @@
     <Reference Include="EdFi.Admin.LearningStandards.Core, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Admin.LearningStandards.Core.1.1.0\lib\netstandard2.0\EdFi.Admin.LearningStandards.Core.dll</HintPath>
     </Reference>
-    <Reference Include="EdFi.Common, Version=5.1.0.13, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EdFi.Suite3.Common.5.1.0-pre0013\lib\net48\EdFi.Common.dll</HintPath>
+    <Reference Include="EdFi.Common, Version=5.1.0.12, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EdFi.Suite3.Common.5.1.0-pre0012\lib\net48\EdFi.Common.dll</HintPath>
     </Reference>
     <Reference Include="EdFi.LoadTools, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Suite3.LoadTools.5.0.0\lib\net48\EdFi.LoadTools.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -90,8 +90,8 @@
     <Reference Include="EdFi.Ods.Common, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Ods.Common.5.1.0-pre0007\lib\net48\EdFi.Ods.Common.dll</HintPath>
     </Reference>
-    <Reference Include="EdFi.Security.DataAccess, Version=5.0.0.5, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EdFi.Suite3.Security.DataAccess.5.0.0\lib\net48\EdFi.Security.DataAccess.dll</HintPath>
+    <Reference Include="EdFi.Security.DataAccess, Version=5.1.0.7, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EdFi.Suite3.Security.DataAccess.5.1.0-pre0007\lib\net48\EdFi.Security.DataAccess.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.4.0\lib\net45\EntityFramework.dll</HintPath>
@@ -324,7 +324,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Annotations, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ComponentModel.Annotations.4.5.0\lib\net461\System.ComponentModel.Annotations.dll</HintPath>
@@ -364,7 +364,7 @@
     </Reference>
     <Reference Include="System.Management" />
     <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.4.5.3\lib\netstandard2.0\System.Memory.dll</HintPath>
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http, Version=4.1.1.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -466,7 +466,7 @@
       <HintPath>..\packages\Microsoft.Tpl.Dataflow.4.5.24\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.3\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Transactions" />
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -81,8 +81,8 @@
     <Reference Include="EdFi.Admin.LearningStandards.Core, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Admin.LearningStandards.Core.1.1.0\lib\netstandard2.0\EdFi.Admin.LearningStandards.Core.dll</HintPath>
     </Reference>
-    <Reference Include="EdFi.Common, Version=5.1.0.12, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EdFi.Common.5.1.0-pre0017\lib\net48\EdFi.Common.dll</HintPath>
+    <Reference Include="EdFi.Common, Version=5.1.0.13, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EdFi.Suite3.Common.5.1.0-pre0013\lib\net48\EdFi.Common.dll</HintPath>
     </Reference>
     <Reference Include="EdFi.LoadTools, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Suite3.LoadTools.5.0.0\lib\net48\EdFi.LoadTools.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -81,8 +81,8 @@
     <Reference Include="EdFi.Admin.LearningStandards.Core, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Admin.LearningStandards.Core.1.1.0\lib\netstandard2.0\EdFi.Admin.LearningStandards.Core.dll</HintPath>
     </Reference>
-    <Reference Include="EdFi.Common, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EdFi.Suite3.Common.5.0.0\lib\net48\EdFi.Common.dll</HintPath>
+    <Reference Include="EdFi.Common, Version=5.1.0.12, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EdFi.Common.5.1.0-pre0017\lib\net48\EdFi.Common.dll</HintPath>
     </Reference>
     <Reference Include="EdFi.LoadTools, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Suite3.LoadTools.5.0.0\lib\net48\EdFi.LoadTools.dll</HintPath>
@@ -199,8 +199,8 @@
     <Reference Include="Microsoft.Extensions.Configuration, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.Configuration.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=3.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.3.1.3\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
@@ -226,8 +226,8 @@
     <Reference Include="Microsoft.Extensions.Options, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.Options.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Options.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Primitives, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Primitives.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=3.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Primitives.3.1.3\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=3.13.7.964, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.13.7\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
@@ -329,8 +329,8 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data.OracleClient" />
-    <Reference Include="System.Data.SqlClient, Version=4.6.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Data.SqlClient.4.8.0\lib\net461\System.Data.SqlClient.dll</HintPath>
+    <Reference Include="System.Data.SqlClient, Version=4.6.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.SqlClient.4.8.1\lib\net461\System.Data.SqlClient.dll</HintPath>
     </Reference>
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.6.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
@@ -385,7 +385,7 @@
     </Reference>
     <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.1\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.Extensions.4.1.0\lib\net462\System.Runtime.Extensions.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -51,8 +51,8 @@
     <DesktopBuildPackageLocation Condition=" '$(BuildPackages)'!='' ">$(DeployPackageLocation)\$(AssemblyName).zip</DesktopBuildPackageLocation>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Antlr3.Runtime, Version=3.4.1.9004, Culture=neutral, PublicKeyToken=eb42632606e9261f, processorArchitecture=MSIL">
-      <HintPath>..\packages\Antlr.3.4.1.9004\lib\Antlr3.Runtime.dll</HintPath>
+    <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f, processorArchitecture=MSIL">
+      <HintPath>..\packages\Antlr3.Runtime.3.5.1\lib\net40-client\Antlr3.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="AsyncEnumerable, Version=2.2.1.0, Culture=neutral, PublicKeyToken=0426b068161bd1d1, processorArchitecture=MSIL">
       <HintPath>..\packages\AsyncEnumerator.2.2.1\lib\net45\AsyncEnumerable.dll</HintPath>
@@ -87,8 +87,8 @@
     <Reference Include="EdFi.LoadTools, Version=5.0.0.9, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Suite3.LoadTools.5.0.0\lib\net48\EdFi.LoadTools.dll</HintPath>
     </Reference>
-    <Reference Include="EdFi.Ods.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EdFi.Ods.Common.5.0.0\lib\net48\EdFi.Ods.Common.dll</HintPath>
+    <Reference Include="EdFi.Ods.Common, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EdFi.Ods.Common.5.1.0-pre0007\lib\net48\EdFi.Ods.Common.dll</HintPath>
     </Reference>
     <Reference Include="EdFi.Security.DataAccess, Version=5.0.0.5, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EdFi.Suite3.Security.DataAccess.5.0.0\lib\net48\EdFi.Security.DataAccess.dll</HintPath>
@@ -125,6 +125,9 @@
     </Reference>
     <Reference Include="HtmlTags, Version=7.0.4.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\HtmlTags.7.0.4\lib\net45\HtmlTags.dll</HintPath>
+    </Reference>
+    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
     </Reference>
     <Reference Include="JsonSubTypes, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\JsonSubTypes.1.2.0\lib\net47\JsonSubTypes.dll</HintPath>
@@ -277,6 +280,9 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="NHibernate, Version=5.2.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHibernate.5.2.7\lib\net461\NHibernate.dll</HintPath>
+    </Reference>
     <Reference Include="Npgsql, Version=4.1.5.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
       <HintPath>..\packages\Npgsql.4.1.5\lib\net461\Npgsql.dll</HintPath>
     </Reference>
@@ -300,6 +306,12 @@
     </Reference>
     <Reference Include="QuickGraph.Serialization, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.Serialization.dll</HintPath>
+    </Reference>
+    <Reference Include="Remotion.Linq, Version=2.2.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Remotion.Linq.2.2.0\lib\net45\Remotion.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="Remotion.Linq.EagerFetching, Version=2.2.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Remotion.Linq.EagerFetching.2.2.0\lib\net45\Remotion.Linq.EagerFetching.dll</HintPath>
     </Reference>
     <Reference Include="RestSharp, Version=106.11.4.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.106.11.4\lib\net452\RestSharp.dll</HintPath>
@@ -434,6 +446,7 @@
     <Reference Include="System.Security.Principal.Windows, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Principal.Windows.4.7.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
+    <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceProcess" />
     <Reference Include="System.Spatial, Version=5.8.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Spatial.5.8.4\lib\net40\System.Spatial.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Web/Web.base.config
+++ b/Application/EdFi.Ods.AdminApp.Web/Web.base.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=301880
@@ -139,6 +139,18 @@
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.3.0" newVersion="3.1.3.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.3.0" newVersion="3.1.3.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Antlr3.Runtime" publicKeyToken="EB42632606E9261F" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2"/>
+      </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-5.8.4.0" newVersion="5.8.4.0"/>

--- a/Application/EdFi.Ods.AdminApp.Web/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Web/packages.config
@@ -14,7 +14,7 @@
   <package id="EdFi.Common" version="5.1.0-pre0017" targetFramework="net48" />
   <package id="EdFi.Ods.Common" version="5.1.0-pre0007" targetFramework="net48" />
   <package id="EdFi.Suite3.Admin.DataAccess" version="5.1.0-pre0017" targetFramework="net48" />
-  <package id="EdFi.Suite3.Common" version="5.1.0-pre0013" targetFramework="net48" />
+  <package id="EdFi.Suite3.Common" version="5.1.0-pre0012" targetFramework="net48" />
   <package id="EdFi.Suite3.LoadTools" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Suite3.Security.DataAccess" version="5.1.0-pre0007" targetFramework="net48" />
   <package id="EntityFramework" version="6.4.0" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Web/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Web/packages.config
@@ -14,7 +14,7 @@
   <package id="EdFi.Common" version="5.1.0-pre0017" targetFramework="net48" />
   <package id="EdFi.Ods.Common" version="5.1.0-pre0007" targetFramework="net48" />
   <package id="EdFi.Suite3.Admin.DataAccess" version="5.0.0" targetFramework="net48" />
-  <package id="EdFi.Suite3.Common" version="5.0.0" targetFramework="net48" />
+  <package id="EdFi.Suite3.Common" version="5.1.0-pre0013" targetFramework="net48" />
   <package id="EdFi.Suite3.LoadTools" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Suite3.Security.DataAccess" version="5.0.0" targetFramework="net48" />
   <package id="EntityFramework" version="6.4.0" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Web/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Web/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.4.1.9004" targetFramework="net48" />
+  <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net48" />
   <package id="AsyncEnumerator" version="2.2.1" targetFramework="net48" />
   <package id="AutoMapper" version="10.0.0" targetFramework="net48" />
   <package id="bootstrap" version="3.3.6" targetFramework="net48" />
@@ -11,7 +12,7 @@
   <package id="Dapper" version="2.0.30" targetFramework="net48" />
   <package id="EdFi.Admin.LearningStandards.Core" version="1.1.0" targetFramework="net48" />
   <package id="EdFi.Common" version="5.1.0-pre0017" targetFramework="net48" />
-  <package id="EdFi.Ods.Common" version="5.0.0" targetFramework="net48" />
+  <package id="EdFi.Ods.Common" version="5.1.0-pre0007" targetFramework="net48" />
   <package id="EdFi.Suite3.Admin.DataAccess" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Suite3.Common" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Suite3.LoadTools" version="5.0.0" targetFramework="net48" />
@@ -27,6 +28,7 @@
   <package id="Hangfire.SqlServer" version="1.7.14" targetFramework="net48" />
   <package id="Hangfire.Windsor" version="2.0.1" targetFramework="net48" />
   <package id="HtmlTags" version="7.0.4" targetFramework="net48" />
+  <package id="Iesi.Collections" version="4.0.4" targetFramework="net48" />
   <package id="jQuery" version="2.2.3" targetFramework="net48" />
   <package id="jQuery.Validation" version="1.15.0" targetFramework="net48" />
   <package id="JsonSubTypes" version="1.2.0" targetFramework="net48" />
@@ -91,11 +93,14 @@
   <package id="Microsoft.Win32.Primitives" version="4.0.1" targetFramework="net48" />
   <package id="Modernizr" version="2.8.3" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
+  <package id="NHibernate" version="5.2.7" targetFramework="net48" />
   <package id="Npgsql" version="4.1.5" targetFramework="net48" />
   <package id="Owin" version="1.0" targetFramework="net48" />
   <package id="Polly" version="6.1.0" targetFramework="net48" />
   <package id="Polly.Extensions.Http" version="2.0.1" targetFramework="net48" />
   <package id="QuickGraph" version="3.6.61119.7" targetFramework="net48" />
+  <package id="Remotion.Linq" version="2.2.0" targetFramework="net48" />
+  <package id="Remotion.Linq.EagerFetching" version="2.2.0" targetFramework="net48" />
   <package id="Respond" version="1.2.0" targetFramework="net48" />
   <package id="RestSharp" version="106.11.4" targetFramework="net48" />
   <package id="Sandwych.QuickGraph.Core" version="1.0.0" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Web/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Web/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.4.1.9004" targetFramework="net48" />
   <package id="AsyncEnumerator" version="2.2.1" targetFramework="net48" />
@@ -10,7 +10,7 @@
   <package id="CsvHelper" version="15.0.5" targetFramework="net48" />
   <package id="Dapper" version="2.0.30" targetFramework="net48" />
   <package id="EdFi.Admin.LearningStandards.Core" version="1.1.0" targetFramework="net48" />
-  <package id="EdFi.Common" version="5.0.0" targetFramework="net48" />
+  <package id="EdFi.Common" version="5.1.0-pre0017" targetFramework="net48" />
   <package id="EdFi.Ods.Common" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Suite3.Admin.DataAccess" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Suite3.Common" version="5.0.0" targetFramework="net48" />
@@ -65,7 +65,7 @@
   <package id="Microsoft.Data.OData" version="5.8.4" targetFramework="net48" />
   <package id="Microsoft.Data.Services.Client" version="5.8.4" targetFramework="net48" />
   <package id="Microsoft.Extensions.Configuration" version="2.1.1" targetFramework="net48" />
-  <package id="Microsoft.Extensions.Configuration.Abstractions" version="2.1.1" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="3.1.3" targetFramework="net48" />
   <package id="Microsoft.Extensions.Configuration.Binder" version="2.1.1" targetFramework="net48" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net48" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net48" />
@@ -74,7 +74,7 @@
   <package id="Microsoft.Extensions.Logging" version="2.1.1" targetFramework="net48" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="2.1.1" targetFramework="net48" />
   <package id="Microsoft.Extensions.Options" version="2.1.1" targetFramework="net48" />
-  <package id="Microsoft.Extensions.Primitives" version="2.1.1" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Primitives" version="3.1.3" targetFramework="net48" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.13.7" targetFramework="net48" />
   <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.0" targetFramework="net48" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.3" targetFramework="net48" />
@@ -107,7 +107,7 @@
   <package id="System.ComponentModel.Primitives" version="4.3.0" targetFramework="net48" />
   <package id="System.Configuration.ConfigurationManager" version="4.7.0" targetFramework="net48" />
   <package id="System.Data.DataSetExtensions" version="4.5.0" targetFramework="net48" />
-  <package id="System.Data.SqlClient" version="4.8.0" targetFramework="net48" />
+  <package id="System.Data.SqlClient" version="4.8.1" targetFramework="net48" />
   <package id="System.Diagnostics.Contracts" version="4.3.0" targetFramework="net48" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net48" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.6.0" targetFramework="net48" />
@@ -122,7 +122,7 @@
   <package id="System.Reflection" version="4.1.0" targetFramework="net48" />
   <package id="System.Reflection.Extensions" version="4.0.1" targetFramework="net48" />
   <package id="System.Runtime" version="4.3.1" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net48" />
   <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net48" />
   <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net48" />
   <package id="System.Runtime.Serialization.Json" version="4.0.2" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Web/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Web/packages.config
@@ -13,12 +13,12 @@
   <package id="EdFi.Admin.LearningStandards.Core" version="1.1.0" targetFramework="net48" />
   <package id="EdFi.Common" version="5.1.0-pre0017" targetFramework="net48" />
   <package id="EdFi.Ods.Common" version="5.1.0-pre0007" targetFramework="net48" />
-  <package id="EdFi.Suite3.Admin.DataAccess" version="5.0.0" targetFramework="net48" />
+  <package id="EdFi.Suite3.Admin.DataAccess" version="5.1.0-pre0017" targetFramework="net48" />
   <package id="EdFi.Suite3.Common" version="5.1.0-pre0013" targetFramework="net48" />
   <package id="EdFi.Suite3.LoadTools" version="5.0.0" targetFramework="net48" />
   <package id="EdFi.Suite3.Security.DataAccess" version="5.0.0" targetFramework="net48" />
   <package id="EntityFramework" version="6.4.0" targetFramework="net48" />
-  <package id="EntityFramework6.Npgsql" version="3.2.1.1" targetFramework="net48" />
+  <package id="EntityFramework6.Npgsql" version="6.4.1" targetFramework="net48" />
   <package id="FluentValidation" version="8.6.3" targetFramework="net48" />
   <package id="FluentValidation.Mvc5" version="8.6.1" targetFramework="net48" />
   <package id="FluentValidation.ValidatorAttribute" version="8.6.1" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Web/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Web/packages.config
@@ -16,7 +16,7 @@
   <package id="EdFi.Suite3.Admin.DataAccess" version="5.1.0-pre0017" targetFramework="net48" />
   <package id="EdFi.Suite3.Common" version="5.1.0-pre0013" targetFramework="net48" />
   <package id="EdFi.Suite3.LoadTools" version="5.0.0" targetFramework="net48" />
-  <package id="EdFi.Suite3.Security.DataAccess" version="5.0.0" targetFramework="net48" />
+  <package id="EdFi.Suite3.Security.DataAccess" version="5.1.0-pre0007" targetFramework="net48" />
   <package id="EntityFramework" version="6.4.0" targetFramework="net48" />
   <package id="EntityFramework6.Npgsql" version="6.4.1" targetFramework="net48" />
   <package id="FluentValidation" version="8.6.3" targetFramework="net48" />
@@ -105,7 +105,7 @@
   <package id="RestSharp" version="106.11.4" targetFramework="net48" />
   <package id="Sandwych.QuickGraph.Core" version="1.0.0" targetFramework="net48" />
   <package id="SimpleInjector" version="4.1.0" targetFramework="net48" />
-  <package id="System.Buffers" version="4.5.0" targetFramework="net48" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
   <package id="System.Collections" version="4.0.11" targetFramework="net48" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net48" />
   <package id="System.ComponentModel.Annotations" version="4.5.0" targetFramework="net48" />
@@ -120,7 +120,7 @@
   <package id="System.IdentityModel.Tokens.Jwt" version="4.0.0" targetFramework="net48" />
   <package id="System.IO" version="4.3.0" targetFramework="net48" />
   <package id="System.Linq" version="4.1.0" targetFramework="net48" />
-  <package id="System.Memory" version="4.5.3" targetFramework="net48" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net48" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net48" />
   <package id="System.Net.Primitives" version="4.0.11" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
@@ -147,7 +147,7 @@
   <package id="System.Text.RegularExpressions" version="4.1.0" targetFramework="net48" />
   <package id="System.Threading" version="4.0.11" targetFramework="net48" />
   <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net48" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.3" targetFramework="net48" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
   <package id="System.Xml.ReaderWriter" version="4.0.11" targetFramework="net48" />
   <package id="System.Xml.XDocument" version="4.0.11" targetFramework="net48" />


### PR DESCRIPTION
Here we upgrade platform dependencies to prerelease packages capable of working for both net48 and netcoreapp3.1. A separate ticket will cover upgrading to the final 5.1.0 packages which will only work for .NET Core. This lets us progressively make each project in Admin App work for .NET Core one at a time in upcoming tickets.

Each commit message indicates which package was explicitly upgraded solution-wide. All changes in those commits were caused by the NuGet UI for transitive dependencies.

Developer testing included running the tests locally, interacting with instance setup, Applications, Descriptors, Education Organizations, Users, Claim Sets.