### PR TITLE
Bulk copy cshtml to aspnet core project

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web.Core/Controllers/HomeController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Controllers/HomeController.cs
@@ -1,11 +1,10 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-using System.Diagnostics;
+using System;
 using Microsoft.AspNetCore.Mvc;
-using EdFi.Ods.AdminApp.Web.Models;
 
 namespace EdFi.Ods.AdminApp.Web.Controllers
 {
@@ -16,10 +15,9 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
             return View();
         }
 
-        [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
-        public IActionResult Error()
+        public ActionResult Error(string message)
         {
-            return View(new ErrorViewModel { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });
+            return View(new HandleErrorInfo(new Exception(message)));
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -213,108 +213,108 @@
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
 
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/_ViewStart.cshtml" LinkBase="Views" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Account/SignOutCallback.cshtml" LinkBase="Views/Account" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Application/_AddApplicationModal.cshtml" LinkBase="Views/Application" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Application/_ApplicationKeyAndSecretContent.cshtml" LinkBase="Views/Application" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Application/_ApplicationKeyAndSecretModal.cshtml" LinkBase="Views/Application" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Application/_EditApplicationModal.cshtml" LinkBase="Views/Application" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/ClaimSets/_AddClaimSet.cshtml" LinkBase="Views/ClaimSets" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/ClaimSets/_AuthStrategiesModal.cshtml" LinkBase="Views/ClaimSets" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/ClaimSets/_ClaimSetDetails.cshtml" LinkBase="Views/ClaimSets" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/ClaimSets/_CopyClaimSetModal.cshtml" LinkBase="Views/ClaimSets" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/ClaimSets/_DeleteClaimSetModal.cshtml" LinkBase="Views/ClaimSets" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/ClaimSets/_DeleteClaimSetResourceModal.cshtml" LinkBase="Views/ClaimSets" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/ClaimSets/_EditClaimSet.cshtml" LinkBase="Views/ClaimSets" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/ClaimSets/_ExportClaimSet.cshtml" LinkBase="Views/ClaimSets" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/ClaimSets/_ExportClaimSetPreview.cshtml" LinkBase="Views/ClaimSets" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/ClaimSets/_ImportExportClaimSet.cshtml" LinkBase="Views/ClaimSets" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/ClaimSets/_ResourceEditor.cshtml" LinkBase="Views/ClaimSets" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Descriptors/_Descriptor.cshtml" LinkBase="Views/Descriptors" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Descriptors/_DescriptorCategories.cshtml" LinkBase="Views/Descriptors" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_AddLocalEducationAgencyModal.cshtml" LinkBase="Views/EducationOrganizations" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_AddSchoolModal.cshtml" LinkBase="Views/EducationOrganizations" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_DeleteOrganizationModal.cshtml" LinkBase="Views/EducationOrganizations" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_EditLocalEducationAgencyModal.cshtml" LinkBase="Views/EducationOrganizations" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_EditSchoolModal.cshtml" LinkBase="Views/EducationOrganizations" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_EducationOrganizations.cshtml" LinkBase="Views/EducationOrganizations" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_MissingData.cshtml" LinkBase="Views/EducationOrganizations" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Error/MultiInstanceError.cshtml" LinkBase="Views/Error" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Error/NotYetImplemented.cshtml" LinkBase="Views/Error" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/GlobalSettings/_AddVendorModal.cshtml" LinkBase="Views/GlobalSettings" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/GlobalSettings/_EditVendorForm.cshtml" LinkBase="Views/GlobalSettings" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/GlobalSettings/_EditVendorModal.cshtml" LinkBase="Views/GlobalSettings" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/GlobalSettings/_SecurityHelpfulHints.cshtml" LinkBase="Views/GlobalSettings" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/GlobalSettings/_VendorsTable.cshtml" LinkBase="Views/GlobalSettings" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/GlobalSettings/AdvancedSettings.cshtml" LinkBase="Views/GlobalSettings" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/GlobalSettings/ClaimSets.cshtml" LinkBase="Views/GlobalSettings" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/GlobalSettings/Users.cshtml" LinkBase="Views/GlobalSettings" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/GlobalSettings/Vendors.cshtml" LinkBase="Views/GlobalSettings" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Home/Index.cshtml" LinkBase="Views/Home" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Identity/ChangePassword.cshtml" LinkBase="Views/Identity" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Identity/ConfirmEmail.cshtml" LinkBase="Views/Identity" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Identity/ForgotPassword.cshtml" LinkBase="Views/Identity" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Identity/ForgotPasswordConfirmation.cshtml" LinkBase="Views/Identity" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Identity/Login.cshtml" LinkBase="Views/Identity" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Identity/Register.cshtml" LinkBase="Views/Identity" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Identity/ResetPassword.cshtml" LinkBase="Views/Identity" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Identity/ResetPasswordConfirmation.cshtml" LinkBase="Views/Identity" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/OdsInstances/_DeregisterOdsInstanceModal.cshtml" LinkBase="Views/OdsInstances" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/OdsInstances/BulkRegisterOdsInstances.cshtml" LinkBase="Views/OdsInstances" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/OdsInstances/Index.cshtml" LinkBase="Views/OdsInstances" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/OdsInstances/RegisterOdsInstance.cshtml" LinkBase="Views/OdsInstances" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/OdsInstanceSettings/_SaveBulkUploadCredentialsForm.cshtml" LinkBase="Views/OdsInstanceSettings" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/OdsInstanceSettings/BulkLoad.cshtml" LinkBase="Views/OdsInstanceSettings" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/OdsInstanceSettings/Descriptors.cshtml" LinkBase="Views/OdsInstanceSettings" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/OdsInstanceSettings/EducationOrganizations.cshtml" LinkBase="Views/OdsInstanceSettings" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/OdsInstanceSettings/EnrollmentByEthnicity.cshtml" LinkBase="Views/OdsInstanceSettings" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/OdsInstanceSettings/EnrollmentByGender.cshtml" LinkBase="Views/OdsInstanceSettings" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/OdsInstanceSettings/EnrollmentByRace.cshtml" LinkBase="Views/OdsInstanceSettings" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/OdsInstanceSettings/Index.cshtml" LinkBase="Views/OdsInstanceSettings" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/OdsInstanceSettings/LearningStandards.cshtml" LinkBase="Views/OdsInstanceSettings" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/OdsInstanceSettings/Logging.cshtml" LinkBase="Views/OdsInstanceSettings" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/OdsInstanceSettings/SchoolsBySchoolType.cshtml" LinkBase="Views/OdsInstanceSettings" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/OdsInstanceSettings/SelectDistrict.cshtml" LinkBase="Views/OdsInstanceSettings" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/OdsInstanceSettings/Setup.cshtml" LinkBase="Views/OdsInstanceSettings" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/OdsInstanceSettings/SetupComplete.cshtml" LinkBase="Views/OdsInstanceSettings" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/OdsInstanceSettings/StudentsByAttribute.cshtml" LinkBase="Views/OdsInstanceSettings" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/OdsInstanceSettings/StudentsByProgram.cshtml" LinkBase="Views/OdsInstanceSettings" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/OdsInstanceSettings/TotalEnrollment.cshtml" LinkBase="Views/OdsInstanceSettings" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Reports/_EnrollmentByEthnicity.cshtml" LinkBase="Views/Reports" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Reports/_EnrollmentByGender.cshtml" LinkBase="Views/Reports" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Reports/_EnrollmentByRace.cshtml" LinkBase="Views/Reports" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Reports/_SchoolsBySchoolType.cshtml" LinkBase="Views/Reports" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Reports/_SelectDistrict.cshtml" LinkBase="Views/Reports" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Reports/_StudentsByAttribute.cshtml" LinkBase="Views/Reports" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Reports/_StudentsByProgram.cshtml" LinkBase="Views/Reports" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Reports/_TotalEnrollment.cshtml" LinkBase="Views/Reports" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Setup/FirstTimeSetup.cshtml" LinkBase="Views/Setup" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Setup/PostUpdateSetup.cshtml" LinkBase="Views/Setup" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Shared/_Applications.cshtml" LinkBase="Views/Shared" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Shared/_ApplicationsByVendor.cshtml" LinkBase="Views/Shared" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Shared/_ApplicationsTable.cshtml" LinkBase="Views/Shared" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Shared/_BulkUploadForm.cshtml" LinkBase="Views/Shared" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Shared/_DeleteVendorApplicationModal.cshtml" LinkBase="Views/Shared" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Shared/_DeleteVendorModal.cshtml" LinkBase="Views/Shared" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Shared/_Layout.cshtml" LinkBase="Views/Shared" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Shared/_LoginPartial.cshtml" LinkBase="Views/Shared" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Shared/_LogSettings.cshtml" LinkBase="Views/Shared" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Shared/_ProductionStagingReadOnlyNotice.cshtml" LinkBase="Views/Shared" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Shared/_RegenerateApplicationSecretModal.cshtml" LinkBase="Views/Shared" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Shared/_Settings_Global.cshtml" LinkBase="Views/Shared" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Shared/_Settings_Production.cshtml" LinkBase="Views/Shared" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Shared/_SettingsGlobalHeader.cshtml" LinkBase="Views/Shared" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Shared/_SignalRStatus.cshtml" LinkBase="Views/Shared" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Shared/_SignalRStatus_BulkLoad.cshtml" LinkBase="Views/Shared" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Shared/_SignalRStatus_LS.cshtml" LinkBase="Views/Shared" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Shared/Error.cshtml" LinkBase="Views/Shared" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Shared/Lockout.cshtml" LinkBase="Views/Shared" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/Update/Index.cshtml" LinkBase="Views/Update" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/User/_DeleteUserModal.cshtml" LinkBase="Views/User" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/User/_EditUserModal.cshtml" LinkBase="Views/User" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/User/_EditUserRoleModal.cshtml" LinkBase="Views/User" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/User/AddUser.cshtml" LinkBase="Views/User" /> -->
-    <!-- <Content Include="../EdFi.Ods.AdminApp.Web/Views/User/EditOdsInstanceRegistrationsForUser.cshtml" LinkBase="Views/User" /> -->
+    <Content Remove="Views\_ViewStart.cshtml" />
+    <Content Remove="Views\Account\SignOutCallback.cshtml" />
+    <Content Remove="Views\Application\_AddApplicationModal.cshtml" />
+    <Content Remove="Views\Application\_ApplicationKeyAndSecretContent.cshtml" />
+    <Content Remove="Views\Application\_ApplicationKeyAndSecretModal.cshtml" />
+    <Content Remove="Views\Application\_EditApplicationModal.cshtml" />
+    <Content Remove="Views\ClaimSets\_AddClaimSet.cshtml" />
+    <Content Remove="Views\ClaimSets\_AuthStrategiesModal.cshtml" />
+    <Content Remove="Views\ClaimSets\_ClaimSetDetails.cshtml" />
+    <Content Remove="Views\ClaimSets\_CopyClaimSetModal.cshtml" />
+    <Content Remove="Views\ClaimSets\_DeleteClaimSetModal.cshtml" />
+    <Content Remove="Views\ClaimSets\_DeleteClaimSetResourceModal.cshtml" />
+    <Content Remove="Views\ClaimSets\_EditClaimSet.cshtml" />
+    <Content Remove="Views\ClaimSets\_ExportClaimSet.cshtml" />
+    <Content Remove="Views\ClaimSets\_ExportClaimSetPreview.cshtml" />
+    <Content Remove="Views\ClaimSets\_ImportExportClaimSet.cshtml" />
+    <Content Remove="Views\ClaimSets\_ResourceEditor.cshtml" />
+    <Content Remove="Views\Descriptors\_Descriptor.cshtml" />
+    <Content Remove="Views\Descriptors\_DescriptorCategories.cshtml" />
+    <Content Remove="Views\EducationOrganizations\_AddLocalEducationAgencyModal.cshtml" />
+    <Content Remove="Views\EducationOrganizations\_AddSchoolModal.cshtml" />
+    <Content Remove="Views\EducationOrganizations\_DeleteOrganizationModal.cshtml" />
+    <Content Remove="Views\EducationOrganizations\_EditLocalEducationAgencyModal.cshtml" />
+    <Content Remove="Views\EducationOrganizations\_EditSchoolModal.cshtml" />
+    <Content Remove="Views\EducationOrganizations\_EducationOrganizations.cshtml" />
+    <Content Remove="Views\EducationOrganizations\_MissingData.cshtml" />
+    <Content Remove="Views\Error\MultiInstanceError.cshtml" />
+    <Content Remove="Views\Error\NotYetImplemented.cshtml" />
+    <Content Remove="Views\GlobalSettings\_AddVendorModal.cshtml" />
+    <Content Remove="Views\GlobalSettings\_EditVendorForm.cshtml" />
+    <Content Remove="Views\GlobalSettings\_EditVendorModal.cshtml" />
+    <Content Remove="Views\GlobalSettings\_SecurityHelpfulHints.cshtml" />
+    <Content Remove="Views\GlobalSettings\_VendorsTable.cshtml" />
+    <Content Remove="Views\GlobalSettings\AdvancedSettings.cshtml" />
+    <Content Remove="Views\GlobalSettings\ClaimSets.cshtml" />
+    <Content Remove="Views\GlobalSettings\Users.cshtml" />
+    <Content Remove="Views\GlobalSettings\Vendors.cshtml" />
+    <Content Remove="Views\Home\Index.cshtml" />
+    <Content Remove="Views\Identity\ChangePassword.cshtml" />
+    <Content Remove="Views\Identity\ConfirmEmail.cshtml" />
+    <Content Remove="Views\Identity\ForgotPassword.cshtml" />
+    <Content Remove="Views\Identity\ForgotPasswordConfirmation.cshtml" />
+    <Content Remove="Views\Identity\Login.cshtml" />
+    <Content Remove="Views\Identity\Register.cshtml" />
+    <Content Remove="Views\Identity\ResetPassword.cshtml" />
+    <Content Remove="Views\Identity\ResetPasswordConfirmation.cshtml" />
+    <Content Remove="Views\OdsInstances\_DeregisterOdsInstanceModal.cshtml" />
+    <Content Remove="Views\OdsInstances\BulkRegisterOdsInstances.cshtml" />
+    <Content Remove="Views\OdsInstances\Index.cshtml" />
+    <Content Remove="Views\OdsInstances\RegisterOdsInstance.cshtml" />
+    <Content Remove="Views\OdsInstanceSettings\_SaveBulkUploadCredentialsForm.cshtml" />
+    <Content Remove="Views\OdsInstanceSettings\BulkLoad.cshtml" />
+    <Content Remove="Views\OdsInstanceSettings\Descriptors.cshtml" />
+    <Content Remove="Views\OdsInstanceSettings\EducationOrganizations.cshtml" />
+    <Content Remove="Views\OdsInstanceSettings\EnrollmentByEthnicity.cshtml" />
+    <Content Remove="Views\OdsInstanceSettings\EnrollmentByGender.cshtml" />
+    <Content Remove="Views\OdsInstanceSettings\EnrollmentByRace.cshtml" />
+    <Content Remove="Views\OdsInstanceSettings\Index.cshtml" />
+    <Content Remove="Views\OdsInstanceSettings\LearningStandards.cshtml" />
+    <Content Remove="Views\OdsInstanceSettings\Logging.cshtml" />
+    <Content Remove="Views\OdsInstanceSettings\SchoolsBySchoolType.cshtml" />
+    <Content Remove="Views\OdsInstanceSettings\SelectDistrict.cshtml" />
+    <Content Remove="Views\OdsInstanceSettings\Setup.cshtml" />
+    <Content Remove="Views\OdsInstanceSettings\SetupComplete.cshtml" />
+    <Content Remove="Views\OdsInstanceSettings\StudentsByAttribute.cshtml" />
+    <Content Remove="Views\OdsInstanceSettings\StudentsByProgram.cshtml" />
+    <Content Remove="Views\OdsInstanceSettings\TotalEnrollment.cshtml" />
+    <Content Remove="Views\Reports\_EnrollmentByEthnicity.cshtml" />
+    <Content Remove="Views\Reports\_EnrollmentByGender.cshtml" />
+    <Content Remove="Views\Reports\_EnrollmentByRace.cshtml" />
+    <Content Remove="Views\Reports\_SchoolsBySchoolType.cshtml" />
+    <Content Remove="Views\Reports\_SelectDistrict.cshtml" />
+    <Content Remove="Views\Reports\_StudentsByAttribute.cshtml" />
+    <Content Remove="Views\Reports\_StudentsByProgram.cshtml" />
+    <Content Remove="Views\Reports\_TotalEnrollment.cshtml" />
+    <Content Remove="Views\Setup\FirstTimeSetup.cshtml" />
+    <Content Remove="Views\Setup\PostUpdateSetup.cshtml" />
+    <Content Remove="Views\Shared\_Applications.cshtml" />
+    <Content Remove="Views\Shared\_ApplicationsByVendor.cshtml" />
+    <Content Remove="Views\Shared\_ApplicationsTable.cshtml" />
+    <Content Remove="Views\Shared\_BulkUploadForm.cshtml" />
+    <Content Remove="Views\Shared\_DeleteVendorApplicationModal.cshtml" />
+    <Content Remove="Views\Shared\_DeleteVendorModal.cshtml" />
+    <Content Remove="Views\Shared\_Layout.cshtml" />
+    <Content Remove="Views\Shared\_LoginPartial.cshtml" />
+    <Content Remove="Views\Shared\_LogSettings.cshtml" />
+    <Content Remove="Views\Shared\_ProductionStagingReadOnlyNotice.cshtml" />
+    <Content Remove="Views\Shared\_RegenerateApplicationSecretModal.cshtml" />
+    <Content Remove="Views\Shared\_Settings_Global.cshtml" />
+    <Content Remove="Views\Shared\_Settings_Production.cshtml" />
+    <Content Remove="Views\Shared\_SettingsGlobalHeader.cshtml" />
+    <Content Remove="Views\Shared\_SignalRStatus.cshtml" />
+    <Content Remove="Views\Shared\_SignalRStatus_BulkLoad.cshtml" />
+    <Content Remove="Views\Shared\_SignalRStatus_LS.cshtml" />
+    <Content Remove="Views\Shared\Error.cshtml" />
+    <Content Remove="Views\Shared\Lockout.cshtml" />
+    <Content Remove="Views\Update\Index.cshtml" />
+    <Content Remove="Views\User\_DeleteUserModal.cshtml" />
+    <Content Remove="Views\User\_EditUserModal.cshtml" />
+    <Content Remove="Views\User\_EditUserRoleModal.cshtml" />
+    <Content Remove="Views\User\AddUser.cshtml" />
+    <Content Remove="Views\User\EditOdsInstanceRegistrationsForUser.cshtml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
@@ -213,7 +213,6 @@
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
 
-    <Content Remove="Views\_ViewStart.cshtml" />
     <Content Remove="Views\Account\SignOutCallback.cshtml" />
     <Content Remove="Views\Application\_AddApplicationModal.cshtml" />
     <Content Remove="Views\Application\_ApplicationKeyAndSecretContent.cshtml" />
@@ -296,7 +295,6 @@
     <Content Remove="Views\Shared\_BulkUploadForm.cshtml" />
     <Content Remove="Views\Shared\_DeleteVendorApplicationModal.cshtml" />
     <Content Remove="Views\Shared\_DeleteVendorModal.cshtml" />
-    <Content Remove="Views\Shared\_Layout.cshtml" />
     <Content Remove="Views\Shared\_LoginPartial.cshtml" />
     <Content Remove="Views\Shared\_LogSettings.cshtml" />
     <Content Remove="Views\Shared\_ProductionStagingReadOnlyNotice.cshtml" />
@@ -307,7 +305,6 @@
     <Content Remove="Views\Shared\_SignalRStatus.cshtml" />
     <Content Remove="Views\Shared\_SignalRStatus_BulkLoad.cshtml" />
     <Content Remove="Views\Shared\_SignalRStatus_LS.cshtml" />
-    <Content Remove="Views\Shared\Error.cshtml" />
     <Content Remove="Views\Shared\Lockout.cshtml" />
     <Content Remove="Views\Update\Index.cshtml" />
     <Content Remove="Views\User\_DeleteUserModal.cshtml" />

--- a/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
@@ -213,6 +213,7 @@
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
 
+    <!-- Manually delete these "Content Remove" lines to include each view into the solution.  -->
     <Content Remove="Views\Account\SignOutCallback.cshtml" />
     <Content Remove="Views\Application\_AddApplicationModal.cshtml" />
     <Content Remove="Views\Application\_ApplicationKeyAndSecretContent.cshtml" />

--- a/Application/EdFi.Ods.AdminApp.Web.Core/StubTypes.cs
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/StubTypes.cs
@@ -6,6 +6,7 @@
 //This file contains temporary type declarations in service of net48/netcoreapp3.1 cross-compilation.
 //These types are intended to be removed as they are ported in full to .NET Core.
 
+using System;
 using EdFi.Ods.AdminApp.Management.Workflow;
 using EdFi.Ods.AdminApp.Web.Infrastructure.Jobs;
 using EdFi.Ods.Common.Security;
@@ -61,4 +62,14 @@ public class StubPbkdf2HmacSha1SecureHasher : ISecureHasher
         => throw new System.NotImplementedException();
 
     public string Algorithm { get => throw new System.NotImplementedException(); }
+}
+
+public class HandleErrorInfo
+{
+    public HandleErrorInfo(Exception exception)
+    {
+        Exception = exception;
+    }
+
+    public Exception Exception { get; }
 }

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Account/SignOutCallback.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Account/SignOutCallback.cshtml
@@ -1,0 +1,12 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@{
+    ViewBag.Title = "Sign Out";
+}
+<h2>@ViewBag.Title</h2>
+<p class="text-success">You have successfully signed out.</p>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Application/_AddApplicationModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Application/_AddApplicationModal.cshtml
@@ -1,0 +1,107 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.Application
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.Application.AddApplicationViewModel
+
+<div class="modal fade" id="add-application-modal" tabindex="-1" role="dialog" aria-labelledby="add-application-modal" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content" id="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Add Application to Vendor</h4>
+            </div>
+            @if (!Model.LocalEducationAgencies.Any() && !Model.LocalEducationAgencies.Any())
+            {
+                <div class="modal-body">
+                    <div class="row">
+                        <div class="col-md-12">
+                            <div class="well">
+                                <strong>To add an application, you must first create at least one education organization</strong>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    @Html.CancelModalButton()
+                </div>
+            }
+            else
+            {
+                <div class="modal-body">
+                    @using (Html.BeginForm("Add", "Application"))
+                    {
+                        @Html.ValidationBlock()
+                        @Html.Input(m => m.VendorId).Hide()
+                        @Html.Input(m => m.Environment).Hide().Value(Model.Environment.Value.ToString())
+                        @Html.InputBlock(m => m.ApplicationName, "Application Name", "Name that identifies this application")
+
+                        <div class="row">
+                            <div class="col-xs-4 text-right">
+                                @Html.Label("Education Organization Type:")
+                            </div>
+                            <div class="col-xs-6 margin-bottom-10">
+                                @Html.InlineRadioButton(x => x.EducationOrganizationType, ApplicationEducationOrganizationType.LocalEducationAgency)
+                                @Html.InlineRadioButton(x => x.EducationOrganizationType, ApplicationEducationOrganizationType.School)
+                            </div>
+                            <div class="col-xs-2">
+                                @Html.ToolTip("An application may only access one type of education organization at a time - either LEAs or schools.")
+                            </div>
+                        </div>
+
+                        @Html.MultiSelectListBlock(m => m.EducationOrganizationIds, Model.LocalEducationAgencies, cs => new SelectListItem {Selected = false, Text = cs.Name, Value = cs.EducationOrganizationId.ToString()}, "Denotes which EdOrgs this application can access").Data("edorg-type", ApplicationEducationOrganizationType.LocalEducationAgency.Value).Hide()
+                        @Html.MultiSelectListBlock(m => m.EducationOrganizationIds, Model.Schools, cs => new SelectListItem {Selected = false, Text = cs.Name, Value = cs.EducationOrganizationId.ToString()}, "Denotes which EdOrgs this application can access").Data("edorg-type", ApplicationEducationOrganizationType.School.Value).Hide()
+
+                        @Html.SelectListBlock(m => m.ClaimSetName, Model.ClaimSetNames, cs => new SelectListItem {Selected = false, Text = cs, Value = cs}, "Claims define the actions this application is allowed to perform")
+
+                        <div class="advanced-option" style="display:none">
+                            @Html.SelectListBlock(m => m.ProfileId, Model.Profiles, ps => new SelectListItem {Selected = false, Text = ps.ProfileName, Value = ps.ProfileId.ToString()}, includeBlankOption: true, helpTooltipText: "Optional. Used to implement data access policies within individual API resources. This is an advanced setting; please see the Ed-Fi ODS technical documentation for more detail.")
+                        </div>
+
+                        <div class="row">
+                            <div class="col-xs-4"></div>
+                            <div class="col-xs-8">
+                                <div class="hides-elements" data-associated-elements="advanced-option" style="display: none">
+                                    <a href="#">Hide Advanced Options</a>
+                                </div>
+                                <div class="shows-elements" data-associated-elements="advanced-option">
+                                    <a href="#">Show Advanced Options</a>
+                                </div>
+                            </div>
+                        </div>
+                    }
+                </div>
+                <div class="modal-footer">
+                    @Html.CancelModalButton()
+                    @Html.SaveButton("Add Application", "modal-content").AppendSpinner("add-app-spinner")
+                </div>
+            }
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+    $(function() {
+        var $edorgOptions = $("input[name='EducationOrganizationType']");
+        $edorgOptions.change(function () {
+            if ($(this).is(':checked')) {
+                var edOrgType = $(this).val();
+                ShowEdOrgSelectList(edOrgType);
+            }
+        });
+    });
+
+    function ShowEdOrgSelectList(edOrgType) {
+        var $allEdOrgSelectLists = $("[data-edorg-type]");
+        $allEdOrgSelectLists.hide();
+        $allEdOrgSelectLists.find("select").prop("disabled", true);
+        var $shownSelectList = $allEdOrgSelectLists.filter("[data-edorg-type='" + edOrgType + "']");
+        $shownSelectList.find("select").prop("disabled", false);
+        $shownSelectList.show();
+    }
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Application/_ApplicationKeyAndSecretContent.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Application/_ApplicationKeyAndSecretContent.cshtml
@@ -1,0 +1,36 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.Application.ApplicationKeyModel
+
+<div class="modal-header">
+    <h4 class="modal-title">Add @Model.ApplicationEnvironment.DisplayName Application</h4>
+</div>
+<div class="modal-body">
+    <div class="text-center">
+        <h7><img class="modal-image-header" src="~/Content/images/key_icon@2x.png" /></h7>
+        <div class="key-text">
+            <div>@Model.ApplicationName</div>
+            <div>Key: <span class="key-generated">@Model.Key</span></div>
+            <div>Secret: <span class="key-generated">@Model.Secret</span></div>
+            <div>API URL: <span class="key-generated">@Model.ApiUrl</span></div>
+        </div>
+    </div>
+    <div class="text-center padding-top">
+        <p><span class="note">Note:</span> For security purposes, this key is not viewable after you leave this page.</p>
+        <p>Be sure to copy the key elsewhere for safekeeping.</p>
+    </div>
+</div>
+<div class="modal-footer">
+    @Html.CancelButton("I have copied the Key and Secret").Id("key-and-secret-dismiss-button")
+</div>
+<script language="javascript">
+    $("#key-and-secret-dismiss-button").click(function() {
+        location.reload(true);
+    });
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Application/_ApplicationKeyAndSecretModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Application/_ApplicationKeyAndSecretModal.cshtml
@@ -1,0 +1,16 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.Application.ApplicationKeyModel
+
+<div class="modal fade" id="application-key-and-secret-modal" tabindex="-1" role="dialog" aria-labelledby="application-key-and-secret-modal" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            @Html.Partial("_ApplicationKeyAndSecretContent", Model)
+        </div>
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Application/_EditApplicationModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Application/_EditApplicationModal.cshtml
@@ -1,0 +1,90 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.Application
+@using HtmlTags.Extended.Attributes
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.Application.EditApplicationViewModel
+
+<div class="modal fade" id="add-application-modal" tabindex="-1" role="dialog" aria-labelledby="add-application-modal" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content" id="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Edit Application</h4>
+            </div>
+            <div class="modal-body">
+                @using (Html.BeginForm("Edit", "Application"))
+                {
+                    @Html.ValidationBlock()
+                    @Html.Input(m => m.VendorId).Hide()
+                    @Html.Input(m => m.Environment).Hide().Value(Model.Environment.Value.ToString())
+                    @Html.Input(m => m.ApplicationId).Hide()
+                    @Html.InputBlock(m => m.ApplicationName, "Application Name", "Name that identifies this application")
+                    <div class="row">
+                        <div class="col-xs-4 text-right">
+                            @Html.Label("Education Organization Type:")
+                        </div>
+                        <div class="col-xs-6">
+                            @Html.InlineRadioButton(x => x.EducationOrganizationType, ApplicationEducationOrganizationType.LocalEducationAgency)
+                            @Html.InlineRadioButton(x => x.EducationOrganizationType, ApplicationEducationOrganizationType.School)
+                        </div>
+                        <div class="col-xs-2">
+                            @Html.ToolTip("An application may only access one type of education organization at a time - either LEAs or schools.")
+                        </div>
+                    </div>
+
+                    @Html.MultiSelectListBlock(m => m.EducationOrganizationIds, Model.LocalEducationAgencies, cs => new SelectListItem { Selected = Model.EducationOrganizationIds.Contains(cs.EducationOrganizationId), Text = cs.Name, Value = cs.EducationOrganizationId.ToString() }, "Denotes which EdOrgs this application can access").Data("edorg-type", ApplicationEducationOrganizationType.LocalEducationAgency.Value).HideUnless(Model.EducationOrganizationType == ApplicationEducationOrganizationType.LocalEducationAgency)
+                    @Html.MultiSelectListBlock(m => m.EducationOrganizationIds, Model.Schools, cs => new SelectListItem { Selected = Model.EducationOrganizationIds.Contains(cs.EducationOrganizationId), Text = cs.Name, Value = cs.EducationOrganizationId.ToString() }, "Denotes which EdOrgs this application can access").Data("edorg-type", ApplicationEducationOrganizationType.School.Value).HideUnless(Model.EducationOrganizationType == ApplicationEducationOrganizationType.School)
+
+                    @Html.SelectListBlock(m => m.ClaimSetName, Model.ClaimSetNames, cs => new SelectListItem {Selected = Model.ClaimSetName == cs, Text = cs, Value = cs}, "Claims define the actions this application is allowed to perform")
+
+                    <div class="advanced-option" style="display:none">
+                        @Html.SelectListBlock(m => m.ProfileId, Model.Profiles, ps => new SelectListItem {Selected = Model.ProfileId == ps.ProfileId, Text = ps.ProfileName, Value = ps.ProfileId.ToString()}, includeBlankOption: true, helpTooltipText: "Optional. Used to implement data access policies within individual API resources. This is an advanced setting; please see the Ed-Fi ODS technical documentation for more detail.")
+                    </div>
+
+                    <div class="row">
+                        <div class="col-xs-4"></div>
+                        <div class="col-xs-8">
+                            <div class="hides-elements" data-associated-elements="advanced-option" style="display: none">
+                                <a href="#">Hide Advanced Options</a>
+                            </div>
+                            <div class="shows-elements" data-associated-elements="advanced-option">
+                                <a href="#">Show Advanced Options</a>
+                            </div>
+                        </div>
+                    </div>
+                }
+            </div>
+            <div class="modal-footer">
+                @Html.CancelModalButton()
+                @Html.SaveButton("Save").AppendSpinner("add-app-spinner")
+            </div>
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+    $(function () {
+        var $edorgOptions = $("input[name='EducationOrganizationType']");
+        $edorgOptions.change(function () {
+            if ($(this).is(':checked')) {
+                var edOrgType = $(this).val();
+                ShowEdOrgSelectList(edOrgType);
+            }
+        });
+    });
+
+    function ShowEdOrgSelectList(edOrgType) {
+        var $allEdOrgSelectLists = $("[data-edorg-type]");
+        $allEdOrgSelectLists.hide();
+        $allEdOrgSelectLists.find("select").prop("disabled", true);
+        var $shownSelectList = $allEdOrgSelectLists.filter("[data-edorg-type='" + edOrgType + "']");
+        $shownSelectList.find("select").prop("disabled", false);
+        $shownSelectList.show();
+    }
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_AddClaimSet.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_AddClaimSet.cshtml
@@ -1,0 +1,51 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets.AddClaimSetModel
+
+<h3>Add Claim Set</h3>
+@using (Html.BeginForm("AddClaimSet", "ClaimSets", FormMethod.Post, new { @id = "add-claim-set-form" }))
+{
+    @Html.AntiForgeryToken()
+    <div id="add-claim-set-validation-summary" class="validationSummary alert alert-danger" hidden></div>
+    <div class="form-group row">
+        @Html.InputBlock(x => x.ClaimSetName)
+    </div>
+    <br />
+    <div class="padding-top-5">
+        @Html.Button("Back").AddClass("back-btn back-ajax claimset-back-btn").Data("back-url", Url.Action("ClaimSets", "GlobalSettings"))
+        @Html.SaveButton("Save")
+    </div>
+}
+<script type="text/javascript">
+    $('#add-claim-set-form').submit(function (e) {
+        e.preventDefault();
+        var successAdditionalBehavior = function() {
+            ClaimSetToastrMessage("New Claimset added successfully", true);
+            ClaimSetWarningMessage(true);
+        };
+        var errorAdditionalBehavior = function () {
+            ClaimSetToastrMessage("There was an error while adding the new Claimset");
+        };
+        var ajaxRequestData = {
+            form: $(this),
+            formData: $(this).serialize(),
+            successAction : {
+                state: 'edit',
+                url: '@Url.Action("ClaimSets", "GlobalSettings")'
+            },
+            panelId: "claim-set-tab",
+            successAdditionalBehavior: successAdditionalBehavior,
+            errorAdditionalBehavior: errorAdditionalBehavior
+        };
+        submitAjaxForInnerTabs(ajaxRequestData);
+    });
+    $(function () {
+        InitializeBackNavigationalAjaxButtons();
+    });
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_AuthStrategiesModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_AuthStrategiesModal.cshtml
@@ -1,0 +1,194 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
+@model AuthStrategyEditorModel
+
+<div id="auth-strategies-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="authStrategiesModal" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" style="text-align: center;">Override Authorization Strategy</h4>
+                <div>
+                    <h6>Editor Legend</h6>
+                    <div class="row">
+                        <span class="default-strategy">(Default)</span><span class="margin-left-10">Not inherited from parent</span>
+                    </div>
+                    <div class="row">
+                        <span class="default-strategy inherited-strategy">(Default)</span><span class="margin-left-10">Inherited from parent</span>
+                    </div>
+                    <div class="row">
+                        <span class="overridden-strategy">(Overridden)</span><span class="margin-left-10">Overridden</span>
+                    </div>
+                    <div class="row">
+                        <span class="overridden-strategy inherited-override">(Overridden)</span><span class="margin-left-10">Overridden by parent</span>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-body center-block text-center">
+                <div id="auth-modal-spinner" class="text-center hidden">
+                    <div><i class="fa fa-spinner fa-pulse fa-3x fa-fw"></i></div>
+                </div>
+                <table class="table" id="auth-table">
+                    <colgroup>
+                        <col style="width: 2%">
+                        <col style="width: 18%">
+                        <col style="width: 18%">
+                        <col style="width: 18%">
+                        <col style="width: 18%">
+                        <col style="width: 18%">
+                        <col style="width: 4%">
+                        <col style="width: 4%">
+                    </colgroup>
+                    <thead>
+                    <tr>
+                        <th scope="col"></th>
+                        <th scope="col">Resource</th>
+                        <th scope="col">Read</th>
+                        <th scope="col">Create</th>
+                        <th scope="col">Update</th>
+                        <th scope="col">Delete</th>
+                        <th scope="col"></th>
+                        <th scope="col"></th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    @if (Model.ResourceClaim != null)
+                    {
+                        <tr class="parent-resource-claim">
+                            <td class="icon-cell"></td>
+                            <td data-resource-id='@Model.ResourceClaim.Id' class="resource-label">@Model.ResourceClaim.Name</td>
+                            <td class="read-action-cell" data-existing-action='@Model.ResourceClaim.Read'>
+                                @if (Model.ResourceClaim.AuthStrategyOverridesForCRUD[1] != null)
+                                {
+                                    <span data-is-inherited="@Model.ResourceClaim.AuthStrategyOverridesForCRUD[1].IsInheritedFromParent" data-default-strategy='@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[1].DisplayName'>@Model.ResourceClaim.AuthStrategyOverridesForCRUD[1].DisplayName</span>
+                                    if (Model.ResourceClaim.AuthStrategyOverridesForCRUD[1].IsInheritedFromParent)
+                                    {
+                                        <span class="overridden-strategy inherited-override">(Overridden)</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="overridden-strategy">(Overridden)</span>
+                                    }
+                                }
+                                else if (Model.ResourceClaim.DefaultAuthStrategiesForCRUD[1] != null)
+                                {
+                                    <span data-is-inherited="@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[1].IsInheritedFromParent" data-default-strategy='@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[1].DisplayName'>@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[1].DisplayName</span>
+                                    if (Model.ResourceClaim.DefaultAuthStrategiesForCRUD[1].IsInheritedFromParent)
+                                    {
+                                        <span class="default-strategy inherited-strategy">(Default)</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="default-strategy">(Default)</span>
+                                    }
+                                }
+                            </td>
+                            <td class="create-action-cell" data-existing-action='@Model.ResourceClaim.Create'>
+                                @if (Model.ResourceClaim.AuthStrategyOverridesForCRUD[0] != null)
+                                {
+                                    <span data-is-inherited="@Model.ResourceClaim.AuthStrategyOverridesForCRUD[0].IsInheritedFromParent" data-default-strategy='@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[0].DisplayName'>@Model.ResourceClaim.AuthStrategyOverridesForCRUD[0].DisplayName</span>
+                                    if (Model.ResourceClaim.AuthStrategyOverridesForCRUD[0].IsInheritedFromParent)
+                                    {
+                                        <span class="overridden-strategy inherited-override">(Overridden)</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="overridden-strategy">(Overridden)</span>
+                                    }
+                                }
+                                else if (Model.ResourceClaim.DefaultAuthStrategiesForCRUD[0] != null)
+                                {
+                                    <span data-is-inherited="@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[0].IsInheritedFromParent" data-default-strategy='@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[0].DisplayName'>@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[0].DisplayName</span>
+                                    if (Model.ResourceClaim.DefaultAuthStrategiesForCRUD[0].IsInheritedFromParent)
+                                    {
+                                        <span class="default-strategy inherited-strategy">(Default)</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="default-strategy">(Default)</span>
+                                    }
+                                }
+                            </td>
+                            <td class="update-action-cell" data-existing-action='@Model.ResourceClaim.Update'>
+                                @if (Model.ResourceClaim.AuthStrategyOverridesForCRUD[2] != null)
+                                {
+                                    <span data-is-inherited="@Model.ResourceClaim.AuthStrategyOverridesForCRUD[2].IsInheritedFromParent" data-default-strategy='@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[2].DisplayName'>@Model.ResourceClaim.AuthStrategyOverridesForCRUD[2].DisplayName</span>
+                                    if (Model.ResourceClaim.AuthStrategyOverridesForCRUD[2].IsInheritedFromParent)
+                                    {
+                                        <span class="overridden-strategy inherited-override">(Overridden)</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="overridden-strategy">(Overridden)</span>
+                                    }
+                                }
+                                else if (Model.ResourceClaim.DefaultAuthStrategiesForCRUD[2] != null)
+                                {
+                                    <span data-is-inherited="@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[2].IsInheritedFromParent" data-default-strategy='@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[2].DisplayName'>@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[2].DisplayName</span>
+                                    if (Model.ResourceClaim.DefaultAuthStrategiesForCRUD[2].IsInheritedFromParent)
+                                    {
+                                        <span class="default-strategy inherited-strategy">(Default)</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="default-strategy">(Default)</span>
+                                    }
+                                }
+                            </td>
+                            <td class="delete-action-cell" data-existing-action='@Model.ResourceClaim.Delete'>
+                                @if (Model.ResourceClaim.AuthStrategyOverridesForCRUD[3] != null)
+                                {
+                                    <span data-is-inherited="@Model.ResourceClaim.AuthStrategyOverridesForCRUD[3].IsInheritedFromParent" data-default-strategy='@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[3].DisplayName'>@Model.ResourceClaim.AuthStrategyOverridesForCRUD[3].DisplayName</span>
+                                    if (Model.ResourceClaim.AuthStrategyOverridesForCRUD[3].IsInheritedFromParent)
+                                    {
+                                        <span class="overridden-strategy inherited-override">(Overridden)</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="overridden-strategy">(Overridden)</span>
+                                    }
+                                }
+                                else if (Model.ResourceClaim.DefaultAuthStrategiesForCRUD[3] != null)
+                                {
+                                    <span data-is-inherited="@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[3].IsInheritedFromParent" data-default-strategy='@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[3].DisplayName'>@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[3].DisplayName</span>
+                                    if (Model.ResourceClaim.DefaultAuthStrategiesForCRUD[3].IsInheritedFromParent)
+                                    {
+                                        <span class="default-strategy inherited-strategy">(Default)</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="default-strategy">(Default)</span>
+                                    }
+                                }
+                            </td>
+                            <td>
+                                <a class="override-auth"> <span class="fa fa-pencil action-icons"></span></a>
+                            </td>
+                            <td>
+                                <a class="reset-auth"> <span class="fa fa-undo action-icons"></span></a>
+                            </td>
+                        </tr>
+                    }
+                    </tbody>
+                </table>
+            </div>
+            <div class="modal-footer">
+                @Html.CancelModalButton()
+            </div>
+        </div>
+    </div>
+</div>
+<script type="text/javascript">
+    var authStrategyOverrideUrl = '@Url.Action("OverrideAuthStrategiesOnResource", "ClaimSets")';
+    var getUpdatedResourceUrl = '@Url.Action("GetUpdatedResourceClaim", "ClaimSets")';
+    var resetAuthStrategyUrl = '@Url.Action("ResetAuthStrategiesOnResource", "ClaimSets")';
+    var authStrategiesOptions = JSON.parse(@Html.Raw(Json.Encode(Model.AuthStrategies)))
+</script>
+@Scripts.Render("~/bundles/scripts/authstrategy")

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_ClaimSetDetails.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_ClaimSetDetails.cshtml
@@ -1,0 +1,136 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets.ClaimSetDetailsModel
+
+<h3>Claim Set Information</h3>
+<div class="form-group row">
+    <label class="col-sm-4">Claim Set Name</label>
+    <div class="col-sm-8">
+        <span>@Html.DisplayFor(x => x.ClaimSet.Name)</span>
+    </div>
+</div>
+<br />
+<h3>Applications</h3>
+@if (Model.Applications.Any())
+{
+    <table class="table">
+        <thead>
+            <tr>
+                <th scope="col">Application Name</th>
+                <th scope="col">Vendor Name</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var application in Model.Applications)
+            {
+                <tr>
+                    <td>@application.Name</td>
+                    <td>@application.VendorName</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+else
+{
+    <div> No applications found.</div>
+}
+<br />
+<h3>Resources</h3>
+@if (Model.ResourceClaims.Any())
+{
+    <table class="table">
+        <thead>
+            <tr>
+                <th scope="col"></th>
+                <th scope="col">Resource</th>
+                <th scope="col">Read</th>
+                <th scope="col">Create</th>
+                <th scope="col">Update</th>
+                <th scope="col">Delete</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var resourceClaim in Model.ResourceClaims)
+            {
+                <tr class="parent-resource-claim">
+                    <td>
+                        @if (resourceClaim.Children.Any())
+                        {<a class="claims-toggle"><span class="fa fa-chevron-down caret-custom"></span></a>}
+                    </td>
+                    <td>@resourceClaim.Name</td>
+                    <td>
+                        @Html.CheckBoxSquare(resourceClaim.Read, "read")
+                    </td>
+                    <td>
+                        @Html.CheckBoxSquare(resourceClaim.Create, "create")
+                    </td>
+                    <td>
+                        @Html.CheckBoxSquare(resourceClaim.Update, "update")
+                    </td>
+                    <td>
+                        @Html.CheckBoxSquare(resourceClaim.Delete, "delete")
+                    </td>
+                </tr>
+
+                foreach (var childResourceClaim in resourceClaim.Children)
+                {
+                    <tr class="child-resource-claim" style="display: none">
+                        <td>
+                            <span class = "child-resource-branch"></span>
+                        </td>
+                        <td>@childResourceClaim.Name</td>
+                        <td>
+                            @Html.CheckBoxSquare(childResourceClaim.Read, "read")
+                        </td>
+                        <td>
+                            @Html.CheckBoxSquare(childResourceClaim.Create, "create")
+                        </td>
+                        <td>
+                            @Html.CheckBoxSquare(childResourceClaim.Update, "update")
+                        </td>
+                        <td>
+                            @Html.CheckBoxSquare(childResourceClaim.Delete, "delete")
+                        </td>
+                    </tr>
+                }
+            }
+        </tbody>
+    </table>
+
+}
+else
+{
+    <div> No resource claims found.</div>
+}
+    <div>
+        @Html.Button("Back").AddClass("back-btn back-ajax claimset-back-btn").Data("back-url", Url.Action("ClaimSets", "GlobalSettings"))
+        @if (Model.ClaimSet.IsEditable)
+        {
+            @Html.Button("Edit Claim Set").Attr("href", Url.Action("EditClaimSet", "ClaimSets", new { claimSetId = Model.ClaimSet.Id })).AddClass("edit-claimset navigational-ajax").Data("state", "edit").Data("page-url", Url.Action("ClaimSets", "GlobalSettings")).Data("action", "editing the Claim Set")
+        }
+    </div>
+
+<script type="text/javascript">
+    $('.claims-toggle').click(function () {
+        var toggle = $(this);
+        if (toggle.find('span:first').hasClass('fa-chevron-down')) {
+            toggle.html('<span class="fa fa-chevron-up caret-custom"></span>');
+        } else {
+            toggle.html('<span class="fa fa-chevron-down caret-custom"></span>');
+        }
+        var row = $(this).closest('.parent-resource-claim');
+        row.nextUntil('tr.parent-resource-claim').slideToggle(100, function () {
+        });
+    });
+    $(function () {
+        InitializeNavigationalAjaxButtons();
+        InitializeBackNavigationalAjaxButtons();
+    });
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_CopyClaimSetModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_CopyClaimSetModal.cshtml
@@ -1,0 +1,35 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets.CopyClaimSetModel
+
+<div id="copy-claimset-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="copyClaimSetModal" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Copy Claim Set</h4>
+            </div>
+            <div class="modal-body center-block text-center">
+                <div class="padding-bottom-10">
+                    Do you want to make a copy of the claimset - <b>@Model.OriginalName</b>?
+                </div>
+                @using (Html.BeginForm("CopyClaimSet", "ClaimSets", FormMethod.Post, new { data_tab_claimset = true }))
+                {
+                    @Html.Input(m => m.OriginalId).Hide()
+                    @Html.ValidationBlock()
+                    @Html.InputBlock(m => m.Name)
+                }
+            </div>
+            <div class="modal-footer">
+                @Html.CancelModalButton()
+                @Html.SaveButton("Copy")
+            </div>
+        </div>
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_DeleteClaimSetModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_DeleteClaimSetModal.cshtml
@@ -1,0 +1,36 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets.DeleteClaimSetModel
+
+<div id="delete-claimset-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="deleteClaimSetModal" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Delete Claim Set</h4>
+            </div>
+            <div class="modal-body center-block text-center">
+                <div class="padding-bottom-10">
+                    Do you want to delete the claimset - <b>@Model.Name</b>?
+                </div>
+                @using (Html.BeginForm("DeleteClaimSet", "ClaimSets", FormMethod.Post, new {data_tab_claimset=true}))
+                {
+                    @Html.ValidationBlock()
+                    @Html.Input(m => m.Id).Hide()
+                    @Html.Input(m => m.VendorApplicationCount).Hide()
+                    @Html.Input(m => m.IsEditable).Hide()
+                }
+            </div>
+            <div class="modal-footer">
+                @Html.CancelModalButton()
+                @Html.SaveButton("Delete")
+            </div>
+        </div>
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_DeleteClaimSetResourceModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_DeleteClaimSetResourceModal.cshtml
@@ -1,0 +1,37 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets.DeleteClaimSetResourceModel
+
+<div id="delete-claimset-resource-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="deleteClaimSetResourceModal" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Delete Claim Set Resource</h4>
+            </div>
+            <div class="modal-body center-block text-center">
+                <div class="padding-bottom-10">
+                    Do you want to delete the resource <b>@Model.ResourceName</b> on claimset <b>@Model.ClaimSetName</b>?
+                </div>
+                <div id="delete-resource-validation-summary" class="validationSummary alert alert-danger" hidden></div>
+                @Html.Input(m => m.ClaimSetId).Hide()
+                @Html.Input(m => m.ResourceClaimId).Hide()
+            </div>
+            <div class="modal-footer">
+                @Html.CancelModalButton()
+                @Html.Button("Delete").Id("delete-resource-button")
+            </div>
+        </div>
+    </div>
+</div>
+<script type="text/javascript">
+    $(function () {
+        $("#delete-resource-button").click(deleteResourceAjax);
+    });
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_EditClaimSet.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_EditClaimSet.cshtml
@@ -1,0 +1,93 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets.EditClaimSetModel
+
+<h3>Edit Claim Set</h3>
+@using (Html.BeginForm("EditClaimSet", "ClaimSets", FormMethod.Post, new { @id = "edit-claim-set-form" }))
+{
+    <div id="edit-claim-set-validation-summary" class="validationSummary alert alert-danger" hidden></div>
+    @Html.Input(x => x.ClaimSetId).Hide()
+    <div class="form-group row">
+        <div class="col-md-8">
+            @Html.InputBlock(x => x.ClaimSetName)
+        </div>
+        <div class="col-md-4">
+            @Html.SaveButton("Update Name")
+        </div>        
+    </div>
+}
+<h3>Applications</h3>
+@if (Model.Applications.Any())
+{
+    <table class="table">
+        <thead>
+            <tr>
+                <th scope="col">Application Name</th>
+                <th scope="col">Vendor Name</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var application in Model.Applications)
+            {
+                <tr>
+                    <td>@application.Name</td>
+                    <td>@application.VendorName</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+else
+{
+    <div> No applications found.</div>
+}
+<br />
+
+<div id="resource-editor-tab">
+    @Html.Partial("_ResourceEditor", new ClaimSetResourcesModel()
+    {
+        AllResourceClaims = Model.AllResourceClaims,
+        ResourceClaims = Model.ResourceClaims,
+        ClaimSetId = Model.ClaimSetId,
+        ClaimSetName = Model.ClaimSetName
+    })
+</div>
+<div class="padding-top-5">
+    @Html.Button("Back").AddClass("back-btn back-ajax claimset-back-btn").Data("back-url", Url.Action("ClaimSets", "GlobalSettings"))
+</div>
+<script type="text/javascript">
+    $('#edit-claim-set-form').submit(function (e) {
+        e.preventDefault();
+        var postData = {
+            'ClaimSetId': parseInt($("#ClaimSetId").val()),
+            'ClaimSetName': $("#ClaimSetName").val()
+        };
+        var successAdditionalBehavior = function() {
+            ClaimSetToastrMessage("Claimset name edited successfully", true);
+            ClaimSetWarningMessage(true);
+        };
+        var errorAdditionalBehavior = function () {
+            ClaimSetToastrMessage("There was an error while editing the Claimset");
+        };
+        var ajaxRequestData = {
+            form: $(this),
+            formData: addAntiForgeryToken(postData),
+            dataType: "html",
+            successAdditionalBehavior: successAdditionalBehavior,
+            errorAdditionalBehavior: errorAdditionalBehavior
+        };
+        submitAjaxForInnerTabs(ajaxRequestData);
+    });
+
+    $(function () {
+        InitializeModalLoaders();
+        InitializeBackNavigationalAjaxButtons();
+    });
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_ExportClaimSet.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_ExportClaimSet.cshtml
@@ -1,0 +1,97 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using System.Web.Mvc.Html
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets.ClaimSetFileExportModel
+
+<h3>Export Claim Set</h3>
+@if (!Model.ClaimSets.Any())
+{
+    <p>
+        You don't have any claimsets to export. Please create one to export.
+    </p>
+}
+else
+{
+    using (Html.BeginForm("FileExport", "ClaimSets", FormMethod.Post, new { @id = "export-claim-set-form" }))
+    {
+        @Html.HiddenFor(x => x.SelectedForExport);
+        @Html.HiddenFor(x => x.ClaimSets);
+        <div id="export-claim-set-validation-summary" class="validationSummary alert alert-danger" hidden></div>
+        <div class="row">
+            @Html.InputBlock(x => x.Title)
+        </div>
+        <div class="row">
+            <div class="col-md-12">
+                <table class="table table-hover table-bordered table-responsive">
+                    <thead>
+                        <tr>
+                            <th class="text-center col-md-1">Export?</th>
+                            <th>ClaimSet Name</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var claimSet in Model.ClaimSets)
+                        {
+                            <tr>
+                                <td>@Html.CheckBox($"claimSet{claimSet.Id}", new { @class = "claimset-to-export", data_claimset_id = claimSet.Id })</td>
+                                <td>@claimSet.Name</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    }
+}
+<div class="padding-top-5">
+    @Html.Button("Back").AddClass("back-btn back-ajax claimset-back-btn").Data("back-url", Url.Action("ClaimSets", "GlobalSettings"))
+    @Html.Button("Preview").Id("export-preview-button")
+</div>
+<script type="text/javascript">
+    var goToPreview = function (e) {
+        e.preventDefault();
+        var selectedClaimSetIds = [];
+        $(".claimset-to-export:checkbox:checked").each(function () {
+            selectedClaimSetIds.push($(this).data("claimset-id"));
+        });
+        $(".claimset-to-export").removeAttr("name");
+
+        var postData = {
+            'Title': $("#Title").val(),
+            'SelectedForExport': selectedClaimSetIds,
+            'ClaimSets': @Html.Raw(Json.Encode(Model.ClaimSets)),
+            "__RequestVerificationToken": getAntiForgeryToken()
+        };
+
+        var successAdditionalBehavior = function () {
+            ClaimSetToastrMessage("Claimset(s) exported successfully.\nPlease click the download button after previewing the information.", true);
+        };
+        var errorAdditionalBehavior = function () {
+            ClaimSetToastrMessage("There was an error while exporting the Claimset(s)");
+        };
+        var ajaxRequestData = {
+            form: $("#export-claim-set-form"),
+            formData: postData,
+            dataType: "html",
+            successAction : {
+                state: 'exportpreview',
+                url: '@Url.Action("ClaimSets", "GlobalSettings")'
+            },
+            panelId: "claim-set-tab",
+            successAdditionalBehavior: successAdditionalBehavior,
+            errorAdditionalBehavior: errorAdditionalBehavior
+        };
+        submitAjaxForInnerTabs(ajaxRequestData);
+    };
+
+    $('#export-preview-button').click(goToPreview);
+    $(function () {
+        InitializeBackNavigationalAjaxButtons();
+    });
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_ExportClaimSetPreview.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_ExportClaimSetPreview.cshtml
@@ -1,0 +1,40 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets.ExportClaimSetPreviewModel
+
+<h3>Export Claim Set Preview</h3>
+
+<p>Review the content of your export before downloading.</p>
+
+@Html.TextArea("exportJson", Model.ExportPreviewString, new { @readonly = true, rows = 25, cols = 80 })
+
+<div class="padding-top-5">
+    @Html.Button("Back").AddClass("back-btn back-ajax claimset-back-btn").Data("back-url", Url.Action("ClaimSets", "GlobalSettings"))
+    @Html.Button("Download").Id("download-claimset-export-button")
+</div>
+<script type="text/javascript">
+    var saveFile = function (content, fileName, contentType) {
+        var a = document.createElement("a");
+        var file = new Blob([content], {type: contentType});
+        a.href = URL.createObjectURL(file);
+        a.download = fileName;
+        a.click();
+    }
+
+    var downloadFile = function(e) {
+        e.preventDefault();
+        var downloadFileName = @Html.Raw(Json.Encode(Model.DownLoadFileTitle));
+        saveFile($("#exportJson").val(), downloadFileName.concat(".json"), "application/json");
+    }
+
+    $('#download-claimset-export-button').click(downloadFile);
+    $(function () {
+        InitializeBackNavigationalAjaxButtons();
+    });
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_ImportExportClaimSet.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_ImportExportClaimSet.cshtml
@@ -1,0 +1,65 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets.ClaimSetFileImportModel
+
+<h3>Import/Export Claim Set</h3>
+@using (Html.BeginForm("FileImport", "ClaimSets", FormMethod.Post, new { @id = "import-claim-set-form", enctype = "multipart/form-data"}))
+{
+@Html.AntiForgeryToken()
+<div id="import-claim-set-validation-summary" class="validationSummary alert alert-danger" hidden></div>
+<div class="row">
+    <div class="col-md-10">
+        @Html.FileInputBlock(x => x.ImportFile)
+    </div>
+    <div class="col-md-2">
+        @Html.SaveButton("Import").AddClass("no-ajax")
+    </div>
+</div>
+}
+<div class="padding-15 col-lg-offset-6">
+    @Html.Button("Export Claimsets").Attr("href", Url.Action("ExportClaimSetIndex", "ClaimSets")).AddClass("navigational-ajax").Data("state", "edit").Data("page-url", Url.Action("ClaimSets", "GlobalSettings")).Data("action", "exporting Claim Sets")
+</div>
+<div class="padding-top-5">
+    @Html.Button("Back").AddClass("back-btn back-ajax claimset-back-btn").Data("back-url", Url.Action("ClaimSets", "GlobalSettings"))
+</div>
+<script type="text/javascript">
+    $('#import-claim-set-form').submit(function (e) {
+        e.preventDefault();
+        var form = $(this);
+        var validationBlock = $('#import-claim-set-validation-summary')[0];
+        var successHandler = function (data) {
+            validationBlock.hidden = true;
+            ClaimSetToastrMessage("Claimset imported successfully", true);
+            ClaimSetWarningMessage(true);
+            history.replaceState({ state: 'listing' }, "", '@Url.Action("ClaimSets", "GlobalSettings")');
+            $("#global-tab").html($(data).find('#global-tab').html());
+            if (sessionStorage.getItem("LatestDatabaseChangeTimestamp") != null) {
+                $("#claim-set-warning-message").show();
+            }
+        };
+        var errorAdditionalBehavior = function () {
+            ClaimSetToastrMessage("There was an error while importing the Claimset");
+        };
+        var ajaxRequestData = {
+            form: $(this),
+            formData: new FormData(form[0]),
+            cache: false,
+            contentType: false,
+            processData: false,
+            successHandler: successHandler,
+            errorAdditionalBehavior: errorAdditionalBehavior
+        };
+        submitAjaxForInnerTabs(ajaxRequestData);
+    });
+    $(function () {
+        InitializeSubmitButtons();
+        InitializeNavigationalAjaxButtons();
+        InitializeBackNavigationalAjaxButtons();
+    });
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_ResourceEditor.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_ResourceEditor.cshtml
@@ -1,0 +1,145 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using System.Web.Mvc.Html
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets.ClaimSetResourcesModel
+
+<h3>Resources</h3>
+<div class="row padding-15">
+    @if (Model.ResourceClaims.Any())
+    {
+        <table class="table">
+            <thead>
+                <tr>
+                    <th scope="col"></th>
+                    <th scope="col">Resource</th>
+                    <th scope="col">Read</th>
+                    <th scope="col">Create</th>
+                    <th scope="col">Update</th>
+                    <th scope="col">Delete</th>
+                    <th scope="col"></th>
+                    <th scope="col"></th>
+                    <th scope="col"></th>
+                </tr>
+            </thead>
+            <tbody id="resource-claim-table-body">
+                @foreach (var resourceClaim in Model.ResourceClaims)
+                {
+                    <tr class="parent-resource-claim">
+                        <td class="icon-cell">
+                            @if (resourceClaim.Children.Any())
+                            {<a class="claims-toggle" data-resource-id='@resourceClaim.Id'><span class="fa fa-chevron-down caret-custom"></span></a>}
+                        </td>
+                        <td data-resource-id='@resourceClaim.Id' class="resource-label">@resourceClaim.Name</td>
+                        <td class="read-action-cell">
+                            @Html.CheckBoxSquare(resourceClaim.Read, "read")
+                        </td>
+                        <td class="create-action-cell">
+                            @Html.CheckBoxSquare(resourceClaim.Create, "create")
+                        </td>
+                        <td class="update-action-cell">
+                            @Html.CheckBoxSquare(resourceClaim.Update, "update")
+                        </td>
+                        <td class="delete-action-cell">
+                            @Html.CheckBoxSquare(resourceClaim.Delete, "delete")
+                        </td>
+                        <td>
+                            <a class="edit-resource"> <span class="fa fa-pencil action-icons"></span></a>
+                        </td>
+                        <td>
+                            <a class="loads-ajax-modal" data-url="@Url.Action("AuthStrategyModal","ClaimSets", new {claimSetId = Model.ClaimSetId, resourceClaimId = resourceClaim.Id})"> <span class="fa fa-info-circle action-icons"></span></a>
+                        </td>
+                        <td>
+                            <a class="loads-ajax-modal" data-url="@Url.Action("DeleteResourceOnClaimSetModal","ClaimSets", new {claimSetId = Model.ClaimSetId, resourceClaimId = resourceClaim.Id, claimSetName = Model.ClaimSetName, resourceName = resourceClaim.Name})"> <span class="fa fa-trash-o action-icons"></span></a>
+                        </td>
+                    </tr>
+
+                    foreach (var childResourceClaim in resourceClaim.Children)
+                    {
+                        <tr class="child-resource-claim" style="display: none">
+                            <td class="icon-cell">
+                                <span class="child-resource-branch"></span>
+                            </td>
+                            <td data-resource-id='@childResourceClaim.Id' data-parent-id='@resourceClaim.Id' class="resource-label">@childResourceClaim.Name</td>
+                            <td class="read-action-cell">
+                                @Html.CheckBoxSquare(childResourceClaim.Read, "read")
+                            </td>
+                            <td class="create-action-cell">
+                                @Html.CheckBoxSquare(childResourceClaim.Create, "create")
+                            </td>
+                            <td class="update-action-cell">
+                                @Html.CheckBoxSquare(childResourceClaim.Update, "update")
+                            </td>
+                            <td class="delete-action-cell">
+                                @Html.CheckBoxSquare(childResourceClaim.Delete, "delete")
+                            </td>
+                            <td>
+                                <a class="edit-resource"> <span class="fa fa-pencil action-icons"></span></a>
+                            </td>
+                            <td>
+                                <a class="loads-ajax-modal" data-url="@Url.Action("AuthStrategyModal","ClaimSets", new {claimSetId = Model.ClaimSetId, resourceClaimId = childResourceClaim.Id})"> <span class="fa fa-info-circle action-icons"></span></a>
+                            </td>
+                            <td>
+                                <a class="loads-ajax-modal" data-url="@Url.Action("DeleteResourceOnClaimSetModal","ClaimSets", new {claimSetId = Model.ClaimSetId, resourceClaimId = childResourceClaim.Id, claimSetName = Model.ClaimSetName, resourceName = childResourceClaim.Name})"> <span class="fa fa-trash-o action-icons"></span></a>
+                            </td>
+                        </tr>
+                    }
+                    <tr class="child-resource-claim" data-parent-id='@resourceClaim.Id' id="child-dropdown-row-@resourceClaim.Id" style="display: none">
+                        <td class="icon-cell">
+                        </td>
+                        <td class="child-dropdown">
+                            @Html.DropDownList("ChildResourceClaimsDropDown", new SelectList(Enumerable.Empty<SelectListItem>()), new {@id= $"child-resource-dropdown-{resourceClaim.Id}"})
+                        </td>
+                        <td colspan="7">
+                            @Html.Button("Add Child Resource").Attr("type", "button").AddClass("add-child-resource-button").Attr("data-parent-id", $"{@resourceClaim.Id}")
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+
+    }
+    else
+    {
+        <table class="table">
+            <thead>
+                <tr>
+                    <th scope="col"></th>
+                    <th scope="col">Resource</th>
+                    <th scope="col">Read</th>
+                    <th scope="col">Create</th>
+                    <th scope="col">Update</th>
+                    <th scope="col">Delete</th>
+                    <th scope="col"></th>
+                    <th scope="col"></th>
+                    <th scope="col"></th>
+                </tr>
+            </thead>
+            <tbody id="resource-claim-table-body"></tbody>
+        </table>
+    }
+    <div class="col-md-8">
+        @Html.DropDownList("ResourceClaimsDropDown", Model.AllResourceClaims, new { @class = "resource-claim-dropdown" })
+    </div>
+    <div class="col-md-4">
+        @Html.Button("Add Resource").Attr("type", "button").Id("add-resource-button")
+    </div>
+</div>
+
+<script type="text/javascript">
+    var editResourceUrl = '@Url.Action("EditResourceOnClaimSet", "ClaimSets")';
+    var claimSetsUrl = '@Url.Action("ClaimSets", "GlobalSettings")';
+    var deleteResourceUrl = '@Url.Action("DeleteResourceOnClaimSet", "ClaimSets")';
+    var deleteResourceModalUrl = '@Url.Action("DeleteResourceOnClaimSetModal", "ClaimSets")';
+    var overrideAuthStrategyModalUrl = '@Url.Action("AuthStrategyModal", "ClaimSets")';
+    var claimSetInfo = @Html.Raw(Json.Encode(new { claimSetId = Model.ClaimSetId, claimSetName = Model.ClaimSetName}));
+    var existingResources = @Html.Raw(Json.Encode(Model.ResourceClaims));
+    var childResourcesForParentUrl = '@Url.Action("GetSelectListForChildResourceClaims", "ClaimSets")';
+    InitializeModalLoaders();
+</script>  
+@Scripts.Render("~/bundles/scripts/claimset")

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Descriptors/_Descriptor.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Descriptors/_Descriptor.cshtml
@@ -1,0 +1,28 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@model List<EdFi.Ods.AdminApp.Web.Models.ViewModels.Descriptors.DescriptorModel>
+
+@if (!Model.Any())
+{
+    <div class="col-md-12">
+        <h6>There are no descriptors in this category</h6>
+    </div>
+}
+else
+{
+    foreach (var descriptor in Model)
+    {
+        <div class="col-md-6">
+            <h6>@descriptor.Description</h6>
+            <ul>
+                <li class="small text-muted margin-left">@descriptor.Namespace</li>
+            </ul>
+        </div>
+    }
+}
+

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Descriptors/_DescriptorCategories.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Descriptors/_DescriptorCategories.cshtml
@@ -1,0 +1,63 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.Descriptors.DescriptorCategoriesModel
+
+<div class="row margin-bottom">
+    <div class="col-lg-12">
+        <h6>Descriptors</h6>
+    </div>
+</div>
+
+@foreach (var category in Model.DescriptorCategories)
+{
+    <div class="panel-section">
+        <div class="row heading">
+            <div class="col-xs-8">
+                <h7>@category</h7>
+            </div>
+            <div class="col-xs-4 text-right">
+                <span class="custom-divider"> |</span>
+                <a href="javascript:void(0)" class="descriptor-panel-toggle" data-target="#descriptor-@(category)"><span class="fa fa-chevron-down caret-custom panel-toggle"></span></a>
+            </div>
+            <div id="descriptor-@(category)" data-category="@category" class="row content collapse panel-loading">
+                <i class="fa fa-spinner fa-pulse fa-fw"></i>
+            </div>
+        </div>
+    </div>
+}
+
+<script type="text/javascript">
+    $(".descriptor-panel-toggle").click(function () {
+        var $toggleLink = $(this);
+        var target = $toggleLink.attr("data-target");
+        var $panel = $(target);
+        $panel.collapse("toggle");
+
+        if ($toggleLink.hasClass("initialized")) {
+            return;
+        }
+        $toggleLink.addClass("initialized");
+
+        if ($panel.hasClass("panel-loading")) {
+            var category = $panel.attr("data-category");
+            var url = "@Html.Raw(Url.Action("GetDescriptorsFromCategoryName", "Descriptors", new { }))" + "?category=" + category;
+            $.ajax({
+                url: url,
+                success: function (data) {
+                    $panel.html(data);
+                },
+                error: function() {
+                    $panel.html("<em class='text-danger margin-top'>An error occured loading the descriptors for this category</em>");
+                },
+                complete: function() {
+                    $panel.removeClass("panel-loading");
+                }
+            });
+        }
+    });
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/EducationOrganizations/_AddLocalEducationAgencyModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/EducationOrganizations/_AddLocalEducationAgencyModal.cshtml
@@ -1,0 +1,54 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Management.Instances
+@using EdFi.Ods.AdminApp.Web.Helpers
+@using EdFi.Ods.AdminApp.Web.Infrastructure
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations.AddLocalEducationAgencyModel
+
+<div id ="add-lea-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="addLEAModal" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Add Local Education Agency</h4>
+            </div>
+        @if (Model.RequiredApiDataExist)
+        {
+            <div class="modal-body center-block text-center">
+                @using (Html.BeginForm("AddLocalEducationAgency", "EducationOrganizations"))
+                {
+                    @Html.ValidationBlock()
+                    if (CloudOdsAdminAppSettings.Instance.Mode == ApiMode.DistrictSpecific)
+                    {
+                        @Html.InputBlock(m => m.LocalEducationAgencyId, inputModifier:x => x.Attr("readonly", "readonly"))
+                    }
+                    else
+                    {
+                        @Html.InputBlock(m => m.LocalEducationAgencyId)
+                    }
+                    @Html.SelectListBlock(m => m.LocalEducationAgencyCategoryType, Model.LocalEducationAgencyCategoryTypeOptions, x => new SelectListItem {Text = x.DisplayText, Value = x.Value})
+                    @Html.InputBlock(m => m.Name)
+                    @Html.InputBlock(m => m.StreetNumberName)
+                    @Html.InputBlock(m => m.ApartmentRoomSuiteNumber)
+                    @Html.InputBlock(m => m.City)
+                    @Html.SelectListBlock(m => m.State, Model.StateOptions, x => new SelectListItem {Text = x.DisplayText, Value = x.Value})
+                    @Html.InputBlock(m => m.ZipCode)
+                }
+            </div>
+            <div class="modal-footer">
+                @Html.CancelModalButton()
+                @Html.SaveButton("Add").AppendSpinner("add-lea-spinner")
+            </div>
+        }
+        else
+        {
+          @Html.Partial("_MissingData")
+        }
+        </div>
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/EducationOrganizations/_AddSchoolModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/EducationOrganizations/_AddSchoolModal.cshtml
@@ -1,0 +1,57 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations.AddSchoolModel
+
+<div id="add-school-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="addSchoolModal" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Add School</h4>
+            </div>
+        @if (Model.RequiredApiDataExist)
+        {
+            <div class="modal-body center-block text-center">
+                @using (Html.BeginForm("AddSchool", "EducationOrganizations"))
+                {
+                    @Html.Input(m => m.LocalEducationAgencyId).Id("add-school-lea-id").Hide()
+                    @Html.ValidationBlock()
+                    @Html.InputBlock(m => m.SchoolId)
+                    @Html.MultiSelectListBlock(m => m.GradeLevels, Model.GradeLevelOptions, x => new SelectListItem {Text = x.DisplayText, Value = x.Value})
+                    @Html.InputBlock(m => m.Name)
+                    @Html.InputBlock(m => m.StreetNumberName)
+                    @Html.InputBlock(m => m.ApartmentRoomSuiteNumber)
+                    @Html.InputBlock(m => m.City)
+                    @Html.SelectListBlock(m => m.State, Model.StateOptions, x => new SelectListItem {Text = x.DisplayText, Value = x.Value})
+                    @Html.InputBlock(m => m.ZipCode)
+                }
+            </div>
+            <div class="modal-footer">
+                @Html.CancelModalButton()
+                @Html.SaveButton("Add").AppendSpinner("add-lea-spinner")
+            </div>
+        }
+        else
+        {
+            @Html.Partial("_MissingData")
+        }
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+    $(function() {
+        $(".add-school-button").click(function () {
+            var $modal = $("#add-school-modal");
+            var leaId = $(this).attr("data-lea-id");
+            $modal.find("#add-school-lea-id").val(leaId);
+            $modal.modal("show");
+        });
+    });
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/EducationOrganizations/_DeleteOrganizationModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/EducationOrganizations/_DeleteOrganizationModal.cshtml
@@ -1,0 +1,64 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations.DeleteEducationOrganizationModel
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+<div id="delete-edorg-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="deleteEdorgModal" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Delete Education Organization</h4>
+            </div>
+            <div class="modal-body">
+                @using (Html.BeginForm(null, null))
+                {
+                    @Html.Input(m => m.Id).Id("delete-edorg-id").Hide()
+                }
+                <div class="alert alert-danger">
+                    <div class="padding-bottom-10">
+                        Are you sure you want to permanently delete <strong id="delete-edorg-name"></strong>?
+                    </div>
+                    <div>
+                        <ul>
+                            <li>Note: Deletion will fail if there is other data in the Ed-Fi ODS that depends on the organization</li>
+                            <li>This action cannot be undone</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                @Html.ModalFormButtons("Delete")
+            </div>
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+    $(function () {
+        $(".delete-lea-link").click(function () {
+            var name = $(this).attr("data-name");
+            var id = $(this).attr("data-id");
+            ShowDeleteEdOrgModal(name, id, "@(Html.Raw(Url.Action("DeleteLocalEducationAgency", "EducationOrganizations")))");
+        });
+
+        $(".delete-school-link").click(function () {
+            var name = $(this).attr("data-name");
+            var id = $(this).attr("data-id");
+            ShowDeleteEdOrgModal(name, id, "@(Html.Raw(Url.Action("DeleteSchool", "EducationOrganizations")))");
+        });
+    });
+
+    function ShowDeleteEdOrgModal(organizationName, organizationId, url) {
+        var $deleteEdOrgModal = $("#delete-edorg-modal");
+        $deleteEdOrgModal.find("form").attr("action", url);
+        $deleteEdOrgModal.find("#delete-edorg-name").text(organizationName);
+        $deleteEdOrgModal.find("#delete-edorg-id").val(organizationId);
+        $deleteEdOrgModal.modal("show");
+    }
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/EducationOrganizations/_EditLocalEducationAgencyModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/EducationOrganizations/_EditLocalEducationAgencyModal.cshtml
@@ -1,0 +1,39 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations.EditLocalEducationAgencyModel
+
+<div id="add-lea-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="addLEAModal" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Edit Local Education Agency</h4>
+            </div>
+            <div class="modal-body center-block text-center">
+                @using (Html.BeginForm("EditLocalEducationAgency", "EducationOrganizations"))
+                {
+                    @Html.Input(m => m.Id).Hide()
+                    @Html.Input(m => m.LocalEducationAgencyId).Hide()
+                    @Html.ValidationBlock()
+                    @Html.SelectListBlock(m => m.LocalEducationAgencyCategoryType, Model.LocalEducationAgencyCategoryTypeOptions, x => new SelectListItem { Text = x.DisplayText, Value = x.Value, Selected = (Model.LocalEducationAgencyCategoryType == x.Value) })
+                    @Html.InputBlock(m => m.Name)
+                    @Html.InputBlock(m => m.StreetNumberName)
+                    @Html.InputBlock(m => m.ApartmentRoomSuiteNumber)
+                    @Html.InputBlock(m => m.City)
+                    @Html.SelectListBlock(m => m.State, Model.StateOptions, x => new SelectListItem { Text = x.DisplayText, Value = x.Value, Selected = Model.State == x.Value })
+                    @Html.InputBlock(m => m.ZipCode)
+                }
+            </div>
+            <div class="modal-footer">
+                @Html.CancelModalButton()
+                @Html.SaveButton("Save Changes").AppendSpinner("edit-lea-spinner")
+            </div>
+        </div>
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/EducationOrganizations/_EditSchoolModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/EducationOrganizations/_EditSchoolModal.cshtml
@@ -1,0 +1,40 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations.EditSchoolModel
+
+<div id="add-school-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="addSchoolModal" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Edit School</h4>
+            </div>
+            <div class="modal-body center-block text-center">
+                @using (Html.BeginForm("EditSchool", "EducationOrganizations"))
+                {
+                    @Html.Input(m => m.Id).Hide()
+                    @Html.Input(m => m.SchoolId).Hide()
+                    @Html.Input(m => m.LocalEducationAgencyId).Hide()
+                    @Html.ValidationBlock()
+                    @Html.MultiSelectListBlock(m => m.GradeLevels, Model.GradeLevelOptions, x => new SelectListItem { Text = x.DisplayText, Value = x.Value, Selected = (Model.GradeLevels != null && Model.GradeLevels.Contains(x.Value)) })
+                    @Html.InputBlock(m => m.Name)
+                    @Html.InputBlock(m => m.StreetNumberName)
+                    @Html.InputBlock(m => m.ApartmentRoomSuiteNumber)
+                    @Html.InputBlock(m => m.City)
+                    @Html.SelectListBlock(m => m.State, Model.StateOptions, x => new SelectListItem { Text = x.DisplayText, Value = x.Value, Selected = Model.State == x.Value })
+                    @Html.InputBlock(m => m.ZipCode)
+                }
+            </div>
+            <div class="modal-footer">
+                @Html.CancelModalButton()
+                @Html.SaveButton("Save Changes").AppendSpinner("edit-school-spinner")
+            </div>
+        </div>
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/EducationOrganizations/_EducationOrganizations.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/EducationOrganizations/_EducationOrganizations.cshtml
@@ -1,0 +1,79 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizationViewModel
+
+<div class="row margin-bottom">
+    <div class="col-lg-6">
+        <h6>Education Organizations</h6>
+    </div>
+
+    @if (!Model.LocalEducationAgencies.Any() || Model.ShouldAllowMultipleDistricts)
+    {
+        <div class="col-lg-6 text-right">
+            <button class="cta" data-toggle="modal" data-target="#add-lea-modal">
+                Add Local Education Agency
+            </button>
+        </div>
+    }
+</div>
+
+@foreach (var localEducationAgency in Model.LocalEducationAgencies)
+{
+    var schools = Model.Schools.Where(x => x.LocalEducationAgencyId == localEducationAgency.EducationOrganizationId).ToList();
+
+    <div class="panel-section">
+        <div class="row heading">
+            <div class="col-lg-6">
+                <h8>@localEducationAgency.Name</h8>
+            </div>
+
+            <div class="col-lg-6 text-right">
+                <a href="javascript:void(0)" class="loads-ajax-modal" data-url="@Url.Action("EditLocalEducationAgencyModal", "EducationOrganizations", new {id = localEducationAgency.Id})"> <span class="fa fa-pencil action-icons"></span></a>
+                @if (!schools.Any())
+                {
+                    <a href="javascript:void(0)" class="delete-lea-link" data-id="@localEducationAgency.Id" data-name="@localEducationAgency.Name"> <span class="fa fa-trash-o action-icons"></span></a>
+                }
+                else
+                {
+                    <a href="javascript:void(0)" data-name="@localEducationAgency.Name"> <span class="fa fa-trash-o action-icons disabled"></span></a>
+                }
+                <span class="custom-divider"> |</span>
+                <a href="javascript:void(0)" data-toggle="collapse" data-target="#lea-@(localEducationAgency.Id)"><span class="fa fa-chevron-up caret-custom panel-toggle"></span></a>
+            </div>
+        </div>
+        <div id="lea-@(localEducationAgency.Id)" class="row content collapse in">
+            @if (!schools.Any())
+            {
+                <div class="col-lg-12">
+                    <em>There are no schools in this category</em>
+                </div>
+            }
+            @foreach (var school in schools)
+            {
+                <div class="col-lg-8">
+                    <h7>@school.Name</h7>
+                </div>
+                <div class="col-lg-4 text-right">
+                    <a href="javascript:void(0)" class="loads-ajax-modal" data-url="@Url.Action("EditSchoolModal", "EducationOrganizations", new {id = school.Id})"> <span class="fa fa-pencil action-icons"></span></a>
+                    <a href="javascript:void(0)" class="delete-school-link" data-id="@school.Id" data-name="@school.Name"> <span class="fa fa-trash-o action-icons"></span></a>
+                </div>
+            }
+            <div class="col-lg-12 text-right padding-bottom-5">
+                <button class="ghost-button btn-sm add-school-button" data-lea-id="@(localEducationAgency.EducationOrganizationId)">
+                    Add School
+                </button>
+            </div>
+        </div>
+    </div>
+}
+
+@{ Html.RenderPartial("_DeleteOrganizationModal", new DeleteEducationOrganizationModel()); }
+@{ Html.RenderAction("AddLocalEducationAgencyModal", "EducationOrganizations"); }
+@{ Html.RenderAction("AddSchoolModal", "EducationOrganizations"); }
+

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/EducationOrganizations/_MissingData.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/EducationOrganizations/_MissingData.cshtml
@@ -1,0 +1,20 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+<div class="modal-body">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="well">
+                <strong>Required descriptors are missing (GradeLevelDescriptor and EducationOrganizationCategoryDescriptor). Please make sure required descriptors are available before adding education organizations.</strong>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="modal-footer">
+    @Html.CancelModalButton()
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Error/MultiInstanceError.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Error/MultiInstanceError.cshtml
@@ -1,0 +1,15 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+<div class="row">
+    <div class="col-md-12">
+        <h5>Invalid configuration</h5>
+        A previous version of Admin App was already setup and this version cannot continue to function. See the <a href="https://techdocs.ed-fi.org/display/ADMIN/Known+Issues">Known Issues</a> documentation page to rerun Admin App setup in this mode, or switch back to using the previous mode.
+        <br>
+        <a href="javascript:history.go(-1);">Back</a>
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Error/NotYetImplemented.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Error/NotYetImplemented.cshtml
@@ -1,0 +1,19 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+
+@{
+    ViewBag.Title = "Not Yet Implemented";
+}
+
+<div class="row">
+    <div class="col-md-12">
+        <h4>This feature is not yet available</h4>
+        <br />
+        <a href="javascript:history.go(-1);">Back</a>
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/GlobalSettings/AdvancedSettings.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/GlobalSettings/AdvancedSettings.cshtml
@@ -1,0 +1,33 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.Global.GlobalSettingsModel
+
+@{
+    Layout = "~/Views/Shared/_Settings_Global.cshtml";
+    ViewBag.Title = "Global | Advanced Settings";
+}
+
+<div class="tab-content" style="margin-top: 30px">
+    <div class="tab-pane active" id="global-advanced">
+        @using (Html.BeginForm("UpdateAdvancedSettings", "GlobalSettings"))
+        {
+            <div class="row subsection">
+                <div class="col-lg-12">
+                    @Html.InputBlock(m => m.AdvancedSettingsModel.BearerTokenTimeoutInMinutes, "Bearer Token Timeout (Minutes)", "Controls the frequency at which applications calling the Ed-Fi ODS API must re-login")
+                </div>
+            </div>
+            <hr/>
+            <div class="row">
+                <div class="col-lg-12 text-right">
+                    @Html.SaveButton().AppendSpinner("advanced-settings-update-button")
+                </div>
+            </div>
+        }
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/GlobalSettings/ClaimSets.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/GlobalSettings/ClaimSets.cshtml
@@ -1,0 +1,71 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@using EdFi.Ods.AdminApp.Web.Infrastructure
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.Global
+@model GlobalSettingsModel
+
+@{
+    Layout = "~/Views/Shared/_Settings_Global.cshtml";
+    ViewBag.Title = "Global | Claim Sets";
+}
+<div id="claim-set-warning-message" class="alert alert-danger margin-top-10" role="alert" hidden>
+    <p>
+        <strong>Please reset IIS or wait <span id="claim-set-warning-time"></span> for the latest claimset changes to take effect.</strong>
+    </p>
+</div>
+<div class="tab-content margin-top-10" id="claims-list">
+    <div id="claim-set-tab" class="tab-pane active navigational-index col-lg-8">
+        <div align="right">
+            @Html.Button("Add Claim Set").Attr("href", Url.Action("AddClaimSet", "ClaimSets")).AddClass("add-claimset navigational-ajax").Data("state", "add").Data("page-url", Url.Action("ClaimSets", "GlobalSettings")).Data("action", "opening Add Claim Set")
+            @Html.Button("Import/Export Claim Set").Attr("href", Url.Action("ImportExportClaimSet", "ClaimSets")).AddClass("import-export-claimset navigational-ajax").Data("state", "import").Data("page-url", Url.Action("ClaimSets", "GlobalSettings")).Data("action", "opening Import/Export Claim Set")
+        </div>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th scope="col">Claim Set Name</th>
+                    <th scope="col">Applications in Use</th>
+                    <th scope="col"></th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var claimSet in Model.ClaimSetEditorModel.ClaimSets)
+                {
+                    <tr>
+                        <th scope="row">
+                            <a class="details-link navigational-ajax" data-state="details" data-page-url="@Url.Action("ClaimSets", "GlobalSettings")" data-action="loading the Claim Set" href="@Url.Action("ClaimSetDetails", "ClaimSets", new {claimSetId = claimSet.Id})">
+                                @claimSet.Name
+                            </a>
+                        </th>
+                        <td>@claimSet.ApplicationsCount</td>
+                        <td>
+                            <div class="text-right">
+                                <a class="loads-ajax-modal" data-url="@Url.Action("CopyClaimSetModal","ClaimSets", new {claimSetId = claimSet.Id})"> <span class="fa fa-copy action-icons"></span></a>
+                                @if (claimSet.IsEditable)
+                                {
+                                    <a class="edit-claimset navigational-ajax" data-state="edit" data-page-url="@Url.Action("ClaimSets", "GlobalSettings")" data-action="editing the Claim Set" href="@Url.Action("EditClaimSet", "ClaimSets", new {claimSetId = claimSet.Id})">
+                                         <span class="fa fa-pencil action-icons"></span>
+                                    </a>
+                                    <a class="loads-ajax-modal" data-url="@Url.Action("DeleteClaimSetModal","ClaimSets", new {claimSetId = claimSet.Id})"> <span class="fa fa-trash-o action-icons"></span></a>
+                                }
+                            </div>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<script type="text/javascript">
+    var cacheTimeout = '@CloudOdsAdminAppSettings.Instance.SecurityMetadataCacheTimeoutMinutes';
+    $(function () {
+        InitializeModalLoaders();
+        InitializeNavigationalAjaxButtons();
+    });
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/GlobalSettings/Users.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/GlobalSettings/Users.cshtml
@@ -1,0 +1,77 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Management.Database.Models
+@using EdFi.Ods.AdminApp.Web.Infrastructure
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.Global
+@using Microsoft.AspNet.Identity
+@model GlobalSettingsModel
+
+@{
+    Layout = "~/Views/Shared/_Settings_Global.cshtml";
+    ViewBag.Title = "Global | Users";
+}
+<div class="tab-content margin-top-10" id="user-list">
+    <div id="adminapp-user-tab" class="tab-pane active padding-15">
+        <div align="right">
+            @Html.ActionLink("Add User", "AddUser", "User", null, new { @class = "btn btn-primary cta"})
+        </div>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th scope="col">User Name</th>
+                    <th scope="col"></th>
+                    <th scope="col"></th>
+                    <th scope="col"></th>
+                </tr>
+            </thead>
+            <tbody>
+            @foreach (var user in Model.UserIndexModel.Users)
+            {
+                <tr>
+                    <th scope="row">@user.UserName</th>
+                    <td colspan="3">
+                        <div class="text-right col-md-offset-8 col-md-4">
+                            <div class="col-md-3">
+                                <a class="loads-ajax-modal" data-toggle="tooltip" title="Edit User Profile" data-url="@Url.Action("EditUser", "User", new {userId = user.UserId})"><span class="fa fa-pencil action-icons"></span></a>
+                            </div>
+                            <div class="col-md-3">
+                                @if (CloudOdsAdminAppSettings.Instance.Mode.SupportsMultipleInstances)
+                                {
+                                    <a data-toggle="tooltip" title="Manage User Ods Instances" href="@Url.Action("EditOdsInstanceRegistrationsForUser", "User", new {userId = user.UserId})"> <span class="fa fa-server action-icons"></span></a>
+                                }
+                            </div>
+                            <div class="col-md-3">
+                                @if (User.Identity.GetUserId() != user.UserId)
+                                {
+                                    <a class="loads-ajax-modal" data-toggle="tooltip" title="Edit User Role" data-url="@Url.Action("EditUserRole", "User", new {userId = user.UserId})"><span class="fa fa-user action-icons"></span></a>
+                                }
+                                else if(User.IsInRole(Role.SuperAdmin.DisplayName))
+                                {
+                                    <a style="opacity: 0.50;" data-toggle="tooltip" title="You are a Super Administrator!" ><span class="fa fa-user action-icons"></span></a>                                                          
+                                }
+
+                            </div>
+                            <div class="col-md-3">
+                                @if (User.Identity.GetUserId() != user.UserId)
+                                {
+                                    <a class="loads-ajax-modal" data-toggle="tooltip" title="Delete User" data-url="@Url.Action("DeleteUser", "User", new {userId = user.UserId})"><span class="fa fa-trash action-icons"></span></a>
+                                }
+                            </div>
+                        </div>
+                </tr>
+            }
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<script type="text/javascript">
+    $(function () {
+        InitializeModalLoaders();
+    });
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/GlobalSettings/Vendors.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/GlobalSettings/Vendors.cshtml
@@ -1,0 +1,57 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Management.Instances
+@using EdFi.Ods.AdminApp.Web.Infrastructure
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.Global
+@model GlobalSettingsModel
+
+@{
+    Layout = "~/Views/Shared/_Settings_Global.cshtml";
+    ViewBag.Title = "Global | Vendors";
+}
+
+<div class="tab-content margin-top-10">
+    <div class="tab-pane active" id="global-vendors">
+        <div class="row subsection">
+            <div class="col-lg-12">
+                @{ Html.RenderPartial("_SecurityHelpfulHints"); }
+            </div>
+        </div>
+        <div class="row subsection-headline">
+            <div class="col-lg-6">
+                <h7><img class="padding-right" src="~/Content/images/vendor-icon@2x.png" alt=""/>Vendors</h7>
+            </div>
+            <div class="col-lg-6 text-right">
+                <button class="btn btn-primary cta" data-toggle="modal" data-target=".add-vendor-modal">
+                    Add Vendor
+                </button>
+                @if (Model.VendorListModel.Vendors.Any())
+                {
+                    var applicationsUrl = Url.Action("Applications", "OdsInstanceSettings");
+
+                    if (CloudOdsAdminAppSettings.Instance.Mode.SupportsMultipleInstances)
+                    {
+                        // Take the user to the instance selection screen, trusting that they will
+                        // then land on the Applications tab for that instance.
+
+                        applicationsUrl = Url.Action("Index", "OdsInstances");
+                    }
+
+                    <a class="btn btn-primary cta" href="@applicationsUrl">Define Applications</a>
+                }
+            </div>
+        </div>
+        <div class="row subsection">
+            <div class="col-lg-12">
+                @{ Html.RenderPartial("_VendorsTable", Model.VendorListModel); }
+            </div>
+        </div>
+    </div>
+</div>
+
+@{ Html.RenderPartial("_AddVendorModal", new AddVendorModel()); }

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/GlobalSettings/_AddVendorModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/GlobalSettings/_AddVendorModal.cshtml
@@ -1,0 +1,34 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.Global.AddVendorModel
+
+<div class="modal fade add-vendor-modal" tabindex="-1" role="dialog" aria-labelledby="addVendorModal" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Add Vendor</h4>
+            </div>
+            <div class="modal-body center-block text-center">
+                @using (Html.BeginForm("AddVendor", "GlobalSettings"))
+                {
+                    @Html.ValidationBlock()
+                    @Html.InputBlock(m => m.Company, "Vendor Name")
+                    @Html.InputBlock(m => m.NamespacePrefix, "http://vendorwebsite.com")
+                    @Html.InputBlock(m => m.ContactName, "Jane Smith")
+                    @Html.InputBlock(m => m.ContactEmailAddress, "email@vendorwebsite.com")
+                }
+            </div>
+            <div class="modal-footer">
+                @Html.ModalFormButtons()
+            </div>
+        </div>
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/GlobalSettings/_EditVendorForm.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/GlobalSettings/_EditVendorForm.cshtml
@@ -1,0 +1,28 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.Global.EditVendorModel
+
+@if (Model == null)
+{
+    <div class="alert alert-danger">
+        This vendor cannot be found. It may have been recently deleted.
+    </div>
+}
+else
+{
+    using (Html.BeginForm("EditVendor", "GlobalSettings"))
+    {
+        @Html.ValidationBlock()
+        @Html.Input(m => m.VendorId).Hide()
+        @Html.InputBlock(m => m.Company, "Vendor Name")
+        @Html.InputBlock(m => m.NamespacePrefix, "http://vendorwebsite.com")
+        @Html.InputBlock(m => m.ContactName, "Jane Smith")
+        @Html.InputBlock(m => m.ContactEmailAddress, "email@vendorwebsite.com")
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/GlobalSettings/_EditVendorModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/GlobalSettings/_EditVendorModal.cshtml
@@ -1,0 +1,46 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.Global.EditVendorModel
+
+<div id="edit-vendor-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="editVendorModal" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Edit Vendor</h4>
+            </div>
+            <div class="modal-body center-block text-center">
+                @{ Html.RenderPartial("_EditVendorForm", Model);}
+            </div>
+            <div class="modal-footer">
+                @Html.ModalFormButtons()
+            </div>
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+    $(function () {
+        $(".edit-vendor-link").click(function (e) {
+            var id = $(this).attr("data-id");
+            var $editVendorModal = $("#edit-vendor-modal");
+            if ($editVendorModal.is(':visible')) {
+                $editVendorModal.modal("hide");
+            } else {
+                var editFormUrl = '@Url.Action("EditVendor", "GlobalSettings")' + '/' + id;
+                ShowNewLoadingOverlay($(this).closest(".row"), "loading-edit-vendor");
+                var $modalBody = $editVendorModal.find(".modal-body");
+                $modalBody.load(editFormUrl, null, function () {
+                    DestroyLoadingOverlay("loading-edit-vendor");
+                    $editVendorModal.modal("show");
+                });
+            }
+        });
+    });
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/GlobalSettings/_SecurityHelpfulHints.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/GlobalSettings/_SecurityHelpfulHints.cshtml
@@ -1,0 +1,49 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+<div id="show-security-hint-link" class="pull-right" style="display: none">
+    <a href="javascript:void(0)">
+        <em class="text-muted">Ed-Fi ODS Security Help</em>
+        <span class="fa fa-question-circle-o"></span>
+    </a>
+</div>
+<div id="security-hint" class="collapse">
+    <div class="alert alert-success message center-block">
+        <a id="hide-security-hint-link" href="javascript:void(0)" class="close" aria-label="close">&times;</a>
+        <div class="row">
+            <div class="col-lg-12 hint-container">
+                <h6>Ed-Fi ODS Security Help</h6>
+                <p>In order to set up the security of your Ed-Fi ODS installation, you need to complete the following workflow. Note that Applications are managed on a per ODS instance basis.</p>
+                <img class="hint-image" src="~/Content/images/hint@2x.png" alt="Security Helpful Hint" />
+            </div>
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+    $(function() {
+        var hideSecurityHint = localStorage.getItem("HideSecurityHelpfulHint");
+        if (StringIsNullOrWhitespace(hideSecurityHint)) {
+            $("#security-hint").addClass("in");
+        } else {
+            $('#show-security-hint-link').show();
+        }
+    });
+
+    $('#hide-security-hint-link').click(function () {
+        $('#hide-security-hint-link').hide();
+        $('#security-hint').collapse('hide');
+        $('#show-security-hint-link').show();
+        localStorage.setItem("HideSecurityHelpfulHint", "true");
+    });
+    $('#show-security-hint-link').click(function () {
+        $('#security-hint').collapse('show');
+        $('#hide-security-hint-link').show();
+        $('#show-security-hint-link').hide();
+        localStorage.removeItem("HideSecurityHelpfulHint");
+    });
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/GlobalSettings/_VendorsTable.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/GlobalSettings/_VendorsTable.cshtml
@@ -1,0 +1,43 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.Global
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.Global.VendorsListModel
+
+<table class="table table-hover table-custom">
+    <thead class="thead-inverse">
+        <tr class="tr-custom">
+            <th>Name</th>
+            <th>Name Space Prefix </th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach (var vendor in Model.Vendors)
+    {
+        <tr class="tr-custom">
+            <th>@vendor.VendorName.ToTitleCase()</th>
+            <td>@vendor.NamespacePrefix</td>
+            <td>
+                <a title="Edit Vendor" href="javascript:void(0)" class="edit-table edit-vendor-link" data-id="@vendor.VendorId"> <span class="fa fa-pencil action-icons"></span></a>
+                <a title="Delete Vendor" href="javascript:void(0)" class="delete-vendor-link" data-id="@vendor.VendorId" data-name="@vendor.VendorName"> <span class="fa fa-trash-o action-icons"></span></a>
+            </td>
+        </tr>
+    }
+    </tbody>
+</table>
+
+@if (!Model.Vendors.Any())
+{
+    <div class="alert alert-info message center-block">
+        <em>Added vendors will appear here</em>
+    </div>
+}
+
+@{ Html.RenderPartial("_DeleteVendorModal", new DeleteVendorModel()); }
+@{ Html.RenderPartial("_EditVendorModal", new EditVendorModel()); }

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Home/Index.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Home/Index.cshtml
@@ -1,12 +1,124 @@
-﻿@*
+@*
 SPDX-License-Identifier: Apache-2.0
 Licensed to the Ed-Fi Alliance under one or more agreements.
 The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 See the LICENSE and NOTICES files in the project root for more information.
 *@
 
-@{
-    ViewData["Title"] = "Home Page";
+@using EdFi.Ods.AdminApp.Web.Display.HomeScreen
+@using EdFi.Ods.AdminApp.Web.Infrastructure
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.Home.IndexModel
+
+@functions
+{
+    public string GetCssClassName(bool isEnabled)
+    {
+        return isEnabled ?  "" :  "disabled";
+    }
 }
 
-<h1>@ViewData["Title"]</h1>
+@{
+    ViewBag.Title = "Home Page";
+
+    var SettingsDisplay = Model.HomeScreenDisplays.First(a => a.HomeScreen == HomeScreenEnumeration.Settings);
+    var OdsInstancesDisplay = Model.HomeScreenDisplays.First(a => a.HomeScreen == HomeScreenEnumeration.OdsInstances);
+    var GlobalDisplay = Model.HomeScreenDisplays.FirstOrDefault(a => a.HomeScreen == HomeScreenEnumeration.Global);
+    var UpdatesDisplay = Model.HomeScreenDisplays.FirstOrDefault(a => a.HomeScreen == HomeScreenEnumeration.Updates);
+}
+
+@if (Request.IsAuthenticated)
+{
+    if (Model.SetupJustCompleted)
+    {
+        <script language="javascript">
+            toastr.success("Setup completed successfully. Your EdFi ODS installation is ready to use!")
+        </script>
+    }
+
+
+    <div class="row text-center features-container">
+
+        @if (GlobalDisplay != null)
+        {
+            <a href="@Url.Action("Vendors", "GlobalSettings")" class="@GetCssClassName(GlobalDisplay.IsEnabled)">
+                <div class="col-md-4 col-sm-6 hero-feature">
+                    <div class="border-circular">
+                        <img src="~/Content/images/reports@2x.png" width="200" alt="Global"/>
+                    </div>
+                    <div class="caption">
+                        <h3>Global</h3>
+                    </div>
+                </div>
+            </a>
+        }
+
+        @if (!CloudOdsAdminAppSettings.Instance.Mode.SupportsMultipleInstances)
+        {
+            <a href="@Url.Action("Applications", "OdsInstanceSettings")" class="@GetCssClassName(SettingsDisplay.IsEnabled)">
+                <div class="col-md-4 col-sm-6 hero-feature">
+                    <div class="border-circular">
+                        <img src="~/Content/images/settings@2x.png" width="200" alt="Settings"/>
+                    </div>
+                    <div class="caption">
+                        <h3>Settings</h3>
+                    </div>
+                </div>
+            </a>
+        }
+
+        @if (CloudOdsAdminAppSettings.Instance.Mode.SupportsMultipleInstances)
+        {
+            <a href="@Url.Action("Index", "OdsInstances")" class="@GetCssClassName(OdsInstancesDisplay.IsEnabled)">
+                <div class="col-md-4 col-sm-6 hero-feature">
+                    <div class="border-circular">
+                        <img src="~/Content/images/settings@2x.png" width="200" alt="Ods Instances"/>
+                    </div>
+                    <div class="caption">
+                        <h3>ODS Instances</h3>
+                    </div>
+                </div>
+            </a>
+        }
+
+        @if (UpdatesDisplay != null)
+        {
+            <a href="@Url.Action("Index", "Update")" class="@GetCssClassName(UpdatesDisplay.IsEnabled)">
+                <div class="col-md-4 col-sm-6 hero-feature">
+                    <div class="border-circular">
+                        <img src="~/Content/images/updates@2x.png" width="200" alt="Updates"/>
+                    </div>
+                    <div class="caption">
+                        <h3>Updates</h3>
+                        @if (Model.UpdateAvailable)
+                        {
+                            <div class="badge update-badge">Update Available</div>
+                        }
+                    </div>
+                </div>
+            </a>
+        }
+    </div>
+}
+
+else
+{
+    <div class="text-center">
+        <img src="~/Content/images/logo-edfi@2x.png"/>
+        <p class="lead">Ed-Fi ODS Admin App for Suite 3</p>
+        <p>Please <a href="@Url.Action("Login", "Identity")" class="btn btn-primary">Sign In <span class="padding-left"><i class="fa fa-chevron-circle-right"></i></span></a> to continue</p>
+    </div>
+}
+
+<script type="text/javascript">
+        $('.disabled').click(function (e) {
+            e.preventDefault();
+        });
+
+        $('.disabled , .disabled .caption, .disabled img').css({
+            'cursor': 'not-allowed',
+            '-webkit-filter': 'grayscale(1)',
+            'filter': 'grayscale(1)'
+        });
+
+        $('.disabled .border-circular').css('background', 'rgba(0,0,0,0.25)');
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Identity/ChangePassword.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Identity/ChangePassword.cshtml
@@ -1,0 +1,37 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.Identity.ChangePasswordViewModel
+@{
+    ViewBag.Title = "Change Password";
+}
+
+<h2>@ViewBag.Title</h2>
+<hr />
+@if (ViewBag.PasswordChanged == true)
+{
+    <script language="javascript">
+        toastr.success("Your password has been changed.")
+    </script>
+}
+@using (Html.BeginForm())
+{
+    @Html.AntiForgeryToken()
+    if (!Html.ViewData.ModelState.IsValid)
+    {
+        @Html.ValidationSummary("", new { @class = "alert alert-danger" })
+    }
+    @Html.InputBlock(x => x.OldPassword)
+    @Html.InputBlock(x => x.NewPassword)
+    @Html.InputBlock(x => x.ConfirmPassword)
+    <div class="row form-group">
+        <div class="col-xs-offset-4 col-xs-6">
+            <button type="submit" class="btn btn-primary cta no-ajax">Change Password</button>
+        </div>
+    </div>
+}

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Identity/ConfirmEmail.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Identity/ConfirmEmail.cshtml
@@ -1,0 +1,17 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@{
+    ViewBag.Title = "Confirm Email";
+}
+
+<h2>@ViewBag.Title</h2>
+<div>
+    <p>
+        Thank you for confirming your email. Please @Html.ActionLink("Click here to Log in", "Login", "Identity").
+    </p>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Identity/ForgotPassword.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Identity/ForgotPassword.cshtml
@@ -1,0 +1,30 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.Identity.ForgotPasswordViewModel
+@{
+    ViewBag.Title = "Forgot your password?";
+}
+
+<h2>@ViewBag.Title</h2>
+<hr />
+
+@using (Html.BeginForm())
+{
+    @Html.AntiForgeryToken()
+    if (!Html.ViewData.ModelState.IsValid)
+    {
+        @Html.ValidationSummary("", new { @class = "alert alert-danger" })
+    }
+    @Html.InputBlock(m => m.Email)
+    <div class="row form-group">
+        <div class="col-xs-offset-4 col-xs-6">
+            <button type="submit" class="btn btn-primary cta no-ajax">Email Link</button>
+        </div>
+    </div>
+}

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Identity/ForgotPasswordConfirmation.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Identity/ForgotPasswordConfirmation.cshtml
@@ -1,0 +1,20 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@{
+    ViewBag.Title = "Forgot Password Confirmation";
+}
+
+<hgroup class="title">
+    <h1>@ViewBag.Title.</h1>
+</hgroup>
+<div>
+    <p>
+        Please check your email to reset your password.
+    </p>
+</div>
+	

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Identity/Login.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Identity/Login.cshtml
@@ -1,0 +1,52 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.Identity.LoginViewModel
+@{
+    ViewBag.Title = "Log In";
+}
+
+<h2>@ViewBag.Title</h2>
+<hr />
+
+@using (Html.BeginForm("Login", "Identity", new { ReturnUrl = ViewBag.ReturnUrl }))
+{
+    @Html.AntiForgeryToken()
+    if (!Html.ViewData.ModelState.IsValid)
+    {
+        @Html.ValidationSummary("", new { @class = "alert alert-danger" })
+    }
+    @Html.HiddenFor(x => x.AllowUserRegistration)
+    @Html.InputBlock(x => x.Email)
+    @Html.InputBlock(x => x.Password)
+
+    <div class="row form-group">
+        <div class="col-xs-offset-4 col-xs-6">
+            <div class="checkbox">
+                @Html.CheckBoxFor(m => m.RememberMe)
+                Remember me?
+            </div>
+        </div>
+    </div>
+    <div class="row form-group">
+        <div class="col-xs-offset-4 col-xs-6">
+            <button type="submit" class="btn btn-primary cta no-ajax">Sign In</button>
+        </div>
+    </div>
+
+    if (Model.AllowUserRegistration)
+    {
+        <p class="text-right">
+            @Html.ActionLink("Register as a new user", "Register")
+        </p>
+    }
+    @* Enable this once you have account confirmation enabled for password reset functionality
+        <p>
+            @Html.ActionLink("Forgot your password?", "ForgotPassword")
+        </p>*@
+}

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Identity/Register.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Identity/Register.cshtml
@@ -1,0 +1,33 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.Identity.RegisterViewModel
+@{
+    ViewBag.Title = "Register";
+}
+
+<h2>@ViewBag.Title</h2>
+<h4>Create a new account.</h4>
+<hr />
+
+@using (Html.BeginForm())
+{
+    @Html.AntiForgeryToken()
+    if (!Html.ViewData.ModelState.IsValid)
+    {
+        @Html.ValidationSummary("", new { @class = "alert alert-danger" })
+    }
+    @Html.InputBlock(x => x.Email)
+    @Html.InputBlock(x => x.Password)
+    @Html.InputBlock(x => x.ConfirmPassword)
+    <div class="row form-group">
+        <div class="col-xs-offset-4 col-xs-6">
+            <button type="submit" class="btn btn-primary cta no-ajax">Register</button>
+        </div>
+    </div>
+}

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Identity/ResetPassword.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Identity/ResetPassword.cshtml
@@ -1,0 +1,33 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.Identity.ResetPasswordViewModel
+@{
+    ViewBag.Title = "Reset Password";
+}
+
+<h2>@ViewBag.Title</h2>
+<hr />
+
+@using (Html.BeginForm())
+{
+    @Html.AntiForgeryToken()
+    if (!Html.ViewData.ModelState.IsValid)
+    {
+        @Html.ValidationSummary("", new { @class = "alert alert-danger" })
+    }
+    @Html.HiddenFor(model => model.Code)
+    @Html.InputBlock(m => m.Email)
+    @Html.InputBlock(m => m.Password)
+    @Html.InputBlock(m => m.ConfirmPassword)
+    <div class="row form-group">
+        <div class="col-xs-offset-4 col-xs-6">
+            <button type="submit" class="btn btn-primary cta no-ajax">Reset</button>
+        </div>
+    </div>
+}

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Identity/ResetPasswordConfirmation.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Identity/ResetPasswordConfirmation.cshtml
@@ -1,0 +1,19 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@{
+    ViewBag.Title = "Reset password confirmation";
+}
+
+<hgroup class="title">
+    <h1>@ViewBag.Title.</h1>
+</hgroup>
+<div>
+    <p>
+        Your password has been reset. Please @Html.ActionLink("click here to log in", "Login", "Identity").
+    </p>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/BulkLoad.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/BulkLoad.cshtml
@@ -1,0 +1,210 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstanceSettings
+@model OdsInstanceSettingsModel
+
+@{
+    Layout = "~/Views/Shared/_Settings_Production.cshtml";
+    ViewBag.Title = "Ods Instance | Bulk Load";
+    var maxFileSizeDisplay = BulkFileUploadModel.MaxFileSize / 1000000;
+}
+@Html.NavPills(Url, Model.OdsInstanceSettingsTabEnumerations)
+<div class="tab-content">
+    @if (!Model.BulkFileUploadModel.CredentialsSaved)
+    {
+        @Html.Partial("_SaveBulkUploadCredentialsForm", Model.BulkFileUploadModel)
+    }
+    else
+    {
+        using (Html.BeginForm("ResetCredentials", "OdsInstanceSettings", FormMethod.Post, new { id = "reset-credentials-form" }))
+        {
+            <br />
+            <div class="row">
+                <div class="col-lg-4" style="padding-top: 5px">
+                    <label>Available ODS / API Key:</label> @Model.BulkFileUploadModel.ApiKey
+                </div>
+                <div class="col-lg-4">
+                    @Html.SaveButton("Reset credentials").Id("bulk-load-reset-button")
+                </div>
+            </div>
+            <br />
+        }
+        using (Html.BeginForm("BulkFileUpload", "OdsInstanceSettings", FormMethod.Post, new { enctype = "multipart/form-data", id = "bulk-upload-form" }))
+        {
+            <div class="row">
+                <div class="col-lg-12">
+                    <div id="validation-Summary" align="left" class="alert alert-danger" hidden></div>
+                </div>
+            </div>
+
+            <div class="row padding-bottom-10">
+                <div class="col-lg-6">
+                    <label>Select File Type:</label>
+                    @(Html.SelectList(x => x.BulkFileUploadModel.BulkFileType))
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-lg-6">
+                    <div class="input-group">
+                        <div class="form-control" id="upload-file-info"></div>
+                        <div class="input-group-btn">
+                            <button style="margin-left: -37px; display: none; z-index: 2;" class="btn btn-default btn-hover" id="clear-file-upload"><i class="fa fa-times fa-lg"></i></button>
+                            <label type="button" class="btn btn-primary">
+                                <input id="bulk-files-input" name="BulkFileUploadModel.BulkFiles" value="@Model.BulkFileUploadModel.BulkFiles" type="file" style="display: none;" maxlength="@BulkFileUploadModel.MaxFileSize" accept=".xml" />
+                                Select file
+                            </label>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-lg-12">
+                    <span style="font-style: italic;">(maximum file size: @maxFileSizeDisplay MB, file type: .xml)</span>
+                </div>
+                <div class="col-lg-12">
+                    <span id="upload-file-size-error" class="upload-error">The selected file to too large. Please select another file.</span>
+                    <span id="upload-file-type-error" class="upload-error">Please select xml file.</span>                    
+                </div>
+            </div>
+            <div class="row" style="padding-top: 10px;">
+                <div class="col-lg-3">
+                    <button id="upload-bulk-files-button" type="submit" class="no-ajax btn btn-success" disabled><i class="fa fa-upload"></i> Upload</button>
+                    <i id="upload-button-spinner" class="fa fa-spinner fa-pulse fa-fw inline-icon" style="display: none;"></i>
+                </div>
+            </div>
+        }
+    }
+</div>
+<div id="bulk-upload-status-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="bulk-upload-status-modal" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title">Bulk Upload</h4>
+            </div>
+            <div class="modal-body center-block" id="signalRstatus">
+                @Html.Partial("_SignalRStatus_BulkLoad")
+            </div>
+            <div class="modal-footer">
+                @Html.CancelModalButton("Close")
+            </div>
+        </div>
+    </div>
+</div>
+
+
+<script type="text/javascript">
+    function ErrorStatusDisplay() {
+        $('#upload-bulk-files-button').prop("disabled", true);
+        $('#clear-file-upload').hide();
+        $('#upload-file-info').html("");
+    }
+
+    $("#bulk-files-input").change(function () {
+        if ($(this).get(0).files.length > 0) {
+            var maxLength = $(this).attr("maxlength");
+            var fileExt = $(this).attr("accept");
+            if (fileExt) {
+                for (var i = 0; i < $(this).get(0).files.length; ++i) {
+                    var fileName = $(this).get(0).files[i].name;
+                    if (fileName.substring(fileName.lastIndexOf('.')) !== fileExt) {
+                        $(this).get(0).value = "";
+                        $('#upload-file-type-error').show();
+                        ErrorStatusDisplay();
+                        return;
+                    }
+                }
+            }
+            if (maxLength) {
+                for (var j = 0; j < $(this).get(0).files.length; ++j) {
+                    if ($(this).get(0).files[j].size > maxLength) {
+                        $(this).get(0).value = "";
+                        $('#upload-file-size-error').show();
+                        ErrorStatusDisplay();
+                        return;
+                    }
+                }
+            }
+
+            $('#upload-file-info').html($(this).get(0).files[0].name);
+            $('#clear-file-upload').show();
+            $('#upload-bulk-files-button').prop("disabled", false);
+            $('.upload-error').hide();
+        }
+    });
+
+    $("#clear-file-upload").click(function (e) {
+        e.preventDefault();
+        $('#bulk-files-input').get(0).value = "";
+        $('#upload-bulk-files-button').prop("disabled", true);
+        $('#clear-file-upload').hide();
+        $('#upload-file-info').html("");
+    });
+
+    $(function () {
+        edfiODS.signalR.startListener($.connection.bulkUploadHub, null);
+        edfiODS.signalR.changeStatusMessage("Initializing file importer");
+    });
+
+    $("#bulk-upload-form").submit(function (e) {
+        e.preventDefault();
+        var $form = $(this);
+        var formData = appendAntiForgeryTokenForFileUpload($form);
+
+        $('#upload-button-spinner').show();
+        $('#upload-bulk-files-button').prop("disabled", true);
+        $('.upload-error').hide();
+        var validationBlock = $('#validation-Summary');
+
+        $.ajax({
+            url: $form.attr("action"),
+            type: 'POST',
+            data: formData,
+            success: function (data, status, xhr) {
+                if (xhr.status !== edfiODS.httpStatusCodes.NoContent) {
+                    $('#signalRstatus').html(data);
+                    ShowBulkUploadStatusModal();
+                }
+                $('#upload-button-spinner').hide();
+                $('#upload-bulk-files-button').prop("disabled", false);
+            },
+            error: function (data) {
+                edfiODS.signalR.showError("Error uploading bulk data.  Please try again later");
+                $('#upload-button-spinner').hide();
+                $('#upload-bulk-files-button').prop("disabled", false);
+                validationBlock.attr("hidden", false);
+                validationBlock.text(getErrorString(data));
+            },
+            cache: false,
+            contentType: false,
+            processData: false
+        });
+    });
+
+    var saveCredentials = function (e) {
+        e.preventDefault();
+        var $form = $(this),
+            formData = appendAntiForgeryToken($form.serialize());
+        $.ajax({
+            url: $form.attr("action"),
+            type: 'POST',
+            data: formData
+        });
+    };
+
+    $('#save-credentials-form').submit(saveCredentials);
+    $('#reset-credentials-form').submit(saveCredentials);
+
+    function ShowBulkUploadStatusModal() {
+        $("#bulk-upload-status-modal").modal({
+            keyboard: false,
+            backdrop: 'static'
+        });
+    }
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/Descriptors.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/Descriptors.cshtml
@@ -1,0 +1,23 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstanceSettings
+@model OdsInstanceSettingsModel
+
+@{
+    Layout = "~/Views/Shared/_Settings_Production.cshtml";
+    ViewBag.Title = "Ods Instance | Descriptors";
+}
+
+@Html.NavPills(Url, Model.OdsInstanceSettingsTabEnumerations)
+
+<div class="tab-content">
+    <div class="tab-pane active">
+        @Html.ActionAjax("DescriptorCategoryList", "Descriptors", new { }, 500, "Retrieving descriptor list...")
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/EducationOrganizations.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/EducationOrganizations.cshtml
@@ -1,0 +1,19 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstanceSettings
+@model OdsInstanceSettingsModel
+
+@{
+    Layout = "~/Views/Shared/_Settings_Production.cshtml";
+    ViewBag.Title = "Ods Instance | Education Organizations";
+}
+
+@Html.NavPills(Url, Model.OdsInstanceSettingsTabEnumerations)
+
+@Html.ActionAjax("EducationOrganizationList", "EducationOrganizations", new { }, 500, "Retrieving organization data...")

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/EnrollmentByEthnicity.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/EnrollmentByEthnicity.cshtml
@@ -1,0 +1,19 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstanceSettings
+@model OdsInstanceSettingsModel
+
+@{
+    ViewBag.Title = "Ods Instance Reports | Enrollment By Ethnicity";
+    Layout = "~/Views/Shared/_Settings_Production.cshtml";
+}
+
+@Html.NavPills(Url, Model.OdsInstanceSettingsTabEnumerations)
+
+@{ Html.RenderAction("EnrollmentByEthnicity", "Reports", new { id = Model.ReportsModel.LocalEducationAgencyId }); }

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/EnrollmentByGender.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/EnrollmentByGender.cshtml
@@ -1,0 +1,19 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstanceSettings
+@model OdsInstanceSettingsModel
+
+@{
+    ViewBag.Title = "Ods Instance Reports | Enrollment By Gender";
+    Layout = "~/Views/Shared/_Settings_Production.cshtml";
+}
+
+@Html.NavPills(Url, Model.OdsInstanceSettingsTabEnumerations)
+
+@{ Html.RenderAction("EnrollmentByGender", "Reports", new { id = Model.ReportsModel.LocalEducationAgencyId }); }

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/EnrollmentByRace.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/EnrollmentByRace.cshtml
@@ -1,0 +1,19 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstanceSettings
+@model OdsInstanceSettingsModel
+
+@{
+    ViewBag.Title = "Ods Instance Reports | Enrollment By Race";
+    Layout = "~/Views/Shared/_Settings_Production.cshtml";
+}
+
+@Html.NavPills(Url, Model.OdsInstanceSettingsTabEnumerations)
+
+@{ Html.RenderAction("EnrollmentByRace", "Reports", new { id = Model.ReportsModel.LocalEducationAgencyId }); }

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/Index.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/Index.cshtml
@@ -1,0 +1,37 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstanceSettings
+@model OdsInstanceSettingsModel
+
+@{
+    Layout = "~/Views/Shared/_Settings_Production.cshtml";
+    ViewBag.Title = "Ods Instance | Applications";
+}
+
+@Html.NavPills(Url, Model.OdsInstanceSettingsTabEnumerations)
+
+<div class="tab-content">
+    <div class="tab-pane active" id="production-applications">
+        @if (!Model.ProductionApiUrl.IsEmpty())
+        {
+            <div class="alert alert-info">
+                <a href="javascript:void(0)" class="copy-to-clipboard" data-clipboard-text="@Model.ProductionApiUrl">
+                    <span class="fa fa-clipboard"></span><span>Production API URL: </span><strong>@Model.ProductionApiUrl</strong>
+                </a>
+            </div>
+            @Html.ActionAjax("ApplicationList", "OdsInstanceSettings", new {}, 250, "Warming up Production API....")
+        }
+    </div>
+</div>
+
+<script type="text/javascript">
+    (function () {
+        InitializeCopyToClipboardLinks();
+    })();
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/LearningStandards.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/LearningStandards.cshtml
@@ -1,0 +1,123 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using System.Globalization
+@using EdFi.Ods.AdminApp.Web.Helpers
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstanceSettings
+@model OdsInstanceSettingsModel
+
+@{
+    Layout = "~/Views/Shared/_Settings_Production.cshtml";
+    ViewBag.Title = "Ods Instance | Learning Standards";
+}
+
+@Html.NavPills(Url, Model.OdsInstanceSettingsTabEnumerations)
+
+<div class="tab-content">
+    @if (Model.LearningStandardsModel.HasApiData)
+    {
+        if (!Model.LearningStandardsModel.SynchronizationWasSuccessful && !Model.LearningStandardsModel.IsJobRunning)
+        {
+            <div class="tab-pane active" id="form-tab-content-prod">
+                <div class="col-xs-12 margin-bottom-10">
+                    <div class="margin-bottom-10">
+                        AB Connect, provided by Certica Solutions, includes the Academic Benchmarks repository of learning standards and is the source for your Ed-Fi learning standards reference data. Once the AB Connect learning standards module is enabled, you can load and refresh your Ed-Fi ODS learning standards reference data.
+                    </div>
+                    <div class="margin-bottom-10">
+                        To enable the AB Connect learning standards module, you will need an AB Connect API ID and key provided by Certica Solutions. <a href="https://certicasolutions.com/products/AB-Ed-Fi/">Contact Certica Solutions</a> to provision your AB Connect account and receive your AB Connect API ID and key.
+                    </div>
+                    <div class="margin-bottom-10">
+                        Please email <a href="mailto:absupport@certicasolutions.com">absupport@certicasolutions.com</a> for general help regarding the AB Connect learning standards module.
+                    </div>
+                </div>
+                @using (Html.BeginForm("LearningStandards", "OdsInstanceSettings", FormMethod.Post, new {id = "learning-standards-prod-form"}))
+                {
+                    @Html.ValidationBlock()
+                    @Html.InputBlock(m => m.LearningStandardsModel.ApiKey)
+                    @Html.InputBlock(m => m.LearningStandardsModel.ApiSecret)
+                    <div class="col-xs-4"></div>
+                    <div class="col-xs-6">
+                        @Html.SaveButton("Enable Learning Standards").Id("learning-standards-prod-button")
+                    </div>
+                }
+                <div class="col-xs-12 margin-top-10">
+                    <div class="margin-top-10">
+                        By enabling the AB Connect learning standards module, I agree to the <a href="https://certicasolutions.com/products/AB-Ed-Fi-terms-use/">Certica Solutions Terms of Service</a> and <a href="https://certicasolutions.com/products/AB-Ed-Fi-privacy/">Privacy Policy</a>.
+                    </div>
+                </div>
+            </div>
+        }
+        else if (Model.LearningStandardsModel.SynchronizationWasSuccessful && !Model.LearningStandardsModel.IsJobRunning)
+        {
+            <div class="tab-pane active">
+                <h3>Learning Standards</h3>
+                <div>The AB Connect learning standards module is enabled. Please refer to the Certica <a href="https://certicasolutions.com/products/AB-Ed-Fi-terms-use/">Terms of Service</a> as it relates to your vendor's AB Connect license.</div>
+                <br />
+                <div style="background-color: #dddddd; width: 50%">
+                    <div>AB Connect ID: @Model.LearningStandardsModel.ApiKey</div>
+                    <div>Last Updated: @Model.LearningStandardsModel.LastUpdatedDate.ToString(CultureInfo.CurrentCulture)</div>
+                </div>
+                <br />
+                @using (Html.BeginForm("UpdateLearningStandards", "OdsInstanceSettings", FormMethod.Post, new { id = "update-now-learning-standards" }))
+                {
+                    @Html.SaveButton("Update Now")
+                }
+                @Html.AjaxPostButton("ResetLearningStandards", "OdsInstanceSettings", "Reset Credentials")
+            </div>
+        }
+        <div class="tab-pane" id="status-tab-content-prod">
+            @Html.Partial("_SignalRStatus_LS")
+        </div>
+    }
+    else
+    {
+        <span>Please setup production instance before enabling Learning Standards</span>
+    }
+</div>
+
+
+<script>
+    var enableLearningStandards = function(e) {
+        e.preventDefault();
+
+        var $form = $(this),
+            formData = appendAntiForgeryToken($form.serialize());
+
+        $.ajax({
+            url: $form.attr("action"),
+            type: 'POST',
+            data: formData,
+            success: function (data, status, xhr) {
+                if (xhr.status !== edfiODS.httpStatusCodes.NoContent) {
+                    ShowLearningStandardsStatus();
+                }
+            },
+            error: function () {
+                edfiODS.signalR.showError("Error enabling Learning Standards.  Please try again later");
+            }
+        });
+    };
+
+    $('#learning-standards-prod-form').submit(enableLearningStandards);
+    $('#update-now-learning-standards').submit(enableLearningStandards);
+
+    function ShowLearningStandardsStatus() {
+        edfiODS.signalR.showProgress();
+        $('#form-tab-content-prod').toggleClass('active');
+        $('#status-tab-content-prod').toggleClass('active');
+    }
+    $(function () {
+        edfiODS.signalR.hideProgress();
+        edfiODS.signalR.startListener($.connection.productionLearningStandardsHub, null);
+        edfiODS.signalR.changeStatusMessage("Initializing Learning Standards");
+
+        var isJobRunning = "@(Model.LearningStandardsModel.IsJobRunning ? "true" : "false")";
+        if (isJobRunning === "true") {
+            ShowLearningStandardsStatus();
+        }
+    });
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/Logging.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/Logging.cshtml
@@ -1,0 +1,23 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstanceSettings
+@model OdsInstanceSettingsModel
+
+@{
+    Layout = "~/Views/Shared/_Settings_Production.cshtml";
+    ViewBag.Title = "Ods Instance | Logging";
+}
+
+@Html.NavPills(Url, Model.OdsInstanceSettingsTabEnumerations)
+
+<div class="tab-content">
+    <div class="tab-pane active">
+        @{ Html.RenderPartial("_LogSettings", Model.LogSettingsModel); }
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/SchoolsBySchoolType.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/SchoolsBySchoolType.cshtml
@@ -1,0 +1,19 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstanceSettings
+@model OdsInstanceSettingsModel
+
+@{
+    ViewBag.Title = "Ods Instance Reports | Schools By School Type";
+    Layout = "~/Views/Shared/_Settings_Production.cshtml";
+}
+
+@Html.NavPills(Url, Model.OdsInstanceSettingsTabEnumerations)
+
+@{ Html.RenderAction("SchoolsBySchoolType", "Reports", new { id = Model.ReportsModel.LocalEducationAgencyId }); }

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/SelectDistrict.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/SelectDistrict.cshtml
@@ -1,0 +1,28 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstanceSettings
+@model OdsInstanceSettingsModel
+
+@{
+    Layout = "~/Views/Shared/_Settings_Production.cshtml";
+    ViewBag.Title = "Ods Instance Reports";
+}
+
+@Html.NavPills(Url, Model.OdsInstanceSettingsTabEnumerations)
+
+@{
+    <div class="row">
+        <div class="col-xs-12 margin-top-10">
+            <div class="alert alert-info">
+                <strong>Note: </strong>These reports allow for basic data quality inspection and system activity monitoring. They are not intended to support day-to-day analytics needs.
+            </div>
+        </div>
+    </div>
+    Html.RenderAction("SelectDistrict", "Reports", new { Model.ReportsModel.LocalEducationAgencyId });
+}

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/Setup.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/Setup.cshtml
@@ -1,0 +1,121 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@using EdFi.Ods.AdminApp.Web.Infrastructure
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstanceSettings
+@model OdsInstanceSettingsModel
+
+@{
+    Layout = "~/Views/Shared/_Settings_Production.cshtml";
+    ViewBag.Title = "Ods Instance | Setup";
+}
+
+@Html.NavPills(Url, Model.OdsInstanceSettingsTabEnumerations)
+
+<div class="tab-content">
+    <div class="tab-pane active" id="applications">
+        <h6>Setup Production</h6>
+        <hr/>
+        
+        <div>
+            @if (!CloudOdsAdminAppSettings.Instance.SystemManagedSqlServer)
+            {
+                <div class="row subsection">
+                    <div class="col-lg-12 text-center">
+                        <span class="note">NOTE:</span>
+                        <span>Your Ed-Fi ODS is running against a self-managed SQL Server. Therefore, you must perform the Production Setup operation manually on your SQL Server. See documentation for more details.</span>
+                    </div>
+                </div>
+            }
+            @using (Html.BeginForm("Setup", "OdsInstanceSettings", FormMethod.Post, new {@id = "setup-production-form"}))
+            {
+                <div class="row">
+                    <div class="col-lg-12 text-right">
+                        <div class="row subsection">
+                            <div class="col-lg-12 text-center">
+                                <span class="note">NOTE:</span>
+                                <span>Interactive setup mode will populate this ODS Instance with default Ed-Fi descriptors. You will need to manually add districts and schools via the Education Organizations tab.</span>
+                            </div>
+                        </div>
+                        @Html.Button("Setup Production").Id("setup-production-button")
+                    </div>
+                </div>
+            }
+        </div>
+    </div>
+</div>
+
+
+<div id="setup-production-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="setup-production-modal" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title">Setup Production</h4>
+            </div>
+            <div class="modal-body center-block" id="production-setup-modal-body">
+                <div class="production-setup-confirm">
+                    <div class="row">
+                        <div class="col-lg-2"></div>
+                        <div class="col-lg-8">
+                            <div class="note">WARNING</div>
+                            <div>
+                                This operation <strong>brings your Production instance online, and may only be performed one time.</strong>
+                            </div>
+                            <div>Are you sure you are ready to bring Production online?</div>
+                        </div>
+                        <div class="col-lg-2"></div>
+                    </div>
+                </div>
+                @Html.Partial("_SignalRStatus")
+            </div>
+            <div class="modal-footer">
+                @Html.CancelModalButton().AddClass("production-setup-confirm")
+                @Html.Button("Confirm").AddClasses("production-setup-confirm").Id("confirm-production-setup-button")
+            </div>
+        </div>
+    </div>
+</div>
+
+<script language="javascript">
+
+    $(document).ready(function() {
+        edfiODS.signalR.hideProgress();
+        edfiODS.signalR.startListener($.connection.productionSetupHub, '@Html.Raw(Url.Action("SetupComplete", "OdsInstanceSettings"))');
+    });
+
+    $('#setup-production-button').click(function(e) {
+        e.preventDefault();
+        $("#setup-production-modal").modal({
+            keyboard: false,
+            backdrop: 'static'
+        });
+    });
+
+    $("#confirm-production-setup-button").click(function(e) {
+        e.preventDefault();
+        var $form = $("#setup-production-form");
+
+        $.ajax({
+            url: $form.attr("action"),
+            type: "post",
+            data: appendAntiForgeryToken($form.serialize()),
+            contentType: "application/x-www-form-urlencoded; charset=UTF-8",
+            success: function() {
+                ShowResetProgress();
+            },
+            error: function () {
+                edfiODS.signalR.showError("Error trying to start Production Setup operation.  Note that this operation may only be performed once.");
+            }
+        });
+    });
+
+    function ShowResetProgress() {
+        $(".production-setup-confirm").hide();
+        edfiODS.signalR.showProgress();
+    }
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/SetupComplete.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/SetupComplete.cshtml
@@ -1,0 +1,64 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstanceSettings
+@model OdsInstanceSettingsModel
+
+@{
+    Layout = "~/Views/Shared/_Settings_Production.cshtml";
+    ViewBag.Title = "Ods Instance | Setup";
+}
+
+@Html.NavPills(Url, Model.OdsInstanceSettingsTabEnumerations)
+
+<div class="tab-content">
+    <div class="tab-pane active" id="applications">
+        <h6>Production Setup Complete</h6>
+        <hr />
+
+        <div class="row subsection">
+            <div class="col-lg-12 text-center">
+                <div>Production Setup has been completed. See documentation if you need to reset your Production instance to a default state.</div>
+            </div>
+        </div>
+
+        @if (Model.ProductionSetupCompletedModel.HasProvisioningWarnings)
+        {
+        <div class="row subsection">
+            <div class="col-lg-12 text-center">
+                <span class="note">WARNING:</span>
+                <span>One or more setup problems have been detected.  Consider resolving these items by visiting <a href="@Model.ProductionSetupCompletedModel.ProvisioningWarnings.ResolutionUrl" target="_blank">@Model.ProductionSetupCompletedModel.ProvisioningWarnings.ResolutionUrl</a></span>
+                <br />
+                <div>
+                    <ul style="display: inline-block">
+                        @foreach (var warning in Model.ProductionSetupCompletedModel.ProvisioningWarnings.Warnings)
+                        {
+                            <li>@warning</li>
+                        }
+                    </ul>
+                </div>
+            </div>
+        </div>
+        }
+
+        else
+        {
+            <div class="row subsection">
+                <div class="col-lg-12 text-center">
+                    <span class="success-note">SUCCESS:</span>
+                    <span>No warnings have been detected.</span>
+                    <br />
+                    <div>
+                        Next step: Setup/Verify <a href="@Url.Action("EducationOrganizations")">Education Organizations</a>
+                    </div>
+                </div>
+            </div>
+        }
+
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/StudentsByAttribute.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/StudentsByAttribute.cshtml
@@ -1,0 +1,19 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstanceSettings
+@model OdsInstanceSettingsModel
+
+@{
+    ViewBag.Title = "Ods Instance Reports | Students By Attribute";
+    Layout = "~/Views/Shared/_Settings_Production.cshtml";
+}
+
+@Html.NavPills(Url, Model.OdsInstanceSettingsTabEnumerations)
+
+@{ Html.RenderAction("StudentsByAttribute", "Reports", new { id = Model.ReportsModel.LocalEducationAgencyId }); }

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/StudentsByProgram.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/StudentsByProgram.cshtml
@@ -1,0 +1,19 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstanceSettings
+@model OdsInstanceSettingsModel
+
+@{
+    ViewBag.Title = "Ods Instance Reports | Students By Program";
+    Layout = "~/Views/Shared/_Settings_Production.cshtml";
+}
+
+@Html.NavPills(Url, Model.OdsInstanceSettingsTabEnumerations)
+
+@{ Html.RenderAction("StudentsByProgram", "Reports", new { id = Model.ReportsModel.LocalEducationAgencyId }); }

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/TotalEnrollment.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/TotalEnrollment.cshtml
@@ -1,0 +1,19 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstanceSettings
+@model OdsInstanceSettingsModel
+
+@{
+    ViewBag.Title = "Ods Instance Reports | Total Enrollment";
+    Layout = "~/Views/Shared/_Settings_Production.cshtml";
+}
+
+@Html.NavPills(Url, Model.OdsInstanceSettingsTabEnumerations)
+
+@{ Html.RenderAction("TotalEnrollment", "Reports", new { id = Model.ReportsModel.LocalEducationAgencyId }); }

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/_SaveBulkUploadCredentialsForm.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstanceSettings/_SaveBulkUploadCredentialsForm.cshtml
@@ -1,0 +1,21 @@
+@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.BulkFileUploadModel
+
+@using (Html.BeginForm("SaveBulkLoadCredentials", "OdsInstanceSettings", FormMethod.Post, new { enctype = "multipart/form-data", id = "save-credentials-form" }))
+{
+    @Html.ValidationBlock()
+    @Html.InputBlock(m => m.ApiKey)
+    @Html.InputBlock(m => m.ApiSecret)
+    <div class="col-xs-4"></div>
+    <div class="col-xs-6">
+        @Html.SaveButton("Save credentials").Id("bulk-load-button")
+    </div>
+}
+

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstances/BulkRegisterOdsInstances.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstances/BulkRegisterOdsInstances.cshtml
@@ -1,0 +1,73 @@
+@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstances.BulkRegisterOdsInstancesModel
+@{
+    ViewBag.Title = "Ods Instances | Bulk Register";
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+<h3 class="text-center padding-bottom-10">Bulk Register Ods Instances</h3>
+@using (Html.BeginForm("BulkRegisterOdsInstances", "OdsInstances", FormMethod.Post, new { enctype = "multipart/form-data", id = "bulk-instances-registration-form" }))
+{
+    @Html.AntiForgeryToken()
+    <div id="bulk-instances-registration-validation-summary" class="validationSummary alert alert-danger" hidden></div>
+    <div class="row">
+        <div class="col-md-12">
+            @Html.FileInputBlock(x => x.OdsInstancesFile).Attr("accept", ".csv").AddClasses("input-file")
+        </div>
+    </div>
+    <div class="row">
+        <div class="padding-top-5 text-center col-md-11">
+            @Html.Button("Back").Attr("type", "button").AddClass("back-btn back-ajax").Data("back-url", Url.Action("Index", "OdsInstances")).Id("ods-instance-settings-back-button")
+            @Html.SaveButton("Register Instances").AddClasses("no-ajax", "bulk-register").Attr("disabled",true)
+        </div>
+    </div>
+    <br/><br/>
+    <div id="result" class="alert alert-info" hidden></div>
+}
+
+<script type="text/javascript">
+    $(".input-file").change(function() {
+        if ($(this).length > 0) {
+            $(".bulk-register").attr('disabled', false);
+        }
+        $('#result').hide();
+    });
+    $('#bulk-instances-registration-form').submit(function (e) {
+        e.preventDefault();
+        var form = $(this);
+        $(".bulk-register")
+            .html('Registering Instances... <span class="padding-left"><i id="spinner" class="fa fa-spinner fa-pulse"></i></span>');
+        $(".bulk-register").attr('disabled', true);
+        var successHandler = function (data) {
+            $(".bulk-register").html('Register Instances');
+            $('#bulk-instances-registration-validation-summary').attr('hidden', true);
+            form[0].reset();
+            $('#result').text(data.successMessage);
+            $('#result').show();
+        };
+        var errorAdditionalBehavior = function () {
+            $(".bulk-register").html('Register Instances');
+        };
+        var ajaxRequestData = {
+            form: $(this),
+            formData: new FormData(form[0]),
+            cache: false,
+            contentType: false,
+            processData: false,
+            successHandler: successHandler,
+            errorAdditionalBehavior: errorAdditionalBehavior
+        };
+        submitAjaxForInnerTabs(ajaxRequestData);
+    });
+    $(function () {
+        InitializeSubmitButtons();
+        InitializeBackNavigationalAjaxButtons();
+    });
+</script>
+

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstances/Index.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstances/Index.cshtml
@@ -1,0 +1,86 @@
+@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Management.Database.Models
+@using EdFi.Ods.AdminApp.Management.Instances
+@using EdFi.Ods.AdminApp.Web.Infrastructure
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstances.IndexModel
+@{
+    ViewBag.Title = "Ods Instances | Index";
+    Layout = "~/Views/Shared/_Layout.cshtml";
+
+    var odsInstanceNumericSuffix = "District / EdOrg Id";
+
+    if (CloudOdsAdminAppSettings.Instance.Mode == ApiMode.YearSpecific)
+    {
+        odsInstanceNumericSuffix = "School Year";
+    }
+}
+<div class="row">
+    <div class="col-xs-12">
+        <div id="ods-instances" class="navigational-index">
+            @if (Model.UserContext.Has(Permission.AccessGlobalSettings))
+            {
+                <div class="row">
+                    <div align="right" class="col-md-9">
+                        @Html.ActionLink("Register A New Instance", "RegisterOdsInstance", null, new { @class = "btn btn-primary cta" })
+                    </div>
+                    <div align="right" class="col-md-3">
+                        @Html.ActionLink("Register Many Instances in Bulk", "BulkRegisterOdsInstances", null, new { @class = "btn btn-primary cta" })
+                    </div>
+                </div>
+                <br/><br/>
+            }
+            @if (Model.OdsInstances.Any())
+            {
+                <table class="table">
+                    <thead>
+                    <tr>
+                        <th scope="col">@odsInstanceNumericSuffix</th>
+                        <th scope="col">Instance Name</th>
+                        <th scope="col">Description</th>
+                        <th scope="col"></th>
+                    </tr>
+                    </thead>
+                    <tbody>
+
+                        @foreach (var instance in Model.OdsInstances)
+                        {
+                            <tr>
+                                <th scope="row"><a class="instance-settings" href="@Url.Action("ActivateOdsInstance", "OdsInstances", new {instanceId = instance.Id})">@instance.Name.ExtractNumericInstanceSuffix().ToString()</a></th>
+                                <td>@instance.Name</td>
+                                <td>@instance.Description</td>
+                                @if (Model.UserContext.Has(Permission.AccessGlobalSettings))
+                                {
+                                    <td>
+                                        <a class="loads-ajax-modal instance-deregister" data-toggle="tooltip" title="Deregister Instance" data-url="@Url.Action("DeregisterOdsInstance", "OdsInstances", new {instanceId = instance.Id})"><span class="fa fa-trash action-icons"></span></a>
+                                    </td>
+                                }
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            }
+            else
+            {
+                if (Model.UserContext.Has(Permission.AccessGlobalSettings))
+                {
+                    <div class="alert alert-info margin-top-10 text-center">No instances registered with the Admin App. Please register a new instance.</div>
+                }
+                else
+                {
+                    <div class="alert alert-info margin-top-10 text-center">No instances have been assigned to you yet. Please contact a @Role.SuperAdmin.DisplayName to get started.</div>
+                }
+            }
+        </div>
+    </div>
+</div>
+<script type="text/javascript">
+    $(function () {
+        InitializeModalLoaders();
+    });
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstances/RegisterOdsInstance.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstances/RegisterOdsInstance.cshtml
@@ -1,0 +1,83 @@
+@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Management.Instances
+@using EdFi.Ods.AdminApp.Web.Helpers
+@using EdFi.Ods.AdminApp.Web.Infrastructure
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstances.RegisterOdsInstanceModel
+
+@{
+    ViewBag.Title = "Ods Instances | Register";
+    Layout = "~/Views/Shared/_Layout.cshtml";
+
+    var exampleName = "eg. 123456";
+    var exampleDescription = "eg. Glendale ISD";
+    var helperText = "District / Education Organization Id";
+    var labelText = "ODS Instance District / EdOrg Id";
+    var maxValue = int.MaxValue;
+    var minValue = 1;
+
+    if (CloudOdsAdminAppSettings.Instance.Mode == ApiMode.YearSpecific)
+    {
+        var currentYear = DateTime.Now.Year;
+        exampleName = "eg. "+currentYear;
+        exampleDescription = "eg. School Year "+currentYear;
+        helperText = "School Year";
+        labelText = "ODS Instance School Year";
+        maxValue = 2099;
+        minValue = 1900;
+    }
+}
+
+<h3 class="text-center padding-bottom-10">Register Ods Instance</h3>
+@using (Html.BeginForm("RegisterOdsInstance", "OdsInstances", FormMethod.Post, new { @id = "register-instance-form" }))
+{
+    @Html.AntiForgeryToken()
+    <div id="register-instance-validation-summary" class="validationSummary alert alert-danger" hidden></div>
+    @Html.NumberOnlyInputBlock(x => x.NumericSuffix, exampleName, $"{helperText} associated with the ODS instance database to connect to (Valid input: {minValue}-{maxValue}.", labelText, maxValue, minValue)
+    @Html.InputBlock(x => x.Description, exampleDescription, "A user-facing descriptive name for this ODS instance database.")
+    <br />
+    <div class="padding-top-5 text-center">
+        @Html.Button("Back").Attr("type", "button").AddClass("back-btn back-ajax").Data("back-url", Url.Action("Index", "OdsInstances")).Id("ods-instance-settings-back-button")
+        @Html.SaveButton("Save").AddClasses("no-ajax", "Save-button")
+    </div>
+    <div align="right">
+        @Html.ActionLink("Register Many Instances in Bulk", "BulkRegisterOdsInstances", null, new { @class = "btn btn-primary cta" })
+    </div>
+}
+<script type="text/javascript">
+    $('#register-instance-form').submit(function (e) {
+        e.preventDefault();
+        var form = $(this);
+        $(".Save-button")
+            .html('Saving... <span class="padding-left"><i id="spinner" class="fa fa-spinner fa-pulse"></i></span>');
+        $(".Save-button").attr('disabled', true);
+
+        var successAdditionalBehavior = function() {
+            SetSuccessMessage("New Instance registered successfully.");
+            ShowToasterMessage();
+            ClearToasterMessage();
+            form[0].reset();
+            $('#ods-instance-settings-back-button').trigger('click');
+        };
+        var errorAdditionalBehavior = function() {
+            $(".Save-button").html('Save');
+            $(".Save-button").attr('disabled', false);
+        };
+        var ajaxRequestData = {
+            form: form,
+            formData: form.serialize(),
+            successAdditionalBehavior: successAdditionalBehavior,
+            errorAdditionalBehavior: errorAdditionalBehavior
+        };
+        submitAjaxForInnerTabs(ajaxRequestData);
+    });
+    $(function () {
+        InitializeSubmitButtons();
+        InitializeBackNavigationalAjaxButtons();
+    });
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstances/_DeregisterOdsInstanceModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/OdsInstances/_DeregisterOdsInstanceModal.cshtml
@@ -1,0 +1,36 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstances.DeregisterOdsInstanceModel
+
+<div id="deregister-instance-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="deregisterOdsInstanceModal" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Deregister Ods Instance</h4>
+            </div>
+            <div class="modal-body center-block text-center">
+                <div class="padding-bottom-10">
+                    Do you want to deregister the instance - <b>@Model.Name</b>?
+                </div>
+                @using (Html.BeginForm("DeregisterOdsInstance", "OdsInstances", FormMethod.Post))
+                {
+                    @Html.ValidationBlock()
+                    @Html.Input(m => m.OdsInstanceId).Hide()
+                    @Html.Input(m => m.Name).Hide()
+                    @Html.Input(m => m.Description).Hide()
+                }
+            </div>
+            <div class="modal-footer">
+                @Html.CancelModalButton()
+                @Html.SaveButton("Deregister")
+            </div>
+        </div>
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Reports/_EnrollmentByEthnicity.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Reports/_EnrollmentByEthnicity.cshtml
@@ -1,0 +1,31 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Management.Database.Ods.StudentEthnicityReport
+<div class="padding-bottom-10" align="center">
+    <h2>@Model.LocalEducationAgencyName</h2>
+</div>
+
+<h3>Enrollment By Ethnicity</h3>
+<table class="table table-condensed table-left-border">
+    <thead>
+    <tr>
+        <th>Ethnicity</th>
+        <th>Students</th>
+    </tr>
+    </thead>
+    <tbody>
+
+    <tr>
+        <td>Hispanic/Latino</td>
+        <td>@Model.HispanicLatinoPercent.ToString("P2")</td>
+    </tr>
+    </tbody>
+</table>
+
+<a href="@Url.Action("SelectDistrict", "OdsInstanceSettings", new {id = Model.LocalEducationAgencyId})">@Html.Button("Back to Reports")</a>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Reports/_EnrollmentByGender.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Reports/_EnrollmentByGender.cshtml
@@ -1,0 +1,41 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Management.Database.Ods.StudentGenderReport
+<div class="padding-bottom-10" align="center">
+    <h2>@Model.LocalEducationAgencyName</h2>
+</div>
+
+<h3>Enrollment By Gender</h3>
+@if (!Model.GenderRepresentation.Any())
+{
+    <em class="padding-top">There is no gender data to display</em>
+}
+else
+{
+    <table class="table table-condensed table-left-border">
+        <thead>
+        <tr>
+            <th>Gender</th>
+            <th>Students</th>
+        </tr>
+        </thead>
+        <tbody>
+        @foreach (var gender in Model.GenderRepresentation)
+        {
+
+            <tr>
+                <td>@gender.GetDisplayName()</td>
+                <td>@gender.PercentOfTotal.ToString("P2")</td>
+            </tr>
+        }
+        </tbody>
+    </table>
+}
+
+<a href="@Url.Action("SelectDistrict", "OdsInstanceSettings", new {id = Model.LocalEducationAgencyId})">@Html.Button("Back to Reports")</a>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Reports/_EnrollmentByRace.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Reports/_EnrollmentByRace.cshtml
@@ -1,0 +1,41 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Management.Database.Ods.StudentRaceReport
+<div class="padding-bottom-10" align="center">
+    <h2>@Model.LocalEducationAgencyName</h2>
+</div>
+
+<h3>Enrollment By Race</h3>
+@if (!Model.RaceRepresentation.Any())
+{
+    <em class="padding-top">There is no race data to display</em>
+}
+else
+{
+    <table class="table table-condensed table-left-border">
+        <thead>
+        <tr>
+            <th>Race</th>
+            <th>Students</th>
+        </tr>
+        </thead>
+        <tbody>
+        @foreach (var race in Model.RaceRepresentation)
+        {
+
+            <tr>
+                <td>@race.GetDisplayName()</td>
+                <td>@race.PercentOfTotal.ToString("P2")</td>
+            </tr>
+        }
+        </tbody>
+    </table>
+}
+
+<a href="@Url.Action("SelectDistrict", "OdsInstanceSettings", new {id = Model.LocalEducationAgencyId})">@Html.Button("Back to Reports")</a>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Reports/_SchoolsBySchoolType.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Reports/_SchoolsBySchoolType.cshtml
@@ -1,0 +1,41 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Management.Database.Ods.SchoolTypeReport
+<div class="padding-bottom-10" align="center">
+    <h2>@Model.LocalEducationAgencyName</h2>
+</div>
+
+<h3>Schools by School Type</h3>
+@if (Model.SchoolCounts.Count == 0)
+{
+    <em class="padding-top">There is no school data to display</em>
+}
+else
+{
+    <table class="table table-condensed table-left-border">
+        <thead>
+            <tr>
+                <th>School Type</th>
+                <th>Count</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var school in Model.SchoolCounts)
+            {
+
+                <tr>
+                    <td>@school.Description</td>
+                    <td>@school.Count</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+<a href="@Url.Action("SelectDistrict", "OdsInstanceSettings", new {id = Model.LocalEducationAgencyId})">@Html.Button("Back to Reports")</a>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Reports/_SelectDistrict.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Reports/_SelectDistrict.cshtml
@@ -1,0 +1,107 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.Reports.SelectDistrictModel
+
+@{
+    bool autoSelectSingleItem = Model.DistrictOptions.Length == 1 && Model.LocalEducationAgencyId.ToString() != Model.DistrictOptions.Single().Value;
+}
+
+<div class="row">
+    @if (Model.DistrictOptions.Any())
+    {
+        if (Model.DistrictOptions.Count() == 1)
+        {
+            <div class="col-md-12 padding-top">
+                @Html.SelectListBlock(m => m.LocalEducationAgencyId, Model.DistrictOptions, x => x, null).Id("select-district-report")
+            </div>
+        }
+        else
+        {
+            <div class="col-md-12 padding-top">
+                @Html.SelectListBlock(m => m.LocalEducationAgencyId, Model.DistrictOptions, x => x, null, true).Id("select-district-report")
+            </div>
+        }
+    }
+    else
+    {
+        <div class="col-md-12 padding-top">
+            <strong>There are no reports available for this category</strong>
+        </div>
+    }
+</div>
+
+<table id="reports-index" class="table" hidden>
+    <thead>
+    <tr>
+        <th>Report Name</th>
+    </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><a data-action="EnrollmentByEthnicity">Enrollment By Ethnicity</a></td>
+        </tr>
+        <tr>
+            <td><a data-action="EnrollmentByGender">Enrollment By Gender</a></td>
+        </tr>
+        <tr>
+            <td><a data-action="EnrollmentByRace">Enrollment By Race</a></td>
+        </tr>
+        <tr>
+            <td><a data-action="TotalEnrollment">Enrollment Total</a></td>
+        </tr>
+        <tr>
+            <td><a data-action="SchoolsBySchoolType">Schools by School Type</a></td>
+        </tr>
+        <tr>
+            <td><a data-action="StudentsByAttribute">Students by Attributes</a></td>
+        </tr>
+        <tr>
+            <td><a data-action="StudentsByProgram">Students by Program</a></td>
+        </tr>
+    </tbody>
+</table>
+
+<script type="text/javascript">
+    $(function () {
+        handleReportList($("#select-district-report").find("select").val());
+
+        function handleReportList(leaId) {
+            if (StringIsNullOrWhitespace(leaId)) {
+                $("#reports-index a").each(function () {
+                    $(this).removeAttr("href");
+                });
+                $("#reports-index").hide();
+                return;
+            }
+
+            $("#reports-index a").each(function () {
+                var action = $(this).data("action");
+                var currentUrl = window.location.pathname;
+                var index = currentUrl.indexOf('/SelectDistrict');
+                var baseHref = currentUrl.substring(0, index !== -1 ? index : currentUrl.length);
+
+                $(this).attr('href', `${baseHref}/${action}/${leaId}`);
+            });
+
+            $("#reports-index").show();
+
+        }
+
+        $("#select-district-report").find("select").change(function () {
+            var leaId = $(this).val();
+            var url = "@Html.Raw(Url.Action("SelectDistrict", "OdsInstanceSettings"))" + "/" + leaId;
+            window.location = url;
+        });
+
+        @if (autoSelectSingleItem)
+        {
+            @:$("#select-district-report").find("select").trigger("change");
+        }
+    });
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Reports/_StudentsByAttribute.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Reports/_StudentsByAttribute.cshtml
@@ -1,0 +1,41 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Management.Database.Ods.StudentEconomicSituationReport
+<div class="padding-bottom-10" align="center">
+    <h2>@Model.LocalEducationAgencyName</h2>
+</div>
+
+<h3>Students By Attribute</h3>
+@if (Model.TotalStudentCount == 0)
+{
+    <em class="padding-top">There is no student data to display</em>
+}
+else
+{
+    <table class="table table-condensed table-left-border">
+        <thead>
+            <tr>
+                <th>Other Student Information</th>
+                <th>Students</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var economicCategory in Model.GetStudentEconomicSummary())
+            {
+
+                <tr>
+                    <td>@economicCategory.Description</td>
+                    <td>@economicCategory.PercentOfTotal.ToString("P2")</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+<a href="@Url.Action("SelectDistrict", "OdsInstanceSettings", new {id = Model.LocalEducationAgencyId})">@Html.Button("Back to Reports")</a>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Reports/_StudentsByProgram.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Reports/_StudentsByProgram.cshtml
@@ -1,0 +1,40 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Management.Database.Ods.StudentsByProgramReport
+<div class="padding-bottom-10" align="center">
+    <h2>@Model.LocalEducationAgencyName</h2>
+</div>
+<h3>Students By Program</h3>
+@if (Model.TotalStudentCount == 0)
+{
+    <em class="padding-top">There is no program data to display</em>
+}
+else
+{
+    <table class="table table-condensed table-left-border">
+        <thead>
+            <tr>
+                <th>Program</th>
+                <th>Students</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var program in Model.GetAllPrograms())
+            {
+
+                <tr>
+                    <td>@program.ProgramName</td>
+                    <td>@program.PercentOfTotalStudents.ToString("P2")</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+<a href="@Url.Action("SelectDistrict", "OdsInstanceSettings", new {id = Model.LocalEducationAgencyId})">@Html.Button("Back to Reports")</a>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Reports/_TotalEnrollment.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Reports/_TotalEnrollment.cshtml
@@ -1,0 +1,25 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Management.Database.Ods.TotalEnrollmentReport
+<div class="padding-bottom-10" align="center">
+    <h2>@Model.LocalEducationAgencyName</h2>
+</div>
+
+<h3>Total Enrollment</h3>
+<table class="table table-condensed table-left-border">
+    <tbody>
+    <tr>
+        <th>Total Enrollment</th>
+        <td>@Model.EnrollmentCount</td>
+    </tr>
+    </tbody>
+</table>
+
+
+<a href="@Url.Action("SelectDistrict", "OdsInstanceSettings", new {id = Model.LocalEducationAgencyId})">@Html.Button("Back to Reports")</a>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Setup/FirstTimeSetup.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Setup/FirstTimeSetup.cshtml
@@ -1,0 +1,106 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+
+@{
+    ViewBag.Title = "First Time Setup";
+}
+
+<div class="container">
+    <div class="row">
+        <div class="col-lg-12">
+            <h5>
+                <img src="~/Content/images/settings_2@2x.png" width="28" height="35" alt="">
+                <span class="padding-left">Additional Setup Required</span>
+            </h5>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-lg-10">
+            <p>
+                There are some final setup tasks required before your Ed-Fi ODS instance is fully functional.
+                Please note that this process could take anywhere from a few minutes to up to 30 minutes or more, depending on the availability of the newly-configured resources.
+            </p>
+            <div id="general-error-note" class="text-danger padding-bottom-10 setup-error" style="display: none">
+                <strong>Note:</strong> Additional setup has experienced an error.<br />
+                Please wait a few minutes and click the <strong><em>Try again</em></strong> button to attempt setup again.
+            </div>
+            <div id="transient-error-note" class="text-danger padding-bottom-10 setup-error" style="display: none">
+                <strong>Note:</strong> Waiting for availability of resources.
+            </div>
+            <div id="retry-error-note" class="text-danger padding-bottom-10 setup-error" style="display: none">
+                <strong>Note:</strong> Waiting for setup processes to complete. Will continue re-trying.
+            </div>
+        </div>
+    </div>    
+    <div>
+        <a href="#" class="btn btn-primary" id="finish-setup-link">Continue <span class="padding-left"><i class="fa fa-chevron-circle-right"></i></span></a>
+    </div>
+</div>
+
+<script language="javascript">
+    $('#finish-setup-link').click(function () {
+        $(this).html('Running... <span class="padding-left"><i id="spinner" class="fa fa-spinner fa-pulse"></i></span>');
+        $(this).attr('disabled', true);
+
+        $('.setup-error').hide();
+
+        var ajaxSettings = {
+            url: "@Url.Action("CompleteFirstTimeSetup")",
+            method: "POST",
+            dataType: "json",
+            data: appendAntiForgeryToken({}),
+            retries: 10
+        };
+
+        var handleSuccess = function() {
+            $('#finish-setup-link').removeClass('btn-primary btn-danger').addClass('btn-success');
+            $('#finish-setup-link').html('Success <span class="padding-left"><i class="fa fa-check-circle"></i></span>');
+            window.location = '@Url.Action("Index", "Home", new { setupCompleted = true })';
+        };
+
+        var handleFailure = function (data) {
+            if (data.responseJSON && data.responseJSON.isTransientError) {
+                $('#transient-error-note').show();
+              
+                $.ajax(ajaxSettings)
+                    .done(function() {
+                        handleSuccess();
+                    })
+                    .fail(function () {
+                        if (ajaxSettings.retries-- > 0) {
+                            $('#finish-setup-link').removeClass('btn-primary').addClass('btn-danger');
+                            $('.setup-error').hide();
+                            $('#retry-error-note').show();
+                            handleFailure(data);
+                        } else {
+                                $('#finish-setup-link').html('Try again <span class="padding-left"><i class="fa fa-chevron-circle-right"></i></span>');
+                                $('#finish-setup-link').attr('disabled', false);
+                                $('.setup-error').hide();
+                                $('#general-error-note').show();
+                        }
+                    });
+            }
+
+            else {
+                $('#general-error-note').show();
+                $('#finish-setup-link').removeClass('btn-primary').addClass('btn-danger');
+                $('#finish-setup-link').html('Try again <span class="padding-left"><i class="fa fa-chevron-circle-right"></i></span>');
+                $('#finish-setup-link').attr('disabled', false);
+
+                var errorMsg = data.responseJSON && data.responseJSON.message
+                    ? data.responseJSON.message
+                    : 'Setup has experienced an error. Please wait a few minutes and click the <strong><em>Try again</em></strong> button to attempt setup again.';
+                toastr.error("<strong>Error:</strong> " + errorMsg);
+            }
+        };
+
+        $.ajax(ajaxSettings)
+            .done(handleSuccess)
+            .fail(handleFailure);
+    });
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Setup/PostUpdateSetup.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Setup/PostUpdateSetup.cshtml
@@ -1,0 +1,69 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+
+@{
+    ViewBag.Title = "Post-Update Setup";
+}
+
+<div class="container">
+    <div class="row">
+        <div class="col-lg-12">
+            <h5>
+                <img src="~/Content/images/settings_2@2x.png" width="28" height="35" alt="">
+                <span class="padding-left">Additional Setup Required</span>
+            </h5>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-lg-10">
+            <p>Some additional setup tasks must be completed before your Ed-Fi ODS upgrade is complete.</p>
+            <div id="transient-error-note" class="text-danger padding-bottom-10" style="display: none">
+                <strong>Note:</strong> Setup has experienced an error. However, it's likely this error is transient.<br/>
+                Please wait a few minutes and click the <strong><em>Try again</em></strong> button to attempt setup again.
+            </div>
+        </div>
+    </div>
+    <div>
+        <a href="#" class="btn btn-primary" id="finish-setup-link">Continue <span class="padding-left"><i class="fa fa-chevron-circle-right"></i></span></a>
+    </div>
+</div>
+
+<script language="javascript">
+    $('#finish-setup-link').click(function () {
+        $(this).html('Running... <span class="padding-left"><i id="spinner" class="fa fa-spinner fa-pulse"></i></span>');
+        $(this).attr('disabled', true);
+
+        $("#transient-error-note").hide();
+        
+        $.ajax({
+            url: "@Url.Action("CompletePostUpdateSetup")",
+            method: "POST",
+            dataType: "json",
+            data: appendAntiForgeryToken({})
+        })
+        .done(function(data) {
+                $('#finish-setup-link').removeClass("btn-primary btn-danger").addClass("btn-success");
+                $('#finish-setup-link').html('Success <span class="padding-left"><i class="fa fa-check-circle"></i></span>');
+                window.location = '@Url.Action("Index", "Home", new { setupCompleted = true })';
+            })
+        .fail(function (data) {
+                $('#finish-setup-link').removeClass("btn-primary").addClass("btn-danger");
+                $('#finish-setup-link').html('Try again <span class="padding-left"><i class="fa fa-chevron-circle-right"></i></span>');
+                $('#finish-setup-link').attr('disabled', false);
+
+                if (data.responseJSON && data.responseJSON.isTransientError) {
+                    $("#transient-error-note").show();
+                }
+
+                var errorMsg = data.responseJSON && data.responseJSON.message
+                    ? data.responseJSON.message
+                    : 'Setup has experienced an error. Please wait a few minutes and click the <strong><em>Try again</em></strong> button to attempt setup again.';
+                toastr.error("<strong>Error:</strong> " + errorMsg);
+            });
+    });
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/Error.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/Error.cshtml
@@ -5,28 +5,24 @@ The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2
 See the LICENSE and NOTICES files in the project root for more information.
 *@
 
-@model ErrorViewModel
+@model HandleErrorInfo
 @{
-    ViewData["Title"] = "Error";
+    ViewBag.Title = "Error";
 }
 
-<h1>@ViewData["Title"]</h1>
-<h2>An error occurred while processing your request.</h2>
+<div class="row">
+    <div class="col-md-12">
+        <h1>Error!</h1>
+        <h4>There was an error processing your request. Please user your browser's back button and try again.</h4>
+        <br />
+        @if (!string.IsNullOrWhiteSpace(Model.Exception.Message))
+        {
+            <h2>Details:</h2>
+            <blockquote>
+                <p>@Model.Exception.Message</p>
+            </blockquote>
+        }
 
-@if (Model.ShowRequestId)
-{
-    <p>
-        <strong>Request ID:</strong> <code>@Model.RequestId</code>
-    </p>
-}
-
-<h3>Development Mode</h3>
-<p>
-    Swapping to <strong>Development</strong> environment will display more detailed information about the error that occurred.
-</p>
-<p>
-    <strong>The Development environment shouldn't be enabled for deployed applications.</strong>
-    It can result in displaying sensitive information from exceptions to end users.
-    For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>
-    and restarting the app.
-</p>
+        <a href="javascript:history.go(-1);">Back</a>
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/Lockout.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/Lockout.cshtml
@@ -1,0 +1,17 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@model System.Web.Mvc.HandleErrorInfo
+
+@{
+    ViewBag.Title = "Locked Out";
+}
+
+<hgroup>
+    <h1 class="text-danger">Locked out.</h1>
+    <h2 class="text-danger">This account has been locked out, please try again later.</h2>
+</hgroup>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_Applications.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_Applications.cshtml
@@ -1,0 +1,21 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.Application
+@model IEnumerable<EdFi.Ods.AdminApp.Web.Models.ViewModels.VendorApplicationsModel>
+
+@{
+    ViewBag.Title = "Production | Applications";
+}
+
+@{ Html.RenderPartial("_DeleteVendorApplicationModal", new DeleteApplicationModel()); }
+@{ Html.RenderPartial("_RegenerateApplicationSecretModal", new RegenerateSecretModel()); }
+
+@foreach (var vendorApplicationModel in Model)
+{
+    Html.RenderPartial("_ApplicationsByVendor", vendorApplicationModel);
+}

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_ApplicationsByVendor.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_ApplicationsByVendor.cshtml
@@ -1,0 +1,31 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.VendorApplicationsModel
+
+<div class="row vendor-heading">
+    <div class="col-lg-12">
+        <h6>Vendor: @Model.VendorName</h6>
+    </div>
+</div>
+<div class="vendor-applications">
+    <div class="row padding-top">
+        <div class="col-lg-6">
+            <h6>Applications</h6>
+        </div>
+        <div class="col-lg-6 pull-right text-right">
+            <button class="cta loads-ajax-modal" data-url="@Url.Action("Add", "Application", new { VendorId = Model.VendorId })">
+                Add Application
+            </button>
+        </div>
+    </div>
+    <div class="row padding-bottom">
+        <div class="col-lg-12">
+            @Html.Partial("_ApplicationsTable", Model.Applications)
+        </div>
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_ApplicationsTable.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_ApplicationsTable.cshtml
@@ -1,0 +1,79 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model IEnumerable<EdFi.Ods.AdminApp.Web.Models.ViewModels.ApplicationModel>
+
+@foreach (var application in Model)
+{
+    <div class="vendor-application card">
+        <div class="row">
+            <div class="col-lg-6">
+                <h8>@application.DisplayName.ToTitleCase()</h8>
+            </div>
+
+            <div class="col-lg-6 text-right">
+                <a href="javascript:void(0)" class="edit-table loads-ajax-modal" data-url="@Url.Action("Edit", "Application", new { ApplicationId = application.ApplicationId, Environment = application.Environment.Value })"> <span class="fa fa-pencil action-icons"></span></a>
+                <a href="javascript:void(0)" class="delete-application-link" data-id="@application.ApplicationId" data-application-name="@application.DisplayName"> <span class="fa fa-trash-o action-icons"></span></a>
+                <span class="custom-divider"> |</span>
+                <a href="javascript:void(0)" data-toggle="collapse" data-target="#app-details-@(application.ApplicationId)"><span class="fa fa-chevron-up caret-custom panel-toggle"></span></a>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-lg-12">
+                <div id="app-details-@(application.ApplicationId)" class="collapse in application">
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <p>
+                                <strong>Education Organizations: </strong>
+                                @foreach (var edOrg in application.EducationOrganizations)
+                                {
+                                    <span class="tag label label-info tag-custom tag-modal">@edOrg.Name</span>
+                                }
+                            </p>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-lg-4">
+                            <p>
+                                <strong>Claim Set: </strong>@application.ClaimSetName
+                            </p>
+                        </div>
+                        <div class="col-lg-6">
+                            <p>
+                                <strong>Profile: </strong>@application.ProfileName
+                            </p>
+                        </div>
+                    </div>
+                    <div class="key-section">
+                        <div class="row">
+                            <div class="col-lg-6">
+                                <strong class="key-label">Key: </strong><a class="regenerate-application-secret-link" data-id="@application.ApplicationId" data-name="@application.DisplayName" href="javascript:void(0)">Regenerate</a>
+                            </div>
+                            <div class="col-lg-6">
+                                <strong class="key-label">Status: </strong> <strong class="text-success">Active</strong>
+                            </div>
+                        </div>
+                        <div class="row padding-top">
+                            <div class="col-lg-12 padding-top">
+                                <strong class="key-label">Secret:</strong> <span class="text-muted">You need to re-generate a key to obtain a secret.</span>
+                            </div>
+                        </div>
+                        <div class="row padding-top">
+                            <div class="col-lg-12 padding-top note-key">
+                                <strong>
+                                    <span class="text-danger">Note:</span>
+                                    For security purposes keys and secrets are viewable only after being re-generated.
+                                </strong>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+}

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_BulkUploadForm.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_BulkUploadForm.cshtml
@@ -1,0 +1,167 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers 
+@using EdFi.Ods.AdminApp.Web.Infrastructure.IO
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels
+@model BulkFileUploadModel
+
+@{
+    var maxFileSizeDisplay = BulkFileUploadModel.MaxFileSize/1000000;
+}
+
+@using (Html.BeginForm("BulkFileUpload", "BulkUpload", FormMethod.Post, new { enctype = "multipart/form-data", id = "bulk-upload-form" }))
+{
+    <div class="row padding-bottom-10">
+        <div class="col-lg-4">
+            <label>Select File Type:</label>
+            @(Html.SelectList<BulkFileUploadModel, InterchangeFileType>(x => x.BulkFileType))
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-lg-4">
+            <div class="input-group">
+                <div class="form-control" id="upload-file-info"></div>
+                <div class="input-group-btn">
+                    <button style="margin-left: -37px; display: none; z-index: 2;" class="btn btn-default btn-hover" id="clear-file-upload"><i class="fa fa-times fa-lg"></i></button>
+                    <label type="button" class="btn btn-primary">
+                        <input id="bulk-files-input" name="bulkFiles" type="file" style="display: none;" maxlength="@BulkFileUploadModel.MaxFileSize" accept=".xml"/>
+                        Select file
+                    </label>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-lg-12">
+            <span style="font-style: italic;">(maximum file size: @maxFileSizeDisplay MB, file type: .xml)</span>
+        </div>
+        <div class="col-lg-12">
+            <span id="upload-file-size-error" class="upload-error">The selected file to too large. Please select another file.</span>
+            <span id="upload-file-type-error" class="upload-error">Please select xml file.</span>
+            <span id="upload-file-error" class="upload-error">Error uploading bulk data. Please try again later.</span>
+        </div>
+    </div>
+    <div class="row" style="padding-top: 10px;">
+        <div class="col-lg-3">
+            <button id="upload-bulk-files-button" type="submit" class="no-ajax btn btn-success" disabled><i class="fa fa-upload"></i> Upload</button>
+            <i id="upload-button-spinner" class="fa fa-spinner fa-pulse fa-fw inline-icon" style="display: none;"></i>
+        </div>
+    </div>
+    @Html.HiddenFor(m => m.CloudOdsEnvironment)
+}
+
+<div id="bulk-upload-status-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="bulk-upload-status-modal" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title">Bulk Upload</h4>
+            </div>
+            <div class="modal-body center-block">
+                @Html.Partial("_SignalRStatus")
+            </div>
+            <div class="modal-footer">
+                @Html.CancelModalButton("Close")
+            </div>
+        </div>
+    </div>
+</div>
+
+
+<script type="text/javascript">
+    function ErrorStatusDisplay() {
+        $('#upload-bulk-files-button').prop("disabled", true);
+        $('#clear-file-upload').hide();
+        $('#upload-file-info').html("");
+    }
+
+    $("#bulk-files-input").change(function() {
+        if ($(this).get(0).files.length > 0) {
+            var maxLength = $(this).attr("maxlength");
+            var fileExt = $(this).attr("accept");
+            if (fileExt) {
+                for (var i = 0; i < $(this).get(0).files.length; ++i) {
+                    var fileName = $(this).get(0).files[i].name;
+                    if (fileName.substring(fileName.lastIndexOf('.')) !== fileExt) {
+                        $(this).get(0).value = "";
+                        $('#upload-file-type-error').show();
+                        ErrorStatusDisplay();
+                        return;
+                    }
+                }
+            }
+            if (maxLength) {
+                for (var j = 0; j < $(this).get(0).files.length; ++j) {
+                    if ($(this).get(0).files[j].size > maxLength) {
+                        $(this).get(0).value = "";
+                        $('#upload-file-size-error').show();
+                        ErrorStatusDisplay();
+                        return;
+                    }
+                }
+            }
+
+            $('#upload-file-info').html($(this).get(0).files[0].name);
+            $('#clear-file-upload').show();
+            $('#upload-bulk-files-button').prop("disabled", false);
+            $('.upload-error').hide();
+        }
+    });
+
+    $("#clear-file-upload").click(function(e) {
+        e.preventDefault();
+        $('#bulk-files-input').get(0).value = "";
+        $('#upload-bulk-files-button').prop("disabled", true);
+        $('#clear-file-upload').hide();
+        $('#upload-file-info').html("");
+    });
+
+    $(function () {
+        edfiODS.signalR.startListener($.connection.bulkUploadHub, null);
+        edfiODS.signalR.changeStatusMessage("Initializing file importer");
+    });
+
+    $("#bulk-upload-form").submit(function (e) {
+        e.preventDefault();
+        var $form = $(this);
+        var formData = appendAntiForgeryTokenForFileUpload($form);
+        
+        $('#upload-button-spinner').show();
+        $('#upload-bulk-files-button').prop("disabled", true);
+        $('.upload-error').hide();
+
+        $.ajax({
+            url: $form.attr("action"),
+            type: 'POST',
+            data: formData,
+            success: function (data, status, xhr) {
+                if (xhr.status !== edfiODS.httpStatusCodes.NoContent) {
+                    ShowBulkUploadStatusModal();
+                }
+                $('#upload-button-spinner').hide();
+                $('#upload-bulk-files-button').prop("disabled", false);
+            },
+            error: function () {
+                edfiODS.signalR.showError("Error uploading bulk data.  Please try again later");
+                $('#upload-button-spinner').hide();
+                $('#upload-bulk-files-button').prop("disabled", false);
+                $('#upload-file-error').show();
+            },
+            cache: false,
+            contentType: false,
+            processData: false
+        });
+    });
+
+    function ShowBulkUploadStatusModal() {
+        $("#bulk-upload-status-modal").modal({
+            keyboard: false,
+            backdrop: 'static'
+        });
+    }
+</script>
+

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_DeleteVendorApplicationModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_DeleteVendorApplicationModal.cshtml
@@ -1,0 +1,45 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.Application.DeleteApplicationModel
+
+<div class="modal fade" id="delete-application-modal" tabindex="-1" role="dialog" aria-labelledby="delete-application-modal" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Delete Application</h4>
+            </div>
+            <div class="modal-body center-block text-center">
+                <div class="alert alert-danger">
+                    <span>Are you sure you want to permanently delete <strong class="application-name"></strong>?  This action cannot be undone.</span>
+                </div>
+                @using (Html.BeginForm("Delete", "Application"))
+                {
+                    @Html.Input(m => m.ApplicationId).AddClass("application-id").Hide()
+                }
+            </div>
+            <div class="modal-footer">
+                @Html.ModalFormButtons("Confirm Delete")
+            </div>
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+    $(function () {
+        $(".delete-application-link").click(function () {
+            var applicationName = $(this).attr("data-application-name");
+            var id = $(this).attr("data-id");
+            var $deleteApplicationModal = $("#delete-application-modal");
+            $deleteApplicationModal.find(".application-name").text(applicationName);
+            $deleteApplicationModal.find(".application-id").attr("value", id);
+            $deleteApplicationModal.modal("toggle");
+        });
+    });
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_DeleteVendorModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_DeleteVendorModal.cshtml
@@ -1,0 +1,49 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.Global.DeleteVendorModel
+
+<div class="modal fade" id="delete-vendor-modal" tabindex="-1" role="dialog" aria-labelledby="delete-vendor-modal" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Delete Vendor</h4>
+            </div>
+            <div class="modal-body">
+                <div class="alert alert-danger">
+                    <div class="padding-bottom-10">Are you sure you want to permanently delete vendor <strong class="vendor-name"></strong>?</div>
+                    <ul>
+                        <li>All applications for this vendor will also be deleted and their API keys invalidated.</li>
+                        <li>This action cannot be undone.</li>
+                    </ul>
+                </div>
+                @using (Html.BeginForm("DeleteVendor", "GlobalSettings"))
+                {
+                    @Html.Input(m => m.VendorId).AddClass("vendor-id").Hide()
+                }
+            </div>
+            <div class="modal-footer">
+                @Html.ModalFormButtons("Delete Vendor")
+            </div>
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+    $(function () {
+        $(".delete-vendor-link").click(function () {
+            var name = $(this).attr("data-name");
+            var id = $(this).attr("data-id");
+            var $deleteVendorModal = $("#delete-vendor-modal");
+            $deleteVendorModal.find(".vendor-name").text(name);
+            $deleteVendorModal.find(".vendor-id").attr("value",id);
+            $deleteVendorModal.modal("toggle");
+        });
+    });
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_LogSettings.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_LogSettings.cshtml
@@ -1,0 +1,25 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.LogSettingsModel
+
+@using (Html.BeginForm("UpdateLogSettings", "GlobalSettings"))
+{
+    <div class="row subsection">
+        <div class="col-lg-12">
+            @Html.SelectListBlock(m => m.LogLevel, "Controls the amount of information logged to the API server logs")
+            @Html.HiddenFor(m => m.Environment)
+        </div>
+    </div>
+    <hr />
+    <div class="row">
+        <div class="col-lg-12 text-right">
+            @Html.SaveButton().AppendSpinner("log-settings-update-button")
+        </div>
+    </div>
+}

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_LoginPartial.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_LoginPartial.cshtml
@@ -1,0 +1,29 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using Microsoft.AspNet.Identity
+
+@helper FormatUsername(string username)
+{
+    var usernameParts = username.Split('#');
+    @usernameParts[usernameParts.Length-1]
+}
+
+@if (Request.IsAuthenticated)
+{
+    using (Html.BeginForm("LogOut", "Identity", FormMethod.Post, new { id = "logoutForm", @class = "navbar-right" }))
+    {
+        @Html.AntiForgeryToken()
+
+        <ul class="nav navbar-nav navbar-right">
+            <li>
+                @Html.ActionLink(User.Identity.GetUserName(), "ChangePassword", "Identity", new { }, new { id = "usernameLink" })
+            </li>
+            <li><a href="javascript:document.getElementById('logoutForm').submit()">Log Out</a></li>
+        </ul>
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_LoginPartial.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_LoginPartial.cshtml
@@ -1,4 +1,4 @@
-﻿@*
+@*
 SPDX-License-Identifier: Apache-2.0
 Licensed to the Ed-Fi Alliance under one or more agreements.
 The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
@@ -6,12 +6,6 @@ See the LICENSE and NOTICES files in the project root for more information.
 *@
 
 @using Microsoft.AspNet.Identity
-
-@helper FormatUsername(string username)
-{
-    var usernameParts = username.Split('#');
-    @usernameParts[usernameParts.Length-1]
-}
 
 @if (Request.IsAuthenticated)
 {

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_ProductionStagingReadOnlyNotice.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_ProductionStagingReadOnlyNotice.cshtml
@@ -1,0 +1,22 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+<div class="row">
+    <div class="col-lg-12 text-right">
+         <span class="read-only"><i class="fa fa-eye" aria-hidden="true"></i> Read Only</span>
+    </div>
+</div>
+<div class="alert alert-success message center-block">
+    <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+    <div class="row">
+        <div class="col-lg-12 hint-container">
+            <h6>Notice</h6>
+            <p>This instance shows read only content. In order to add vendors and applications, you should go to the <a href="@Url.Action("Index", "Settings")">Global tab</a>.
+            </p>
+        </div>
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_RegenerateApplicationSecretModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_RegenerateApplicationSecretModal.cshtml
@@ -1,0 +1,51 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.Application.RegenerateSecretModel
+
+<div class="modal fade" id="regenerate-application-secret-modal" tabindex="-1" role="dialog" aria-labelledby="regenerate-application-secret-modal" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content" id="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Regenerate Application Key/Secret</h4>
+            </div>
+            <div class="modal-body">
+                <div class="alert alert-danger">
+                    <div class="padding-bottom-10">Are you sure you want to regenerate the Key/Secret for <strong class="application-name"></strong>?</div>
+                    <ul>
+                        <li>The current API key will be invalidated.</li>
+                        <li>You'll need to update your external application configuration with the new Key/Secret.</li>
+                        <li>This action cannot be undone.</li>
+                    </ul>
+                </div>
+                @using (Html.BeginForm("RegenerateSecret", "Application"))
+                {
+                    @Html.Input(m => m.ApplicationId).AddClass("application-id").Hide()
+                }
+            </div>
+            <div class="modal-footer">
+                @Html.CancelModalButton()
+                @Html.SaveButton("Regenerate Key", "modal-content").AppendSpinner("add-app-spinner")
+            </div>
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+    $(function () {
+        $(".regenerate-application-secret-link").click(function () {
+            var name = $(this).attr("data-name");
+            var id = $(this).attr("data-id");
+            var $regenerateSecretModal = $("#regenerate-application-secret-modal");
+            $regenerateSecretModal.find(".application-name").text(name);
+            $regenerateSecretModal.find(".application-id").attr("value",id);
+            $regenerateSecretModal.modal("toggle");
+        });
+    });
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_SettingsGlobalHeader.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_SettingsGlobalHeader.cshtml
@@ -1,0 +1,21 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model List<EdFi.Ods.AdminApp.Web.Display.TabEnumeration.TabDisplay<EdFi.Ods.AdminApp.Web.Display.TabEnumeration.GlobalSettingsTabEnumeration>>
+
+<div class="row">
+    <div class="col-lg-4">
+        <h5>
+            <img src="~/Content/images/reports_2@2x.png"  height="30" alt="Reports" />
+            <span class="padding-left">Global</span>
+        </h5>
+    </div>
+</div>
+<div class="row">
+    @Html.NavTabs(Url, Model)
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_Settings_Global.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_Settings_Global.cshtml
@@ -1,0 +1,26 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.Global
+@model GlobalSettingsModel
+
+@{
+    ViewBag.Title = "Global";
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+
+@Html.Partial("_SettingsGlobalHeader", Model.GlobalSettingsTabEnumerations)
+
+<div class="row">
+    <div class="col-xs-12">
+        <div class="tab-content">
+            <div class="tab-pane active" id="global-tab">
+                @RenderBody()
+            </div>
+        </div>
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_Settings_Production.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_Settings_Production.cshtml
@@ -1,0 +1,43 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@using EdFi.Ods.AdminApp.Web.Infrastructure
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstanceSettings
+@model OdsInstanceSettingsModel
+
+@{
+    ViewBag.Title = "Settings";
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+
+<div class="row">
+    @if (CloudOdsAdminAppSettings.Instance.Mode.SupportsMultipleInstances)
+    {
+        <div class="col-xs-6">
+            <h2 title="@(Model.OdsInstance?.Name)">@(Model.OdsInstance?.Description)</h2>
+        </div>
+        <div class="col-xs-3 col-xs-offset-3">
+            @Html.Button("Back to ODS Instances").AddClass("back-btn back-ajax").Data("back-url", Url.Action("Index", "OdsInstances"))
+        </div>
+    }
+</div>
+
+<div class="row">
+    <div class="col-xs-12">
+        <div class="tab-content" id="settings-tabs">
+            <div class="tab-pane active" id="production-tab">
+                @RenderBody()
+            </div>
+        </div>
+    </div>
+</div>
+<script type="text/javascript">
+    $(function () {
+        InitializeBackNavigationalAjaxButtons();
+    });
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_SignalRStatus.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_SignalRStatus.cshtml
@@ -1,0 +1,19 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+<div id="signalr-progress">
+    <div class="progress">
+        <div id="signalr-status-progress-bar" class="progress-bar progress-bar-striped progress-bar-success active" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 1%;"></div>
+    </div>
+    <div class="text-left"><strong>Status: </strong><span id="signalr-status-message">Waiting for process to start.</span></div>
+    <div class="text-right margin-top-10">
+        <a id="signalr-done-button" href="javascript:void(0)" class="btn btn-primary" style="display:none">View</a>
+    </div>
+</div>
+
+@Scripts.Render("~/bundles/scripts/signalr")
+@Scripts.Render("~/signalr/hubs")

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_SignalRStatus_BulkLoad.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_SignalRStatus_BulkLoad.cshtml
@@ -1,0 +1,37 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstanceSettings
+@model OdsInstanceSettingsModel
+
+@if (Model.BulkFileUploadModel.IsJobRunning)
+{
+<div id="signalr-progress">
+    @if (Model.BulkFileUploadModel.IsSameOdsInstance)
+    {
+        <div class="progress" id="progress-bar">
+            <div id="signalr-status-progress-bar" class="progress-bar progress-bar-striped progress-bar-success active" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 1%;"></div>
+        </div>
+        <div class="text-left"><strong>Status: </strong><span id="signalr-status-message">Waiting for process to start.</span></div>
+    }
+    else
+    {
+        <div id="waiting-msg" class="alert alert-info">
+            Please wait. A bulk load job is already running for another instance of the ODS. The job status will be updated here when it has completed.
+        </div>
+        <div id="completed-msg" class="alert alert-info" style="display: none">
+            A bulk load job that was running for another instance of the ODS has completed. Please reload this page.
+        </div>
+    }
+    <div class="text-right margin-top-10">
+        <a id="signalr-done-button" href="javascript:void(0)" class="btn btn-primary" style="display: none">View</a>
+    </div>
+</div>
+}
+
+@Scripts.Render("~/bundles/scripts/signalr")
+@Scripts.Render("~/signalr/hubs")

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_SignalRStatus_LS.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_SignalRStatus_LS.cshtml
@@ -1,0 +1,36 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstanceSettings
+@model OdsInstanceSettingsModel
+@if (Model.LearningStandardsModel.IsJobRunning)
+{
+    <div id="signalr-progress">
+        @if (Model.LearningStandardsModel.IsSameOdsInstance)
+        {
+            <div class="progress" id="progress-bar">
+                <div id="signalr-status-progress-bar" class="progress-bar progress-bar-striped progress-bar-success active" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 1%;"></div>
+            </div>
+            <div class="text-left"><strong>Status: </strong><span id="signalr-status-message">Waiting for process to start.</span></div>
+        }
+        else
+        {
+            <div id="waiting-msg" class="alert alert-info">
+                Please wait. A learning standards job is already running for another instance of the ODS. The job status will be updated here when it has completed.
+            </div>
+            <div id="completed-msg" class="alert alert-info" style="display: none">
+                A learning standards job that was running for another instance of the ODS has completed. Please reload this page.
+            </div>
+        }
+        <div class="text-right margin-top-10">
+            <a id="signalr-done-button" href="javascript:void(0)" class="btn btn-primary" style="display: none">View</a>
+        </div>
+    </div>
+}
+
+@Scripts.Render("~/bundles/scripts/signalr")
+@Scripts.Render("~/signalr/hubs")

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Update/Index.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Update/Index.cshtml
@@ -1,0 +1,51 @@
+@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Infrastructure
+@model EdFi.Ods.AdminApp.Management.CloudOdsUpdateInfo
+
+@{
+    ViewBag.Title = "Updates";
+}
+<div class="row">
+    <div class="col-lg-12">
+        <h5>
+            <img src="~/Content/images/updates@2x.png" width="64" height="64" alt=""/>
+            <span class="padding-left">Updates</span>
+        </h5>
+        <hr />
+    </div>
+</div>
+<div class="row">
+    <div class="col-lg-12">
+        
+        @if (Model.UpdateAvailable)
+        {
+            <h5 class="note">Update Available</h5>
+            <div>Installed Version: @Model.CurrentInstanceVersion</div>
+            <div>Latest Version: @Model.LatestPublishedVersion</div>
+            <br/>
+
+            if (Model.UpdateIsCompatible)
+            {
+                <p><strong>Good news!</strong> There's a newer version of the Ed-Fi ODS available. You can install this update via Windows PowerShell.</p>
+                <p>Please see the release notes for more details.</p>
+            }
+
+            else
+            {
+                <p>There's a newer version of the Ed-Fi ODS available, but it must be installed manually since it is a major version upgrade.</p>
+                <p>Please see the upgrade documentation for more details.</p>
+            }
+        }
+
+        else
+        {
+            <h5>Your system is up to date!</h5>
+        }
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/User/AddUser.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/User/AddUser.cshtml
@@ -1,0 +1,39 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.User.AddUserModel
+
+@{
+    ViewBag.Title = "Global | Users | Add User";
+}
+
+@Html.Partial("_SettingsGlobalHeader", Model.GlobalSettingsTabEnumerations)
+
+<div class="row">
+    <div class="col-md-offset-2 col-md-8">
+        <h3 style="text-align: center">Add a New User</h3>
+
+        @using (Html.BeginForm("AddUser", "User"))
+        {
+            @Html.AntiForgeryToken()
+            if (!Html.ViewData.ModelState.IsValid)
+            {
+                @Html.ValidationSummary("", new {@class = "alert alert-danger"})
+            }
+            @Html.InputBlock(x => x.Email)
+            @Html.InputBlock(x => x.Password)
+            @Html.InputBlock(x => x.ConfirmPassword)
+            <div class="row form-group">
+                <div class="col-xs-offset-4 col-xs-6">
+                    @Html.ActionLink("Back", "Users", "GlobalSettings", null, new {@class = "btn btn-primary cta"})
+                    @Html.SaveButton("Register a New User").AddClass("no-ajax")
+                </div>
+            </div>
+        }
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/User/EditOdsInstanceRegistrationsForUser.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/User/EditOdsInstanceRegistrationsForUser.cshtml
@@ -1,0 +1,68 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using System.Web.Mvc.Html
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.User.EditOdsInstanceRegistrationForUserModel
+
+@{
+    ViewBag.Title = "Global | Users | Manage Instances";
+}
+
+@Html.Partial("_SettingsGlobalHeader", Model.GlobalSettingsTabEnumerations)
+
+<div class="row">
+    <div class="col-md-offset-4 col-md-8">
+        <div class="padding-15">
+            <h3 style="display: inline">Manage Ods Instances For : </h3>
+            <h4 style="display: inline"><b>@Model.Email</b></h4>
+        </div>
+
+        @if (Model.OdsInstanceRegistrations.Any())
+        {
+            using (Html.BeginForm("EditOdsInstanceRegistrationsForUser", "User", FormMethod.Post, new
+            {
+                @id = "edit-ods-instances-on-user-form",
+                @class = "padding-15"
+            }))
+            {
+                @Html.HiddenFor(x => x.UserId)
+                @Html.HiddenFor(x => x.Email)
+                @Html.AntiForgeryToken()
+                if (!Html.ViewData.ModelState.IsValid)
+                {
+                    @Html.ValidationSummary("", new { @class = "alert alert-danger" })
+                }
+                <input type="checkbox" id="selectAllCheckbox" /><label class="padding-left" for="selectAllCheckbox">Select All</label>
+                for (int i = 0; i < Model.OdsInstanceRegistrations.Count(); i++)
+                {
+                    <div>
+                        @Html.HiddenFor(m => m.OdsInstanceRegistrations[i].OdsInstanceRegistrationId)
+                        @Html.HiddenFor(m => m.OdsInstanceRegistrations[i].Name)
+                        @Html.CheckBoxFor(m => m.OdsInstanceRegistrations[i].Selected, new { @class = "instance-checkbox" })
+                        @Html.LabelFor(m => m.OdsInstanceRegistrations[i].Selected, Model.OdsInstanceRegistrations[i].Name)
+                    </div>
+                }
+
+                <div class="padding-top-5 margin-top-10">
+                    @Html.ActionLink("Back", "Users", "GlobalSettings", null, new { @class = "btn btn-primary cta" })
+                    @Html.SaveButton("Assign Instances").AddClass("no-ajax")
+                </div>
+            }
+        }
+    </div>
+</div>
+<script type="text/javascript">
+    $("#selectAllCheckbox").click(function () {
+        $(".instance-checkbox").prop('checked', $(this).prop('checked'));
+    });
+    $(".instance-checkbox").change(function () {
+        if (!$(this).prop("checked")) {
+            $("#selectAllCheckbox").prop("checked", false);
+        }
+    });
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/User/_DeleteUserModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/User/_DeleteUserModal.cshtml
@@ -1,0 +1,35 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.User.DeleteUserModel
+
+<div id="delete-user-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="deleteUserModal" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Delete User</h4>
+            </div>
+            <div class="modal-body center-block text-center">
+                <div class="padding-bottom-10">
+                    Do you want to delete the user - <b>@Model.Email</b>?
+                </div>
+                @using (Html.BeginForm("DeleteUser", "User", FormMethod.Post))
+                {
+                    @Html.ValidationBlock()
+                    @Html.Input(m => m.UserId).Hide()
+                    @Html.Input(m => m.Email).Hide()
+                }
+            </div>
+            <div class="modal-footer">
+                @Html.CancelModalButton()
+                @Html.SaveButton("Delete")
+            </div>
+        </div>
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/User/_EditUserModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/User/_EditUserModal.cshtml
@@ -1,0 +1,35 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.User.EditUserModel
+
+<div id="edit-user-profile-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="editUserProfileModal" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Edit User Profile</h4>
+            </div>
+            <div class="modal-body center-block text-center">
+                <div class="padding-bottom-10">
+                    Edit User Profile for <b>@Model.Email</b>?
+                </div>
+                @using (Html.BeginForm("EditUser", "User", FormMethod.Post))
+                {
+                    @Html.Input(x => x.UserId).Hide()
+                    @Html.ValidationBlock()
+                    @Html.InputBlock(x => x.Email)
+                }
+            </div>
+            <div class="modal-footer">
+                @Html.CancelModalButton()
+                @Html.SaveButton("Update")
+            </div>
+        </div>
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/User/_EditUserRoleModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/User/_EditUserRoleModal.cshtml
@@ -1,0 +1,49 @@
+﻿@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using System.Web.Mvc.Html
+@using EdFi.Ods.AdminApp.Management.Database.Models
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.User.EditUserRoleModel
+
+<div id="edit-user-role-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="editUserRoleModal" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Edit User Role</h4>
+            </div>
+            <div class="modal-body center-block text-center">
+                <div class="padding-bottom-10">
+                    Edit Role for <b>@Model.Email</b>?
+                </div>
+                @using (Html.BeginForm("EditUserRole", "User", FormMethod.Post))
+                {
+                    @Html.Input(x => x.UserId).Hide()
+                    @Html.Input(x => x.Email).Hide()
+                    @Html.ValidationBlock()
+                    <div class="row">
+                        <div class="col-md-offset-4 col-md-4">
+                            <div class="row form-group pull-left">
+                                @Html.RadioButtonFor(x => x.RoleId, Role.SuperAdmin.Value)
+                                @Html.Label(Role.SuperAdmin.DisplayName)
+                            </div>
+                            <div class="row form-group pull-left">
+                                @Html.RadioButtonFor(x => x.RoleId, Role.Admin.Value)
+                                @Html.Label(Role.Admin.DisplayName)
+                            </div>
+                        </div>
+                    </div>
+                }
+            </div>
+            <div class="modal-footer">
+                @Html.CancelModalButton()
+                @Html.SaveButton("Save")
+            </div>
+        </div>
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web/Views/Shared/_LoginPartial.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/Shared/_LoginPartial.cshtml
@@ -1,4 +1,4 @@
-﻿@*
+@*
 SPDX-License-Identifier: Apache-2.0
 Licensed to the Ed-Fi Alliance under one or more agreements.
 The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
@@ -6,12 +6,6 @@ See the LICENSE and NOTICES files in the project root for more information.
 *@
 
 @using Microsoft.AspNet.Identity
-
-@helper FormatUsername(string username)
-{
-    var usernameParts = username.Split('#');
-    @usernameParts[usernameParts.Length-1]
-}
 
 @if (Request.IsAuthenticated)
 {


### PR DESCRIPTION
Because cshtml files need to be physically present in the Web.Core project to work, here we stop attempting to share file paths with the Web project. We bulk copy all the views from the old Web project to the new Web.Core project.

There were a small number of manual edits, which I will list explicitly here. The reviewer need not verify the content of the other files being added here as I have already done that.

Actual changes:

1. For both the old _LoginPartial and its copy, I removed the helper FormatUsername(....). This helper was not in fact used anymore, so there is no change in behavior. I had to do this because the helper concept no longer exists in ASPNET Core, and it was producing a compiler error.
2. We have a trivial temporary HomeController, to soon be replaced with our real HomeController. Just to keep this one running so that the developer can see the layout working, I had to modify the Error action and introduce a stub copy of the old MVC HandleErrorInfo type.
3. Because some cshtml issues to be resolved in future PRs cause compiler errors now, I modified the csproj to explicitly exclude the cshtml files one by one. As we "wake up" each user-facing feature, the developer should manually delete the Content Remove lines for their views, allowing the default wildcard to automatically include them again. Think of this series of Content Remove tags as a "to-do list" for establishing our features in Web.Core.