### PR TITLE
[AA-809] - Move log4net config out of Web.config and add logging to .Net Core project

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management/Helpers/ConfigurationHelper.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Helpers/ConfigurationHelper.cs
@@ -41,6 +41,7 @@ namespace EdFi.Ods.AdminApp.Management.Helpers
             _appSettings.IdaSubscriptionId = ConfigurationManager.AppSettings["ida:SubscriptionId"];
             _appSettings.AwsCurrentVersion = ConfigurationManager.AppSettings["AwsCurrentVersion"];
             _appSettings.OptionalEntropy = ConfigurationManager.AppSettings["OptionalEntropy"];
+            _appSettings.Log4NetConfigPath = ConfigurationManager.AppSettings["log4net.Config"];
 
             _connectionStrings.Admin = ConfigurationManager.ConnectionStrings[CloudOdsDatabaseNames.Admin] != null ? ConfigurationManager.ConnectionStrings[CloudOdsDatabaseNames.Admin].ConnectionString : "";
             _connectionStrings.Security = ConfigurationManager.ConnectionStrings[CloudOdsDatabaseNames.Security] != null ? ConfigurationManager.ConnectionStrings[CloudOdsDatabaseNames.Security].ConnectionString : "";
@@ -99,6 +100,7 @@ namespace EdFi.Ods.AdminApp.Management.Helpers
         public string IdaSubscriptionId { get; set; }
         public string AwsCurrentVersion { get; set; }
         public string OptionalEntropy { get; set; }
+        public string Log4NetConfigPath { get; set; }
     }
 
     public class ConnectionStrings

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Controllers/HomeController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Controllers/HomeController.cs
@@ -6,21 +6,13 @@
 using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using EdFi.Ods.AdminApp.Web.Models;
-using log4net;
 
 namespace EdFi.Ods.AdminApp.Web.Controllers
 {
     public class HomeController : Controller
     {
-        private readonly ILog _logger = LogManager.GetLogger(typeof(HomeController));
-
         public IActionResult Index()
         {
-            _logger.Info("TEST INFO LOGGING");
-            _logger.Error("TEST ERROR LOGGING");
-            _logger.Debug("TEST DEBUG LOGGING");
-            _logger.Warn("TEST WARN LOGGING");
-
             return View();
         }
 

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Controllers/HomeController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Controllers/HomeController.cs
@@ -6,13 +6,21 @@
 using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using EdFi.Ods.AdminApp.Web.Models;
+using log4net;
 
 namespace EdFi.Ods.AdminApp.Web.Controllers
 {
     public class HomeController : Controller
     {
+        private readonly ILog _logger = LogManager.GetLogger(typeof(HomeController));
+
         public IActionResult Index()
         {
+            _logger.Info("TEST INFO LOGGING");
+            _logger.Error("TEST ERROR LOGGING");
+            _logger.Debug("TEST DEBUG LOGGING");
+            _logger.Warn("TEST WARN LOGGING");
+
             return View();
         }
 

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Properties/launchSettings.json
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Properties/launchSettings.json
@@ -12,7 +12,7 @@
       "commandName": "IISExpress",
       "launchBrowser": true,
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "OnPremises"
       }
     },
     "EdFi.Ods.AdminApp.Web": {
@@ -20,7 +20,7 @@
       "launchBrowser": true,
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "OnPremises"
       }
     }
   }

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Startup.cs
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Startup.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.IO;
 using System.Reflection;
 using AutoMapper;
 using EdFi.Ods.AdminApp.Management.Api.Automapper;
@@ -14,6 +15,8 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using FluentValidation.AspNetCore;
+using log4net;
+using log4net.Config;
 
 namespace EdFi.Ods.AdminApp.Web
 {
@@ -53,6 +56,8 @@ namespace EdFi.Ods.AdminApp.Web
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
+            ConfigureLogging();
+
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
@@ -76,6 +81,15 @@ namespace EdFi.Ods.AdminApp.Web
                     name: "default",
                     pattern: "{controller=Home}/{action=Index}/{id?}");
             });
+        }
+
+        private void ConfigureLogging()
+        {
+            var assembly = typeof(Program).GetTypeInfo().Assembly;
+
+            var configPath = Path.Combine(Path.GetDirectoryName(assembly.Location) ?? string.Empty, Configuration["AppSettings:Log4NetConfigPath"]);
+
+            XmlConfigurator.Configure(LogManager.GetRepository(assembly), new FileInfo(configPath));
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web.Core/appsettings.OnPremisesRelease.json
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/appsettings.OnPremisesRelease.json
@@ -1,7 +1,8 @@
 {
     "AppSettings": {
         "AppStartup": "OnPrem",
-        "DbSetupEnabled": "false"
+        "DbSetupEnabled": "false",
+        "Log4NetConfigPath": "log4net\\log4net.OnPremisesRelease.config"
     },
     "ConnectionStrings": {
         "ProductionOds": "Data Source=.\\;Initial Catalog=EdFi_Ods_Populated_Template;Integrated Security=True"

--- a/Application/EdFi.Ods.AdminApp.Web.Core/appsettings.OnPremisesYearSpecificRelease.json
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/appsettings.OnPremisesYearSpecificRelease.json
@@ -1,0 +1,6 @@
+{
+    "AppSettings": {
+        "AppStartup": "OnPremisesYearSpecificRelease",
+        "Log4NetConfigPath": "log4net\\log4net.OnPremisesYearSpecificRelease.config"
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Web.Core/appsettings.OnPremisesYearSpecificRelease.json
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/appsettings.OnPremisesYearSpecificRelease.json
@@ -1,6 +1,11 @@
 {
     "AppSettings": {
-        "AppStartup": "OnPremisesYearSpecificRelease",
+        "AppStartup": "OnPrem",
+        "DbSetupEnabled": "false",
+        "ApiStartupType": "yearspecific",
         "Log4NetConfigPath": "log4net\\log4net.OnPremisesYearSpecificRelease.config"
+    },
+    "ConnectionStrings": {
+        "ProductionOds": "Data Source=.\\;Initial Catalog=EdFi_Ods_2019;Integrated Security=True"
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web.Core/appsettings.Release.json
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/appsettings.Release.json
@@ -1,0 +1,6 @@
+{
+    "AppSettings": {
+        "AppStartup": "Release",
+        "Log4NetConfigPath": "log4net\\log4net.Release.config"
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Web.Core/appsettings.Release.json
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/appsettings.Release.json
@@ -1,6 +1,5 @@
 {
     "AppSettings": {
-        "AppStartup": "Release",
         "Log4NetConfigPath": "log4net\\log4net.Release.config"
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web.Core/appsettings.json
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/appsettings.json
@@ -19,7 +19,8 @@
         "IdaTenantId": "",
         "IdaSubscriptionId": "",
         "AwsCurrentVersion": "1.0",
-        "OptionalEntropy": "OptionalEntropy"
+        "OptionalEntropy": "OptionalEntropy",
+        "Log4NetConfigPath": "log4net\\log4net.config"
     },
     "ConnectionStrings": {
         "Admin": "Data Source=.\\;Initial Catalog=EdFi_Admin;Integrated Security=True",

--- a/Application/EdFi.Ods.AdminApp.Web.Core/log4net/log4net.OnPremisesRelease.config
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/log4net/log4net.OnPremisesRelease.config
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<log4net>
+    <appender name="TraceAppender" type="log4net.Appender.TraceAppender">
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <appender name="FileAppender" type="log4net.Appender.RollingFileAppender">
+        <file value="${ProgramData}\Ed-Fi-ODS-AdminApp\Log.txt" />
+        <appendToFile value="true" />
+        <rollingStyle value="Size" />
+        <maxSizeRollBackups value="10" />
+        <maximumFileSize value="15MB" />
+        <staticLogFileName value="true" />
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <appender name="BulkRegisterOdsInstancesLog" type="log4net.Appender.RollingFileAppender">
+        <file value="${ProgramData}\Ed-Fi-ODS-AdminApp\BulkRegisterOdsInstancesLog\Log.txt" />
+        <appendToFile value="true" />
+        <rollingStyle value="Size" />
+        <maxSizeRollBackups value="10" />
+        <maximumFileSize value="15MB" />
+        <staticLogFileName value="true" />
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <appender name="LearningStandardLog" type="log4net.Appender.RollingFileAppender">
+        <file value="${ProgramData}\Ed-Fi-ODS-AdminApp\LearningStandardLog\Log.txt" />
+        <appendToFile value="true" />
+        <rollingStyle value="Size" />
+        <maxSizeRollBackups value="10" />
+        <maximumFileSize value="20MB" />
+        <staticLogFileName value="true" />
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <root>
+        <level value="WARN" />
+        <appender-ref ref="TraceAppender" />
+        <appender-ref ref="FileAppender" />
+    </root>
+    <logger additivity="false" name="LearningStandardLog">
+        <level value="INFO"/>
+        <appender-ref ref="LearningStandardLog" />
+    </logger>
+    <logger additivity="false" name="BulkRegisterOdsInstancesLog">
+        <level value="INFO"/>
+        <appender-ref ref="BulkRegisterOdsInstancesLog" />
+    </logger>
+</log4net>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/log4net/log4net.OnPremisesYearSpecificRelease.config
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/log4net/log4net.OnPremisesYearSpecificRelease.config
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<log4net>
+    <appender name="TraceAppender" type="log4net.Appender.TraceAppender">
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <appender name="FileAppender" type="log4net.Appender.RollingFileAppender">
+        <file value="${ProgramData}\Ed-Fi-ODS-AdminApp\Log.txt" />
+        <appendToFile value="true" />
+        <rollingStyle value="Size" />
+        <maxSizeRollBackups value="10" />
+        <maximumFileSize value="15MB" />
+        <staticLogFileName value="true" />
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <appender name="BulkRegisterOdsInstancesLog" type="log4net.Appender.RollingFileAppender">
+        <file value="${ProgramData}\Ed-Fi-ODS-AdminApp\BulkRegisterOdsInstancesLog\Log.txt" />
+        <appendToFile value="true" />
+        <rollingStyle value="Size" />
+        <maxSizeRollBackups value="10" />
+        <maximumFileSize value="15MB" />
+        <staticLogFileName value="true" />
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <appender name="LearningStandardLog" type="log4net.Appender.RollingFileAppender">
+        <file value="${ProgramData}\Ed-Fi-ODS-AdminApp\LearningStandardLog\Log.txt" />
+        <appendToFile value="true" />
+        <rollingStyle value="Size" />
+        <maxSizeRollBackups value="10" />
+        <maximumFileSize value="20MB" />
+        <staticLogFileName value="true" />
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <root>
+        <level value="WARN" />
+        <appender-ref ref="TraceAppender" />
+        <appender-ref ref="FileAppender" />
+    </root>
+    <logger additivity="false" name="LearningStandardLog">
+        <level value="INFO"/>
+        <appender-ref ref="LearningStandardLog" />
+    </logger>
+    <logger additivity="false" name="BulkRegisterOdsInstancesLog">
+        <level value="INFO"/>
+        <appender-ref ref="BulkRegisterOdsInstancesLog" />
+    </logger>
+</log4net>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/log4net/log4net.Release.config
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/log4net/log4net.Release.config
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<log4net>
+    <appender name="TraceAppender" type="log4net.Appender.TraceAppender">
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <appender name="FileAppender" type="log4net.Appender.RollingFileAppender">
+        <file value="D:\Home\LogFiles\Log.txt" />
+        <appendToFile value="true" />
+        <rollingStyle value="Size" />
+        <maxSizeRollBackups value="10" />
+        <maximumFileSize value="15MB" />
+        <staticLogFileName value="true" />
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <appender name="LearningStandardLog" type="log4net.Appender.RollingFileAppender">
+        <file value="D:\Home\LogFiles\LearningStandardLog\Log.txt" />
+        <appendToFile value="true" />
+        <rollingStyle value="Size" />
+        <maxSizeRollBackups value="10" />
+        <maximumFileSize value="20MB" />
+        <staticLogFileName value="true" />
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <appender name="aiAppender" type="Microsoft.ApplicationInsights.Log4NetAppender.ApplicationInsightsAppender, Microsoft.ApplicationInsights.Log4NetAppender">
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%message%newline"/>
+        </layout>
+    </appender>
+    <root>
+        <level value="INFO"/>
+        <appender-ref ref="aiAppender"/>
+    </root>
+    <root>
+        <level value="INFO" />
+        <appender-ref ref="TraceAppender" />
+        <appender-ref ref="FileAppender" />
+    </root>
+    <logger additivity="false" name="LearningStandardLog">
+        <level value="INFO"/>
+        <appender-ref ref="LearningStandardLog" />
+    </logger>
+</log4net>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/log4net/log4net.Release.config
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/log4net/log4net.Release.config
@@ -16,6 +16,17 @@
             <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
         </layout>
     </appender>
+    <appender name="BulkRegisterOdsInstancesLog" type="log4net.Appender.RollingFileAppender">
+        <file value="D:\Home\LogFiles\BulkRegisterOdsInstancesLog\Log.txt" />
+        <appendToFile value="true" />
+        <rollingStyle value="Size" />
+        <maxSizeRollBackups value="10" />
+        <maximumFileSize value="15MB" />
+        <staticLogFileName value="true" />
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
     <appender name="LearningStandardLog" type="log4net.Appender.RollingFileAppender">
         <file value="D:\Home\LogFiles\LearningStandardLog\Log.txt" />
         <appendToFile value="true" />
@@ -33,16 +44,17 @@
         </layout>
     </appender>
     <root>
-        <level value="INFO"/>
-        <appender-ref ref="aiAppender"/>
-    </root>
-    <root>
         <level value="INFO" />
+        <appender-ref ref="aiAppender"/>
         <appender-ref ref="TraceAppender" />
         <appender-ref ref="FileAppender" />
     </root>
     <logger additivity="false" name="LearningStandardLog">
         <level value="INFO"/>
         <appender-ref ref="LearningStandardLog" />
+    </logger>
+    <logger additivity="false" name="BulkRegisterOdsInstancesLog">
+        <level value="INFO"/>
+        <appender-ref ref="BulkRegisterOdsInstancesLog" />
     </logger>
 </log4net>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/log4net/log4net.config
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/log4net/log4net.config
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<log4net>
+    <appender name="TraceAppender" type="log4net.Appender.TraceAppender">
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <appender name="FileAppender" type="log4net.Appender.RollingFileAppender">
+        <file value="${ProgramData}\Ed-Fi-ODS-AdminApp\Log.txt" />
+        <appendToFile value="true" />
+        <rollingStyle value="Size" />
+        <maxSizeRollBackups value="10" />
+        <maximumFileSize value="15MB" />
+        <staticLogFileName value="true" />
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <appender name="BulkRegisterOdsInstancesLog" type="log4net.Appender.RollingFileAppender">
+        <file value="${ProgramData}\Ed-Fi-ODS-AdminApp\BulkRegisterOdsInstancesLog\Log.txt" />
+        <appendToFile value="true" />
+        <rollingStyle value="Size" />
+        <maxSizeRollBackups value="10" />
+        <maximumFileSize value="15MB" />
+        <staticLogFileName value="true" />
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <appender name="LearningStandardLog" type="log4net.Appender.RollingFileAppender">
+        <file value="${ProgramData}\Ed-Fi-ODS-AdminApp\LearningStandardLog\Log.txt" />
+        <appendToFile value="true" />
+        <rollingStyle value="Size" />
+        <maxSizeRollBackups value="10" />
+        <maximumFileSize value="20MB" />
+        <staticLogFileName value="true" />
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <root>
+        <level value="DEBUG" />
+        <appender-ref ref="TraceAppender" />
+        <appender-ref ref="FileAppender" />
+    </root>
+    <logger additivity="false" name="LearningStandardLog">
+        <level value="INFO"/>
+        <appender-ref ref="LearningStandardLog" />
+    </logger>
+    <logger additivity="false" name="BulkRegisterOdsInstancesLog">
+        <level value="INFO"/>
+        <appender-ref ref="BulkRegisterOdsInstancesLog" />
+    </logger>
+</log4net>

--- a/Application/EdFi.Ods.AdminApp.Web/App_Start/StartupBase.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/App_Start/StartupBase.cs
@@ -9,6 +9,7 @@ using System.IdentityModel.Claims;
 using System.IO;
 using System.Net;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Web.Helpers;
@@ -134,7 +135,12 @@ namespace EdFi.Ods.AdminApp.Web
 
         protected void ConfigureLogging()
         {
-            XmlConfigurator.Configure();
+            var assembly = Assembly.GetExecutingAssembly();
+
+            var configPath = Path.Combine(Path.GetDirectoryName(AppDomain.CurrentDomain.SetupInformation.ConfigurationFile), ConfigurationHelper.GetAppSettings().Log4NetConfigPath);
+
+            XmlConfigurator.Configure(LogManager.GetRepository(assembly), new FileInfo(configPath));
+
             Logger = LogManager.GetLogger(typeof(StartupBase));
 
             if (AppSettings.AppStartup == "Azure")

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -878,6 +878,10 @@
     <Content Include="Schema\3.2.0-c\SchemaAnnotation.xsd">
       <SubType>Designer</SubType>
     </Content>
+    <Content Include="log4net\log4net.config" />
+    <Content Include="log4net\log4net.OnPremisesRelease.config" />
+    <Content Include="log4net\log4net.OnPremisesYearSpecificRelease.config" />
+    <Content Include="log4net\log4net.Release.config" />
     <None Include="Scripts\jquery-2.2.3.intellisense.js" />
     <Content Include="Scripts\jquery-2.2.3.js" />
     <Content Include="Scripts\jquery-2.2.3.min.js" />

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.nuspec
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.nuspec
@@ -15,6 +15,7 @@
     <file src="bin\*.compiled" target="bin" />
     <file src="bin\roslyn\*" target="bin\roslyn" />
     <file src="Content\**" target="Content" />
+    <file src="log4net\**" target="log4net" />
     <file src="fonts\**" target="fonts" />
     <file src="Schema\**" target="Schema" />
     <file src="Scripts\**" target="Scripts" />

--- a/Application/EdFi.Ods.AdminApp.Web/Web.OnPremYearSpecificRelease.config
+++ b/Application/EdFi.Ods.AdminApp.Web/Web.OnPremYearSpecificRelease.config
@@ -10,6 +10,7 @@
     <add key="autoFormsAuthentication" value="false" xdt:Transform="Insert" />
     <add key="enableSimpleMembership" value="false" xdt:Transform="Insert" />
     <add key="DbSetupEnabled" value="false" xdt:Transform="Replace" xdt:Locator="Match(key)"/>
+    <add key="log4net.Config" value="log4net\log4net.OnPremisesYearSpecificRelease.config" xdt:Transform="Replace" xdt:Locator="Match(key)"/>
   </appSettings>
   <system.web>
     <compilation xdt:Transform="RemoveAttributes(debug)" />

--- a/Application/EdFi.Ods.AdminApp.Web/Web.OnPremYearSpecificRelease.config
+++ b/Application/EdFi.Ods.AdminApp.Web/Web.OnPremYearSpecificRelease.config
@@ -11,11 +11,6 @@
     <add key="enableSimpleMembership" value="false" xdt:Transform="Insert" />
     <add key="DbSetupEnabled" value="false" xdt:Transform="Replace" xdt:Locator="Match(key)"/>
   </appSettings>
-  <log4net>
-    <root>
-      <level value="WARN" xdt:Transform="Replace" />
-    </root>
-  </log4net>
   <system.web>
     <compilation xdt:Transform="RemoveAttributes(debug)" />
     <httpCookies httpOnlyCookies="true" requireSSL="true" lockItem="true" xdt:Transform="Replace" />

--- a/Application/EdFi.Ods.AdminApp.Web/Web.OnPremisesRelease.config
+++ b/Application/EdFi.Ods.AdminApp.Web/Web.OnPremisesRelease.config
@@ -9,6 +9,7 @@
     <add key="autoFormsAuthentication" value="false" xdt:Transform="Insert" />
     <add key="enableSimpleMembership" value="false" xdt:Transform="Insert" />
     <add key="DbSetupEnabled" value="false" xdt:Transform="Replace" xdt:Locator="Match(key)"/>
+    <add key="log4net.Config" value="log4net\log4net.OnPremisesRelease.config" xdt:Transform="Replace" xdt:Locator="Match(key)"/>
   </appSettings>
   <system.web>
     <compilation xdt:Transform="RemoveAttributes(debug)" />

--- a/Application/EdFi.Ods.AdminApp.Web/Web.OnPremisesRelease.config
+++ b/Application/EdFi.Ods.AdminApp.Web/Web.OnPremisesRelease.config
@@ -10,11 +10,6 @@
     <add key="enableSimpleMembership" value="false" xdt:Transform="Insert" />
     <add key="DbSetupEnabled" value="false" xdt:Transform="Replace" xdt:Locator="Match(key)"/>
   </appSettings>
-  <log4net>
-    <root>
-      <level value="WARN" xdt:Transform="Replace" />
-    </root>
-  </log4net>
   <system.web>
     <compilation xdt:Transform="RemoveAttributes(debug)" />
     <httpCookies httpOnlyCookies="true" requireSSL="true" lockItem="true" xdt:Transform="Replace" />

--- a/Application/EdFi.Ods.AdminApp.Web/Web.Release.config
+++ b/Application/EdFi.Ods.AdminApp.Web/Web.Release.config
@@ -16,53 +16,6 @@
   -->
   <appSettings xdt:Transform="RemoveAttributes(file)">
   </appSettings>
-  <log4net xdt:Transform="Replace">
-    <appender name="TraceAppender" type="log4net.Appender.TraceAppender">
-      <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
-      </layout>
-    </appender>
-    <appender name="FileAppender" type="log4net.Appender.RollingFileAppender">
-      <file value="D:\Home\LogFiles\Log.txt" />
-      <appendToFile value="true" />
-      <rollingStyle value="Size" />
-      <maxSizeRollBackups value="10" />
-      <maximumFileSize value="15MB" />
-      <staticLogFileName value="true" />
-      <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
-      </layout>
-    </appender>
-    <appender name="LearningStandardLog" type="log4net.Appender.RollingFileAppender">
-      <file value="D:\Home\LogFiles\LearningStandardLog\Log.txt" />
-      <appendToFile value="true" />
-      <rollingStyle value="Size" />
-      <maxSizeRollBackups value="10" />
-      <maximumFileSize value="20MB" />
-      <staticLogFileName value="true" />
-      <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
-      </layout>
-    </appender>
-    <appender name="aiAppender" type="Microsoft.ApplicationInsights.Log4NetAppender.ApplicationInsightsAppender, Microsoft.ApplicationInsights.Log4NetAppender">
-      <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%message%newline"/>
-      </layout>
-    </appender>
-    <root>
-      <level value="INFO"/>
-      <appender-ref ref="aiAppender"/>
-    </root>
-    <root>
-      <level value="INFO" />
-      <appender-ref ref="TraceAppender" />
-      <appender-ref ref="FileAppender" />
-    </root>
-    <logger additivity="false" name="LearningStandardLog">
-      <level value="INFO"/>
-      <appender-ref ref="LearningStandardLog" />
-    </logger>
-  </log4net>
   <system.web>
     <compilation xdt:Transform="RemoveAttributes(debug)" />
     <httpCookies httpOnlyCookies="true" requireSSL="true" lockItem="true" xdt:Transform="Replace" />

--- a/Application/EdFi.Ods.AdminApp.Web/Web.Release.config
+++ b/Application/EdFi.Ods.AdminApp.Web/Web.Release.config
@@ -15,6 +15,7 @@
     </connectionStrings>
   -->
   <appSettings xdt:Transform="RemoveAttributes(file)">
+      <add key="log4net.Config" value="log4net\log4net.Release.config" xdt:Transform="Replace" xdt:Locator="Match(key)"/>
   </appSettings>
   <system.web>
     <compilation xdt:Transform="RemoveAttributes(debug)" />

--- a/Application/EdFi.Ods.AdminApp.Web/Web.base.config
+++ b/Application/EdFi.Ods.AdminApp.Web/Web.base.config
@@ -34,6 +34,7 @@
     <add key="XsdFolder" value="~\Schema"/>
     <add key="DbSetupEnabled" value="true"/>
     <add key="SecurityMetadataCacheTimeoutMinutes" value="0"/>
+    <add key="log4net.Config" value="log4net\log4net.config" />
   </appSettings>
     <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.

--- a/Application/EdFi.Ods.AdminApp.Web/Web.base.config
+++ b/Application/EdFi.Ods.AdminApp.Web/Web.base.config
@@ -35,60 +35,7 @@
     <add key="DbSetupEnabled" value="true"/>
     <add key="SecurityMetadataCacheTimeoutMinutes" value="0"/>
   </appSettings>
-  <log4net>
-    <appender name="TraceAppender" type="log4net.Appender.TraceAppender">
-      <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
-      </layout>
-    </appender>
-    <appender name="FileAppender" type="log4net.Appender.RollingFileAppender">
-      <file value="${ProgramData}\Ed-Fi-ODS-AdminApp\Log.txt" />
-      <appendToFile value="true" />
-      <rollingStyle value="Size" />
-      <maxSizeRollBackups value="10" />
-      <maximumFileSize value="15MB" />
-      <staticLogFileName value="true" />
-      <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
-      </layout>
-    </appender>
-    <appender name="BulkRegisterOdsInstancesLog" type="log4net.Appender.RollingFileAppender">
-      <file value="${ProgramData}\Ed-Fi-ODS-AdminApp\BulkRegisterOdsInstancesLog\Log.txt" />
-      <appendToFile value="true" />
-      <rollingStyle value="Size" />
-      <maxSizeRollBackups value="10" />
-      <maximumFileSize value="15MB" />
-      <staticLogFileName value="true" />
-      <layout type="log4net.Layout.PatternLayout">
-          <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
-      </layout>
-    </appender>
-    <appender name="LearningStandardLog" type="log4net.Appender.RollingFileAppender">
-      <file value="${ProgramData}\Ed-Fi-ODS-AdminApp\LearningStandardLog\Log.txt" />
-      <appendToFile value="true" />
-      <rollingStyle value="Size" />
-      <maxSizeRollBackups value="10" />
-      <maximumFileSize value="20MB" />
-      <staticLogFileName value="true" />
-      <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
-      </layout>
-    </appender>
-    <root>
-      <level value="DEBUG" />
-      <appender-ref ref="TraceAppender" />
-      <appender-ref ref="FileAppender" />
-    </root>
-    <logger additivity="false" name="LearningStandardLog">
-      <level value="INFO"/>
-      <appender-ref ref="LearningStandardLog" />
-    </logger>
-     <logger additivity="false" name="BulkRegisterOdsInstancesLog">
-      <level value="INFO"/>
-      <appender-ref ref="BulkRegisterOdsInstancesLog" />
-     </logger>
-  </log4net>
-  <!--
+    <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
 
     The following attributes can be set on the <httpRuntime> tag.

--- a/Application/EdFi.Ods.AdminApp.Web/Web.base.config
+++ b/Application/EdFi.Ods.AdminApp.Web/Web.base.config
@@ -7,7 +7,6 @@
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
-    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
   </configSections>
   <connectionStrings>
     <!--Clear is needed because there is always a SQLExpress default connection.-->

--- a/Application/EdFi.Ods.AdminApp.Web/log4net/log4net.OnPremisesRelease.config
+++ b/Application/EdFi.Ods.AdminApp.Web/log4net/log4net.OnPremisesRelease.config
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<log4net>
+    <appender name="TraceAppender" type="log4net.Appender.TraceAppender">
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <appender name="FileAppender" type="log4net.Appender.RollingFileAppender">
+        <file value="${ProgramData}\Ed-Fi-ODS-AdminApp\Log.txt" />
+        <appendToFile value="true" />
+        <rollingStyle value="Size" />
+        <maxSizeRollBackups value="10" />
+        <maximumFileSize value="15MB" />
+        <staticLogFileName value="true" />
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <appender name="BulkRegisterOdsInstancesLog" type="log4net.Appender.RollingFileAppender">
+        <file value="${ProgramData}\Ed-Fi-ODS-AdminApp\BulkRegisterOdsInstancesLog\Log.txt" />
+        <appendToFile value="true" />
+        <rollingStyle value="Size" />
+        <maxSizeRollBackups value="10" />
+        <maximumFileSize value="15MB" />
+        <staticLogFileName value="true" />
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <appender name="LearningStandardLog" type="log4net.Appender.RollingFileAppender">
+        <file value="${ProgramData}\Ed-Fi-ODS-AdminApp\LearningStandardLog\Log.txt" />
+        <appendToFile value="true" />
+        <rollingStyle value="Size" />
+        <maxSizeRollBackups value="10" />
+        <maximumFileSize value="20MB" />
+        <staticLogFileName value="true" />
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <root>
+        <level value="WARN" />
+        <appender-ref ref="TraceAppender" />
+        <appender-ref ref="FileAppender" />
+    </root>
+    <logger additivity="false" name="LearningStandardLog">
+        <level value="INFO"/>
+        <appender-ref ref="LearningStandardLog" />
+    </logger>
+    <logger additivity="false" name="BulkRegisterOdsInstancesLog">
+        <level value="INFO"/>
+        <appender-ref ref="BulkRegisterOdsInstancesLog" />
+    </logger>
+</log4net>

--- a/Application/EdFi.Ods.AdminApp.Web/log4net/log4net.OnPremisesYearSpecificRelease.config
+++ b/Application/EdFi.Ods.AdminApp.Web/log4net/log4net.OnPremisesYearSpecificRelease.config
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<log4net>
+    <appender name="TraceAppender" type="log4net.Appender.TraceAppender">
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <appender name="FileAppender" type="log4net.Appender.RollingFileAppender">
+        <file value="${ProgramData}\Ed-Fi-ODS-AdminApp\Log.txt" />
+        <appendToFile value="true" />
+        <rollingStyle value="Size" />
+        <maxSizeRollBackups value="10" />
+        <maximumFileSize value="15MB" />
+        <staticLogFileName value="true" />
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <appender name="BulkRegisterOdsInstancesLog" type="log4net.Appender.RollingFileAppender">
+        <file value="${ProgramData}\Ed-Fi-ODS-AdminApp\BulkRegisterOdsInstancesLog\Log.txt" />
+        <appendToFile value="true" />
+        <rollingStyle value="Size" />
+        <maxSizeRollBackups value="10" />
+        <maximumFileSize value="15MB" />
+        <staticLogFileName value="true" />
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <appender name="LearningStandardLog" type="log4net.Appender.RollingFileAppender">
+        <file value="${ProgramData}\Ed-Fi-ODS-AdminApp\LearningStandardLog\Log.txt" />
+        <appendToFile value="true" />
+        <rollingStyle value="Size" />
+        <maxSizeRollBackups value="10" />
+        <maximumFileSize value="20MB" />
+        <staticLogFileName value="true" />
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <root>
+        <level value="WARN" />
+        <appender-ref ref="TraceAppender" />
+        <appender-ref ref="FileAppender" />
+    </root>
+    <logger additivity="false" name="LearningStandardLog">
+        <level value="INFO"/>
+        <appender-ref ref="LearningStandardLog" />
+    </logger>
+    <logger additivity="false" name="BulkRegisterOdsInstancesLog">
+        <level value="INFO"/>
+        <appender-ref ref="BulkRegisterOdsInstancesLog" />
+    </logger>
+</log4net>

--- a/Application/EdFi.Ods.AdminApp.Web/log4net/log4net.Release.config
+++ b/Application/EdFi.Ods.AdminApp.Web/log4net/log4net.Release.config
@@ -16,6 +16,17 @@
             <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
         </layout>
     </appender>
+    <appender name="BulkRegisterOdsInstancesLog" type="log4net.Appender.RollingFileAppender">
+        <file value="D:\Home\LogFiles\BulkRegisterOdsInstancesLog\Log.txt" />
+        <appendToFile value="true" />
+        <rollingStyle value="Size" />
+        <maxSizeRollBackups value="10" />
+        <maximumFileSize value="15MB" />
+        <staticLogFileName value="true" />
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
     <appender name="LearningStandardLog" type="log4net.Appender.RollingFileAppender">
         <file value="D:\Home\LogFiles\LearningStandardLog\Log.txt" />
         <appendToFile value="true" />
@@ -41,5 +52,9 @@
     <logger additivity="false" name="LearningStandardLog">
         <level value="INFO"/>
         <appender-ref ref="LearningStandardLog" />
+    </logger>
+    <logger additivity="false" name="BulkRegisterOdsInstancesLog">
+        <level value="INFO"/>
+        <appender-ref ref="BulkRegisterOdsInstancesLog" />
     </logger>
 </log4net>

--- a/Application/EdFi.Ods.AdminApp.Web/log4net/log4net.Release.config
+++ b/Application/EdFi.Ods.AdminApp.Web/log4net/log4net.Release.config
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<log4net>
+    <appender name="TraceAppender" type="log4net.Appender.TraceAppender">
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <appender name="FileAppender" type="log4net.Appender.RollingFileAppender">
+        <file value="D:\Home\LogFiles\Log.txt" />
+        <appendToFile value="true" />
+        <rollingStyle value="Size" />
+        <maxSizeRollBackups value="10" />
+        <maximumFileSize value="15MB" />
+        <staticLogFileName value="true" />
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <appender name="LearningStandardLog" type="log4net.Appender.RollingFileAppender">
+        <file value="D:\Home\LogFiles\LearningStandardLog\Log.txt" />
+        <appendToFile value="true" />
+        <rollingStyle value="Size" />
+        <maxSizeRollBackups value="10" />
+        <maximumFileSize value="20MB" />
+        <staticLogFileName value="true" />
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <appender name="aiAppender" type="Microsoft.ApplicationInsights.Log4NetAppender.ApplicationInsightsAppender, Microsoft.ApplicationInsights.Log4NetAppender">
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%message%newline"/>
+        </layout>
+    </appender>
+    <root>
+        <level value="INFO"/>
+        <appender-ref ref="aiAppender"/>
+    </root>
+    <root>
+        <level value="INFO" />
+        <appender-ref ref="TraceAppender" />
+        <appender-ref ref="FileAppender" />
+    </root>
+    <logger additivity="false" name="LearningStandardLog">
+        <level value="INFO"/>
+        <appender-ref ref="LearningStandardLog" />
+    </logger>
+</log4net>

--- a/Application/EdFi.Ods.AdminApp.Web/log4net/log4net.Release.config
+++ b/Application/EdFi.Ods.AdminApp.Web/log4net/log4net.Release.config
@@ -33,11 +33,8 @@
         </layout>
     </appender>
     <root>
-        <level value="INFO"/>
-        <appender-ref ref="aiAppender"/>
-    </root>
-    <root>
         <level value="INFO" />
+        <appender-ref ref="aiAppender"/>
         <appender-ref ref="TraceAppender" />
         <appender-ref ref="FileAppender" />
     </root>

--- a/Application/EdFi.Ods.AdminApp.Web/log4net/log4net.config
+++ b/Application/EdFi.Ods.AdminApp.Web/log4net/log4net.config
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<log4net>
+    <appender name="TraceAppender" type="log4net.Appender.TraceAppender">
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <appender name="FileAppender" type="log4net.Appender.RollingFileAppender">
+        <file value="${ProgramData}\Ed-Fi-ODS-AdminApp\Log.txt" />
+        <appendToFile value="true" />
+        <rollingStyle value="Size" />
+        <maxSizeRollBackups value="10" />
+        <maximumFileSize value="15MB" />
+        <staticLogFileName value="true" />
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <appender name="BulkRegisterOdsInstancesLog" type="log4net.Appender.RollingFileAppender">
+        <file value="${ProgramData}\Ed-Fi-ODS-AdminApp\BulkRegisterOdsInstancesLog\Log.txt" />
+        <appendToFile value="true" />
+        <rollingStyle value="Size" />
+        <maxSizeRollBackups value="10" />
+        <maximumFileSize value="15MB" />
+        <staticLogFileName value="true" />
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <appender name="LearningStandardLog" type="log4net.Appender.RollingFileAppender">
+        <file value="${ProgramData}\Ed-Fi-ODS-AdminApp\LearningStandardLog\Log.txt" />
+        <appendToFile value="true" />
+        <rollingStyle value="Size" />
+        <maxSizeRollBackups value="10" />
+        <maximumFileSize value="20MB" />
+        <staticLogFileName value="true" />
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <root>
+        <level value="DEBUG" />
+        <appender-ref ref="TraceAppender" />
+        <appender-ref ref="FileAppender" />
+    </root>
+    <logger additivity="false" name="LearningStandardLog">
+        <level value="INFO"/>
+        <appender-ref ref="LearningStandardLog" />
+    </logger>
+    <logger additivity="false" name="BulkRegisterOdsInstancesLog">
+        <level value="INFO"/>
+        <appender-ref ref="BulkRegisterOdsInstancesLog" />
+    </logger>
+</log4net>


### PR DESCRIPTION
**Description**

**.Net48 Changes**
- Moved log4net configuration to separate config files under log4net folder for the net48 project. The added xml elements in log4net.OnPremisesRelease.config and log4net.OnPremisesYearSpecificRelease.config are used to emulate the transform behavior in OnPremisesRelease.config and OnPremisesYearSpecificRelease.config files.
- Added Log4NetConfigPath appSetting to set the configuration file path for log4net for different transforms(environments).
- Refactored ConfigureLogging() to configure log4net using the corresponding log4net config path from the appSetting Log4NetConfigPath and the ILoggerRepository argument to make it similar to the log4Net configuration setup in the .net core projects.

**.Net Core Changes**
- Added log4net configuration to separate config files under log4net folder for the .netcore project similar to net48 project.
- Added the Log4NetConfigPath appSetting to .net core appSettings json files similar to the net48 project. Added appSettings.Release.json and appSettings.OnPremisesYearSpecificRelease.json to specify the log4net config appSetting.
- Added ConfigureLogging() to configure log4net using the corresponding log4net config path from the appSetting Log4NetConfigPath and the ILoggerRepository argument.
- Added temporary logic to demonstrate that log4net logging still works.