### PR TITLE
Strongly typed dbsets

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/User/UserTestSetup.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/User/UserTestSetup.cs
@@ -119,7 +119,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.User
             }
             using (var database = AdminAppIdentityDbContext.Create())
             {
-                database.Set<IdentityUserRole>().AddRange(userRoleRecords);
+                database.UserRoles.AddRange(userRoleRecords);
                 database.SaveChanges();
             }
         }

--- a/Application/EdFi.Ods.AdminApp.Management/Database/AdminAppIdentityDbContext.net48.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/AdminAppIdentityDbContext.net48.cs
@@ -41,6 +41,7 @@ namespace EdFi.Ods.AdminApp.Management.Database
         }
 
         public DbSet<UserOdsInstanceRegistration> UserOdsInstanceRegistrations { get; set; }
+        public DbSet<IdentityUserRole> UserRoles { get; set; }
 
         public static AdminAppIdentityDbContext Create()
         {

--- a/Application/EdFi.Ods.AdminApp.Management/User/DeleteUserCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/User/DeleteUserCommand.cs
@@ -49,11 +49,11 @@ namespace EdFi.Ods.AdminApp.Management.User
         private void RemoveExistingUserRoles(string userId)
         {
             var existingUserRoles =
-                _identity.Set<IdentityUserRole>().Where(x => x.UserId == userId);
+                _identity.UserRoles.Where(x => x.UserId == userId);
 
             if (existingUserRoles.Any())
             {
-                _identity.Set<IdentityUserRole>().RemoveRange(existingUserRoles);
+                _identity.UserRoles.RemoveRange(existingUserRoles);
             }
 
             _identity.SaveChanges();

--- a/Application/EdFi.Ods.AdminApp.Management/User/EditUserRoleCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/User/EditUserRoleCommand.cs
@@ -31,14 +31,14 @@ namespace EdFi.Ods.AdminApp.Management.User
             };
 
             var currentUserRole =
-                _identity.Set<IdentityUserRole>().SingleOrDefault(x => x.UserId == model.UserId);
+                _identity.UserRoles.SingleOrDefault(x => x.UserId == model.UserId);
 
             if (currentUserRole != null)
             {
-                _identity.Set<IdentityUserRole>().Remove(currentUserRole);
+                _identity.UserRoles.Remove(currentUserRole);
             }
 
-            _identity.Set<IdentityUserRole>().Add(newUserRole);
+            _identity.UserRoles.Add(newUserRole);
             _identity.SaveChanges();
         }
     }

--- a/Application/EdFi.Ods.AdminApp.Management/User/GetRoleForUserQuery.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/User/GetRoleForUserQuery.cs
@@ -23,7 +23,7 @@ namespace EdFi.Ods.AdminApp.Management.User
 
         public Role Execute(string userId)
         {
-            var userRoleId = _identity.Set<IdentityUserRole>().SingleOrDefault(x => x.UserId == userId)?.RoleId;
+            var userRoleId = _identity.UserRoles.SingleOrDefault(x => x.UserId == userId)?.RoleId;
             return userRoleId != null ? Role.GetAll().Single(x => x.Value.Equals(int.Parse(userRoleId))) : null;
         }
     }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/User/EditUserRoleModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/User/EditUserRoleModel.cs
@@ -60,7 +60,7 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.User
 
         private bool BeAnExistingRole(string roleId)
         {
-            return _identity.Set<IdentityRole>().Any(x => x.Id == roleId);
+            return _identity.Roles.Any(x => x.Id == roleId);
         }
     }
 }


### PR DESCRIPTION
Under .NET Core, some usages of dbContext.Set<T>() compile but will fail at runtime due to subtle discrepancies in the data type T versus EFCore's understanding of what the model should be. The solution is to use the strongly typed DbSet properties from the base class. Unfortunately, under the *old* Identity system in NET48, such a property is not always present. Here we work around that by defining it for NET48, and then using it in both NET48 and .NET Core.

Although I tested this, please be sure that your own testing hits each affected usage.