### PR TITLE
Applied the AutoValidateAntiforgeryTokenAttribute for .NET Core project

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
@@ -31,7 +31,6 @@
     <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/ActionFilters/RequreSecureConnectionFilter.cs" LinkBase="ActionFilters" /> -->
     <Compile Include="../EdFi.Ods.AdminApp.Web/ActionFilters/SetupRequiredFilter.cs" LinkBase="ActionFilters" />
     <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/ActionFilters/UserContextFilter.cs" LinkBase="ActionFilters" /> -->
-    <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/ActionFilters/ValidateAntiForgeryTokenOnPostActionsFilter.cs" LinkBase="ActionFilters" /> -->
 
     <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/App_Start/ApplicationSignInManager.cs" LinkBase="App_Start" /> -->
     <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/App_Start/ApplicationUserManager.cs" LinkBase="App_Start" /> -->

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Startup.cs
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Startup.cs
@@ -22,6 +22,7 @@ using FluentValidation.AspNetCore;
 using Hangfire;
 using log4net;
 using log4net.Config;
+using Microsoft.AspNetCore.Mvc;
 
 namespace EdFi.Ods.AdminApp.Web
 {
@@ -64,6 +65,7 @@ namespace EdFi.Ods.AdminApp.Web
                     {
                         options.Filters.Add<JsonValidationFilter>();
                         options.Filters.Add<SetupRequiredFilter>();
+                        options.Filters.Add<AutoValidateAntiforgeryTokenAttribute>();
                     })
                     .AddFluentValidation(opt =>
                     {

--- a/Application/EdFi.Ods.AdminApp.Web.Core/wwwroot/Scripts/site-form-handlers.js
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/wwwroot/Scripts/site-form-handlers.js
@@ -12,7 +12,10 @@ var submitAjax = function ($form, updateTargetId, spinnerId) {
     $.ajax({
         url: $form.attr("action"),
         type: "post",
-        data: appendAntiForgeryToken($form.serialize()),
+        data: $form.serialize(),
+        beforeSend: function (xhr) {
+            xhr.setRequestHeader("RequestVerificationToken", getAntiForgeryToken());
+        },
         contentType: "application/x-www-form-urlencoded; charset=UTF-8",
         global: false,  //global handlers disabled as logic below handles these cases
         success: function (data, status, xhr) {

--- a/Application/EdFi.Ods.AdminApp.Web.Core/wwwroot/Scripts/site.js
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/wwwroot/Scripts/site.js
@@ -46,9 +46,6 @@ function GlobalInitialize() {
     SetupPanelToggle();
     LoadAsyncActions();
     ClaimSetWarningMessage();
-    //Temporarily break the __RequestVerificationToken, to prove that
-    //antiforgery tokens are not being enforced yet.
-    $("input[name=__RequestVerificationToken]").remove();
 }
 
 function ReinitializeForModal() {

--- a/Application/EdFi.Ods.AdminApp.Web.Core/wwwroot/Scripts/site.js
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/wwwroot/Scripts/site.js
@@ -46,6 +46,9 @@ function GlobalInitialize() {
     SetupPanelToggle();
     LoadAsyncActions();
     ClaimSetWarningMessage();
+    //Temporarily break the __RequestVerificationToken, to prove that
+    //antiforgery tokens are not being enforced yet.
+    $("input[name=__RequestVerificationToken]").remove();
 }
 
 function ReinitializeForModal() {


### PR DESCRIPTION
**Description**

This PR serves to apply the AutoValidateAntiforgeryTokenAttribute globally in the .NET Core Web project. This performs the same function as the ValidateAntiForgeryTokenOnPostActionsFilter in .NET 48 project to prevent CSRF attacks.

- Proving that altough antiforgery tokens are included in forms by default, they are not enforced. Even after an explicit token removal, POSTs are processed in full.
- Added AutoValidateAntiforgeryTokenAttribute globally to validate the AntiForgery token for POST requests.
- Refactored the submitAjax  function in site-form-handler.js to add the RequestVerification token to the specific "RequestVeirficationToken" request header instead of appending it to the serialized form as the server is looking for the particular header for the token.
- Removed the temporary breakage of client side antiforgery tokens, now that we have proven the server side is correctly requiring and validating them. The Vendor flow should be working again as of this commit.
- Removed the commented explicit inclusion of ValidateAntiForgeryTokenOnPostActionsFilter as this is an in-built mechanism available with .NET Core.