### PR TITLE
[AA-1090] Enable the Management project to cross-compile ASP.NET Identity usages

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.OnPrem.Tests/EdFi.Ods.AdminApp.Management.OnPrem.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.OnPrem.Tests/EdFi.Ods.AdminApp.Management.OnPrem.Tests.csproj
@@ -7,9 +7,18 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
+  </ItemGroup>
+
+  <!-- As long as the solution uses ConfigurationManager.*, enable Test Explorer runs to successfully witness config settings. -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <None Update="App.config">
+        <Link>testhost.dll.config</Link>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.OnPrem.Tests/EdFi.Ods.AdminApp.Management.OnPrem.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.OnPrem.Tests/EdFi.Ods.AdminApp.Management.OnPrem.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
     <Configurations>Debug;Release;OnPremNpgsql</Configurations>
     <Copyright>Copyright © 2018 Ed-Fi Alliance</Copyright>
   </PropertyGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.OnPrem.Tests/OnPremOdsDatabaseNameProviderTests/WhenGettingDatabaseName.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.OnPrem.Tests/OnPremOdsDatabaseNameProviderTests/WhenGettingDatabaseName.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.

--- a/Application/EdFi.Ods.AdminApp.Management.OnPrem/EdFi.Ods.AdminApp.Management.OnPrem.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.OnPrem/EdFi.Ods.AdminApp.Management.OnPrem.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
     <Configurations>Debug;Release;OnPremNpgsql;OnPremises</Configurations>
     <Copyright>Copyright © 2018 Ed-Fi Alliance</Copyright>
   </PropertyGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
@@ -217,8 +217,8 @@
       <HintPath>..\packages\Respawn.0.2.0\lib\net45\Respawn.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.105.2.3\lib\net46\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=106.8.10.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.11.5\lib\net452\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="Sandwych.QuickGraph.Core, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Sandwych.QuickGraph.Core.1.0.0\lib\net45\Sandwych.QuickGraph.Core.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
@@ -54,7 +54,7 @@
   <package id="Remotion.Linq" version="2.2.0" targetFramework="net48" />
   <package id="Remotion.Linq.EagerFetching" version="2.2.0" targetFramework="net48" />
   <package id="Respawn" version="0.2.0" targetFramework="net48" />
-  <package id="RestSharp" version="105.2.3" targetFramework="net48" />
+  <package id="RestSharp" version="106.11.5" targetFramework="net48" />
   <package id="Sandwych.QuickGraph.Core" version="1.0.0" targetFramework="net48" />
   <package id="Shouldly" version="3.0.2" targetFramework="net48" />
   <package id="SimpleInjector" version="4.1.0" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Management.UnitTests/EdFi.Ods.AdminApp.Management.UnitTests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.UnitTests/EdFi.Ods.AdminApp.Management.UnitTests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
     <Configurations>Debug;Release;OnPremNpgsql</Configurations>
     <Copyright>Copyright © 2019 Ed-Fi Alliance</Copyright>
   </PropertyGroup>

--- a/Application/EdFi.Ods.AdminApp.Management/Database/AdminAppIdentityDbContext.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/AdminAppIdentityDbContext.cs
@@ -40,7 +40,7 @@ namespace EdFi.Ods.AdminApp.Management.Database
             modelBuilder.Entity<IdentityUserClaim>().ToTable("UserClaims");
             modelBuilder.Entity<IdentityUserLogin>().ToTable("UserLogins");
             modelBuilder.Entity<IdentityUserRole>().ToTable("UserRoles");
-            modelBuilder.Entity<UserOdsInstanceRegistration>().HasKey(k => new { k.UserId, k.OdsInstanceRegistrationId }).ToTable("UserOdsInstanceRegistrations");
+            modelBuilder.Entity<UserOdsInstanceRegistration>().ToTable("UserOdsInstanceRegistrations").HasKey(k => new { k.UserId, k.OdsInstanceRegistrationId });
 
             modelBuilder.ApplyDatabaseServerSpecificConventions();
         }

--- a/Application/EdFi.Ods.AdminApp.Management/Database/AdminAppIdentityDbContext.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/AdminAppIdentityDbContext.cs
@@ -1,11 +1,16 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Data.Entity;
 using EdFi.Ods.AdminApp.Management.Database.Models;
+#if NET48
 using Microsoft.AspNet.Identity.EntityFramework;
+#else
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+#endif
 
 namespace EdFi.Ods.AdminApp.Management.Database
 {

--- a/Application/EdFi.Ods.AdminApp.Management/Database/AdminAppIdentityDbContext.net48.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/AdminAppIdentityDbContext.net48.cs
@@ -5,12 +5,7 @@
 
 using System.Data.Entity;
 using EdFi.Ods.AdminApp.Management.Database.Models;
-#if NET48
 using Microsoft.AspNet.Identity.EntityFramework;
-#else
-using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
-#endif
 
 namespace EdFi.Ods.AdminApp.Management.Database
 {

--- a/Application/EdFi.Ods.AdminApp.Management/Database/AdminAppIdentityDbContext.net48.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/AdminAppIdentityDbContext.net48.cs
@@ -2,7 +2,7 @@
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
-
+#if NET48
 using System.Data.Entity;
 using EdFi.Ods.AdminApp.Management.Database.Models;
 using Microsoft.AspNet.Identity.EntityFramework;
@@ -48,3 +48,4 @@ namespace EdFi.Ods.AdminApp.Management.Database
         }
     }
 }
+#endif

--- a/Application/EdFi.Ods.AdminApp.Management/Database/EntityFramework6DatabaseModelBuilderExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/EntityFramework6DatabaseModelBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -12,7 +12,7 @@ using EdFi.Ods.Common.Utils.Extensions;
 
 namespace EdFi.Ods.AdminApp.Management.Database
 {
-    public static class DatabaseModelBuilderExtensions
+    public static class EntityFramework6DatabaseModelBuilderExtensions
     {
         public static DbModelBuilder ApplyDatabaseServerSpecificConventions(this DbModelBuilder modelBuilder)
         {

--- a/Application/EdFi.Ods.AdminApp.Management/Database/EntityFrameworkCoreDatabaseModelBuilderExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/EntityFrameworkCoreDatabaseModelBuilderExtensions.cs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+#if !NET48
+using Microsoft.EntityFrameworkCore;
+
+namespace EdFi.Ods.AdminApp.Management.Database
+{
+    public static class EntityFrameworkCoreDatabaseModelBuilderExtensions
+    {
+        public static void ApplyDatabaseServerSpecificConventions(this ModelBuilder modelBuilder)
+        {
+            if (DatabaseProviderHelper.PgSqlProvider)
+            {
+                foreach (var entity in modelBuilder.Model.GetEntityTypes())
+                {
+                    entity.SetTableName(entity.GetTableName().ToLowerInvariant());
+
+                    foreach (var property in entity.GetProperties())
+                        property.SetColumnName(property.GetColumnName().ToLowerInvariant());
+
+                    foreach (var key in entity.GetKeys())
+                        key.SetName(key.GetName().ToLowerInvariant());
+
+                    foreach (var key in entity.GetForeignKeys())
+                        key.SetConstraintName(key.GetConstraintName().ToLowerInvariant());
+
+                    foreach (var index in entity.GetIndexes())
+                        index.SetName(index.GetName().ToLowerInvariant());
+                }
+            }
+        }
+    }
+}
+#endif

--- a/Application/EdFi.Ods.AdminApp.Management/Database/Models/AdminAppUser.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/Models/AdminAppUser.cs
@@ -1,9 +1,13 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+#if NET48
 using Microsoft.AspNet.Identity.EntityFramework;
+#else
+using Microsoft.AspNetCore.Identity;
+#endif
 
 namespace EdFi.Ods.AdminApp.Management.Database.Models
 {

--- a/Application/EdFi.Ods.AdminApp.Management/Database/Models/AspNetIdentityShimTypes.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/Models/AspNetIdentityShimTypes.cs
@@ -1,0 +1,18 @@
+#if !NET48
+using Microsoft.AspNetCore.Identity;
+
+namespace EdFi.Ods.AdminApp.Management.Database.Models
+{
+    public class IdentityUserClaim : IdentityUserClaim<string>
+    {
+    }
+
+    public class IdentityUserLogin : IdentityUserLogin<string>
+    {
+    }
+
+    public class IdentityUserRole : IdentityUserRole<string>
+    {
+    }
+}
+#endif

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="log4net" Version="2.0.11" />
     <PackageReference Include="Microsoft.AspNet.Identity.Core" Version="2.2.3" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="Microsoft.AspNet.Identity.EntityFramework" Version="2.2.3" Condition="'$(TargetFramework)' == 'net48'" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.8" Condition="'$(TargetFramework)' != 'net48'" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Npgsql" Version="4.1.5" />
     <PackageReference Include="RestSharp" Version="106.11.4" />

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -27,6 +27,8 @@
     <PackageReference Include="Microsoft.AspNet.Identity.Core" Version="2.2.3" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="Microsoft.AspNet.Identity.EntityFramework" Version="2.2.3" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.8" Condition="'$(TargetFramework)' != 'net48'" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.8" Condition="'$(TargetFramework)' != 'net48'" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.4" Condition="'$(TargetFramework)' != 'net48'" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Npgsql" Version="4.1.5" />
     <PackageReference Include="RestSharp" Version="106.11.4" />

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
     <Configurations>Debug;Release;OnPremises;OnPremNpgsql</Configurations>
     <Copyright>Copyright © 2016 Ed-Fi Alliance</Copyright>
   </PropertyGroup>

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -24,8 +24,8 @@
     <PackageReference Include="EntityFramework" Version="6.4.0" />
     <PackageReference Include="Flurl" Version="2.8.2" />
     <PackageReference Include="log4net" Version="2.0.11" />
-    <PackageReference Include="Microsoft.AspNet.Identity.Core" Version="2.2.3" />
-    <PackageReference Include="Microsoft.AspNet.Identity.EntityFramework" Version="2.2.3" />
+    <PackageReference Include="Microsoft.AspNet.Identity.Core" Version="2.2.3" Condition="'$(TargetFramework)' == 'net48'" />
+    <PackageReference Include="Microsoft.AspNet.Identity.EntityFramework" Version="2.2.3" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Npgsql" Version="4.1.5" />
     <PackageReference Include="RestSharp" Version="106.11.4" />

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.4" Condition="'$(TargetFramework)' != 'net48'" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Npgsql" Version="4.1.5" />
-    <PackageReference Include="RestSharp" Version="106.11.4" />
+    <PackageReference Include="RestSharp" Version="106.11.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management/Identity/RegisterCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Identity/RegisterCommand.cs
@@ -1,11 +1,15 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Threading.Tasks;
 using EdFi.Ods.AdminApp.Management.Database.Models;
+#if NET48
 using Microsoft.AspNet.Identity;
+#else
+using Microsoft.AspNetCore.Identity;
+#endif
 
 namespace EdFi.Ods.AdminApp.Management.Identity
 {

--- a/Application/EdFi.Ods.AdminApp.Management/User/AddUserCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/User/AddUserCommand.cs
@@ -1,11 +1,15 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Threading.Tasks;
 using EdFi.Ods.AdminApp.Management.Database.Models;
+#if NET48
 using Microsoft.AspNet.Identity;
+#else
+using Microsoft.AspNetCore.Identity;
+#endif
 
 namespace EdFi.Ods.AdminApp.Management.User
 {

--- a/Application/EdFi.Ods.AdminApp.Management/User/DeleteUserCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/User/DeleteUserCommand.cs
@@ -1,11 +1,15 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Linq;
 using EdFi.Ods.AdminApp.Management.Database;
+#if NET48
 using Microsoft.AspNet.Identity.EntityFramework;
+#else
+using EdFi.Ods.AdminApp.Management.Database.Models;
+#endif
 
 namespace EdFi.Ods.AdminApp.Management.User
 {

--- a/Application/EdFi.Ods.AdminApp.Management/User/EditUserCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/User/EditUserCommand.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -6,7 +6,11 @@
 using System.Linq;
 using System.Threading.Tasks;
 using EdFi.Ods.AdminApp.Management.Database.Models;
+#if NET48
 using Microsoft.AspNet.Identity;
+#else
+using Microsoft.AspNetCore.Identity;
+#endif
 
 namespace EdFi.Ods.AdminApp.Management.User
 {

--- a/Application/EdFi.Ods.AdminApp.Management/User/EditUserRoleCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/User/EditUserRoleCommand.cs
@@ -1,11 +1,15 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Linq;
 using EdFi.Ods.AdminApp.Management.Database;
+#if NET48
 using Microsoft.AspNet.Identity.EntityFramework;
+#else
+using EdFi.Ods.AdminApp.Management.Database.Models;
+#endif
 
 namespace EdFi.Ods.AdminApp.Management.User
 {

--- a/Application/EdFi.Ods.AdminApp.Management/User/GetRoleForUserQuery.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/User/GetRoleForUserQuery.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -6,7 +6,9 @@
 using System.Linq;
 using EdFi.Ods.AdminApp.Management.Database;
 using EdFi.Ods.AdminApp.Management.Database.Models;
+#if NET48
 using Microsoft.AspNet.Identity.EntityFramework;
+#endif
 
 namespace EdFi.Ods.AdminApp.Management.User
 {

--- a/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
@@ -45,17 +45,17 @@
 
   </ItemGroup>
 
-  <!-- <ItemGroup> -->
-    <!-- These project references can be uncommented once each one is upgrade to support .NET Core.
-         These can be temporarily uncommented even before then, though doing so introduces compatibility
-         warnings about referncing .NET Framework projects and would not be trusted in production.
-    -->
+  <ItemGroup>
+      <!-- These project references can be uncommented once each one is upgrade to support .NET Core.
+           These can be temporarily uncommented even before then, though doing so introduces compatibility
+           warnings about referncing .NET Framework projects and would not be trusted in production.
+      -->
 
     <!-- <ProjectReference Include="..\EdFi.Ods.AdminApp.Management.Aws\EdFi.Ods.AdminApp.Management.Aws.csproj" /> -->
     <!-- <ProjectReference Include="..\EdFi.Ods.AdminApp.Management.Azure\EdFi.Ods.AdminApp.Management.Azure.csproj" /> -->
-    <!-- <ProjectReference Include="..\EdFi.Ods.AdminApp.Management.OnPrem\EdFi.Ods.AdminApp.Management.OnPrem.csproj" /> -->
-    <!-- <ProjectReference Include="..\EdFi.Ods.AdminApp.Management\EdFi.Ods.AdminApp.Management.csproj" /> -->
-  <!-- </ItemGroup> -->
+    <ProjectReference Include="..\EdFi.Ods.AdminApp.Management.OnPrem\EdFi.Ods.AdminApp.Management.OnPrem.csproj" />
+    <ProjectReference Include="..\EdFi.Ods.AdminApp.Management\EdFi.Ods.AdminApp.Management.csproj" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.0.0" />

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -313,8 +313,8 @@
     <Reference Include="Remotion.Linq.EagerFetching, Version=2.2.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
       <HintPath>..\packages\Remotion.Linq.EagerFetching.2.2.0\lib\net45\Remotion.Linq.EagerFetching.dll</HintPath>
     </Reference>
-    <Reference Include="RestSharp, Version=106.11.4.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.106.11.4\lib\net452\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=106.8.10.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.11.5\lib\net452\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="Sandwych.QuickGraph.Core, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Sandwych.QuickGraph.Core.1.0.0\lib\net45\Sandwych.QuickGraph.Core.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Web/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Web/packages.config
@@ -102,7 +102,7 @@
   <package id="Remotion.Linq" version="2.2.0" targetFramework="net48" />
   <package id="Remotion.Linq.EagerFetching" version="2.2.0" targetFramework="net48" />
   <package id="Respond" version="1.2.0" targetFramework="net48" />
-  <package id="RestSharp" version="106.11.4" targetFramework="net48" />
+  <package id="RestSharp" version="106.11.5" targetFramework="net48" />
   <package id="Sandwych.QuickGraph.Core" version="1.0.0" targetFramework="net48" />
   <package id="SimpleInjector" version="4.1.0" targetFramework="net48" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />

--- a/build.ps1
+++ b/build.ps1
@@ -227,11 +227,12 @@ function RunTests {
     }
 
     $testAssemblies | ForEach-Object {
-        Write-Host "Executing: $($script:nunitExe) $($_.name)"
-
         if ($_.FullName.Contains("netcoreapp")) {
-            Invoke-Execute { dotnet test $_.FullName }
+            Write-Host "Executing: dotnet test $($_)"
+            Invoke-Execute { dotnet test $_ }
         } else {
+            Write-Host "Executing: $($script:nunitExe) $($_)"
+
             $outFile = "$($_.name).xml"
             if ($OdsVersion) {
                 $outFile = "$($_.name)_ODS_$OdsVersion.xml"

--- a/build.ps1
+++ b/build.ps1
@@ -229,12 +229,16 @@ function RunTests {
     $testAssemblies | ForEach-Object {
         Write-Host "Executing: $($script:nunitExe) $($_.name)"
 
-        $outFile = "$($_.name).xml"
-        if ($OdsVersion) {
-            $outFile = "$($_.name)_ODS_$OdsVersion.xml"
-        }
+        if ($_.FullName.Contains("netcoreapp")) {
+            Invoke-Execute { dotnet test $_.FullName }
+        } else {
+            $outFile = "$($_.name).xml"
+            if ($OdsVersion) {
+                $outFile = "$($_.name)_ODS_$OdsVersion.xml"
+            }
 
-        Invoke-Execute { &$script:nunitExe $_ --result $outFile}
+            Invoke-Execute { &$script:nunitExe $_ --result $outFile}
+        }
     }
 }
 


### PR DESCRIPTION
This may be easiest to review commit-by-commit. Note that this resolves AA-1090 as well as AA-803 and AA-1094 since the primary task here immediately allowed for multiple projects to cross-target netcoreapp3.1.

End to end setup of Identity in the ASPNET Core application is a separate ticket. This merely sets us up for that and unblocks other work by making the Management project's usages of Identity cross-target with a successful build.