### PR TITLE
[AA-1110] - Finalize Global\Claimsets tab for .NET Core

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Core.Tests/EdFi.Ods.AdminApp.Management.Core.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Core.Tests/EdFi.Ods.AdminApp.Management.Core.Tests.csproj
@@ -47,23 +47,23 @@
         <!-- <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/User/GetAdminAppUserByIdQueryTests.cs" LinkBase="User" /> -->
         <!-- <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/User/GetAdminAppUsersQueryTests.cs" LinkBase="User" /> -->
         <!-- <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/User/AddUserTests.cs" LinkBase="User" /> -->
-        <!-- <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/AdminAppDataTestBase.cs" /> -->
+        <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/AdminAppDataTestBase.cs" />
         <!-- <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/AutoMapper/AutoMapperTests.cs" LinkBase="AutoMapper" /> -->
-        <!-- <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ClaimSetFileImportCommandTests.cs" LinkBase="ClaimSetEditor" /> -->
-        <!-- <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/DeleteResourceOnClaimSetCommandTests.cs" LinkBase="ClaimSetEditor" /> -->
-        <!-- <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ClaimSetFileExportCommandTests.cs" LinkBase="ClaimSetEditor" /> -->
-        <!-- <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ResetToDefaultAuthStrategyCommandTests.cs" LinkBase="ClaimSetEditor" /> -->
-        <!-- <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/OverrideDefaultAuthorizationStrategyCommandTests.cs" LinkBase="ClaimSetEditor" /> -->
-        <!-- <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/EditResourceOnClaimSetCommandTests.cs" LinkBase="ClaimSetEditor" /> -->
-        <!-- <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/EditClaimSetCommandTests.cs" LinkBase="ClaimSetEditor" /> -->
-        <!-- <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/AddClaimSetCommandTests.cs" LinkBase="ClaimSetEditor" /> -->
-        <!-- <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/DeleteClaimSetCommandTests.cs" LinkBase="ClaimSetEditor" /> -->
-        <!-- <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/CopyClaimSetCommandTests.cs" LinkBase="ClaimSetEditor" /> -->
-        <!-- <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetAuthStrategiesByApplicationNameQueryTests.cs" LinkBase="ClaimSetEditor" /> -->
-        <!-- <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetResourcesByClaimSetIdQueryTests.cs" LinkBase="ClaimSetEditor" /> -->
-        <!-- <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetApplicationsByClaimSetIdQueryTests.cs" LinkBase="ClaimSetEditor" /> -->
-        <!-- <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetClaimSetByIdQueryTests.cs" LinkBase="ClaimSetEditor" /> -->
-        <!-- <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetClaimSetsByApplicationNameQueryTests.cs" LinkBase="ClaimSetEditor" /> -->
+        <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ClaimSetFileImportCommandTests.cs" LinkBase="ClaimSetEditor" />
+        <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/DeleteResourceOnClaimSetCommandTests.cs" LinkBase="ClaimSetEditor" />
+        <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ClaimSetFileExportCommandTests.cs" LinkBase="ClaimSetEditor" />
+        <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ResetToDefaultAuthStrategyCommandTests.cs" LinkBase="ClaimSetEditor" />
+        <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/OverrideDefaultAuthorizationStrategyCommandTests.cs" LinkBase="ClaimSetEditor" />
+        <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/EditResourceOnClaimSetCommandTests.cs" LinkBase="ClaimSetEditor" />
+        <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/EditClaimSetCommandTests.cs" LinkBase="ClaimSetEditor" />
+        <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/AddClaimSetCommandTests.cs" LinkBase="ClaimSetEditor" />
+        <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/DeleteClaimSetCommandTests.cs" LinkBase="ClaimSetEditor" />
+        <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/CopyClaimSetCommandTests.cs" LinkBase="ClaimSetEditor" />
+        <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetAuthStrategiesByApplicationNameQueryTests.cs" LinkBase="ClaimSetEditor" />
+        <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetResourcesByClaimSetIdQueryTests.cs" LinkBase="ClaimSetEditor" />
+        <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetApplicationsByClaimSetIdQueryTests.cs" LinkBase="ClaimSetEditor" />
+        <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetClaimSetByIdQueryTests.cs" LinkBase="ClaimSetEditor" />
+        <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetClaimSetsByApplicationNameQueryTests.cs" LinkBase="ClaimSetEditor" />
         <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/CloudOdsUpdateCheckServiceTester.cs" />
         <!-- <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/Configuration/Claims/CloudOdsClaimSetConfiguratorTester.cs" LinkBase="Configuration\Claims" /> -->
         <!-- <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/Configuration/Claims/ModifyClaimSetsServiceTests.cs" LinkBase="Configuration\Claims" /> -->
@@ -105,7 +105,7 @@
         <!-- <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/Database/Queries/GetClaimSetNamesQueryTests.cs" LinkBase="Database/Queries" /> -->
         <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/Database/Queries/GetVendorByIdQueryTests.cs" LinkBase="Database/Queries" />
         <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/Database/Queries/GetVendorsQueryTests.cs" LinkBase="Database/Queries" />
-        <!-- <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/SecurityDataTestBase.cs" /> -->
+        <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/SecurityDataTestBase.cs" />
         <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/GetLatestPublishedOdsVersionQueryTester.cs" />
         <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/GetOdsStatusQueryTester.cs" />
         <Compile Include="../EdFi.Ods.AdminApp.Management.Tests/MockExtensions.cs" />

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/AdminAppDataTestBase.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/AdminAppDataTestBase.cs
@@ -4,7 +4,11 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using EdFi.Ods.AdminApp.Management.Database;
-using EdFi.Ods.AdminApp.Management.Helpers;
+#if NET48
+    using EdFi.Ods.AdminApp.Management.Helpers;
+#else
+    using EdFi.Ods.AdminApp.Web;
+#endif
 using NUnit.Framework;
 
 namespace EdFi.Ods.AdminApp.Management.Tests

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/CopyClaimSetCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/CopyClaimSetCommandTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using EdFi.Admin.DataAccess.Contexts;
 using NUnit.Framework;
 using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
+using EdFi.Ods.AdminApp.Web;
 using Moq;
 using Shouldly;
 using ClaimSet = EdFi.Security.DataAccess.Models.ClaimSet;
@@ -68,10 +69,20 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
                     parentResult.Children.All(x => x.Create).ShouldBe(true);
                 }
             });
-            Transaction<SqlServerUsersContext>(usersContext =>
+
+            #if NET48
+                using (var usersDbContext = new SqlServerUsersContext())
+            #else
+                using (var usersDbContext = new SqlServerUsersContext(Startup.ConfigurationConnectionStrings.Admin))
+            #endif
             {
-                usersContext.Applications.Count(x => x.ClaimSetName == copiedClaimSet.ClaimSetName).ShouldBe(0);
-            });
+                Transaction(
+                    usersDbContext, usersContext =>
+                    {
+                        usersContext.Applications.Count(x => x.ClaimSetName == copiedClaimSet.ClaimSetName)
+                            .ShouldBe(0);
+                    });
+            }
         }
 
         [Test]

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/CopyClaimSetCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/CopyClaimSetCommandTests.cs
@@ -44,7 +44,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 
             var copiedClaimSet = TestContext.ClaimSets.Single(x => x.ClaimSetId == copyClaimSetId);
             copiedClaimSet.ClaimSetName.ShouldBe(newClaimSet.Object.Name);
-            Transaction<SqlServerSecurityContext>(securityContext =>
+            Transaction(securityContext =>
             {
                 var query = new GetResourcesByClaimSetIdQuery(securityContext, GetMapper());
 

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/DeleteClaimSetCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/DeleteClaimSetCommandTests.cs
@@ -52,7 +52,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 
             var preservedClaimSet = TestContext.ClaimSets.Single(x => x.ClaimSetId == testClaimSetToPreserve.ClaimSetId);
             preservedClaimSet.ClaimSetName.ShouldBe(testClaimSetToPreserve.ClaimSetName);
-            Transaction<SqlServerSecurityContext>(securityContext =>
+            Transaction(securityContext =>
             {
                 var query = new GetResourcesByClaimSetIdQuery(securityContext, GetMapper());
 

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetAuthStrategiesByApplicationNameQueryTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetAuthStrategiesByApplicationNameQueryTests.cs
@@ -1,10 +1,9 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Linq;
-using EdFi.Admin.DataAccess.Contexts;
 using NUnit.Framework;
 using Shouldly;
 using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
@@ -26,9 +25,9 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 
             var authStrategies = SetupApplicationAuthorizationStrategies(testApplication);
 
-            Transaction(usersContext =>
+            Transaction(securityContext =>
             {
-                var query = new GetAuthStrategiesByApplicationNameQuery(TestContext);
+                var query = new GetAuthStrategiesByApplicationNameQuery(securityContext);
                 var results = query.Execute(authStrategies.First().Application.ApplicationName).ToArray();
 
                 results.Length.ShouldBe(authStrategies.Count);
@@ -62,9 +61,9 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 
             var authStrategies = SetupApplicationAuthorizationStrategies(testApplication);
 
-            Transaction(usersContext =>
+            Transaction(securityContext =>
             {
-                var query = new GetAuthStrategiesByApplicationNameQuery(TestContext);
+                var query = new GetAuthStrategiesByApplicationNameQuery(securityContext);
                 var results = query.Execute(authStrategies.First().Application.ApplicationName).ToArray();
 
                 results.Length.ShouldBe(authStrategies.Count);

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetAuthStrategiesByApplicationNameQueryTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetAuthStrategiesByApplicationNameQueryTests.cs
@@ -26,7 +26,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 
             var authStrategies = SetupApplicationAuthorizationStrategies(testApplication);
 
-            Transaction<SqlServerUsersContext>(usersContext =>
+            Transaction(usersContext =>
             {
                 var query = new GetAuthStrategiesByApplicationNameQuery(TestContext);
                 var results = query.Execute(authStrategies.First().Application.ApplicationName).ToArray();
@@ -62,7 +62,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 
             var authStrategies = SetupApplicationAuthorizationStrategies(testApplication);
 
-            Transaction<SqlServerUsersContext>(usersContext =>
+            Transaction(usersContext =>
             {
                 var query = new GetAuthStrategiesByApplicationNameQuery(TestContext);
                 var results = query.Execute(authStrategies.First().Application.ApplicationName).ToArray();

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetClaimSetsByApplicationNameQueryTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetClaimSetsByApplicationNameQueryTests.cs
@@ -10,6 +10,7 @@ using EdFi.Admin.DataAccess.Contexts;
 using NUnit.Framework;
 using Shouldly;
 using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
+using EdFi.Ods.AdminApp.Web;
 using Application = EdFi.Security.DataAccess.Models.Application;
 using VendorApplication = EdFi.Admin.DataAccess.Models.Application;
 using ClaimSet = EdFi.Security.DataAccess.Models.ClaimSet;
@@ -32,7 +33,12 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
                 Application = testApplication
             });
 
-            Transaction<SqlServerUsersContext>(usersContext =>
+            #if NET48
+                using (var usersDbContext = new SqlServerUsersContext())
+            #else
+                using (var usersDbContext = new SqlServerUsersContext(Startup.ConfigurationConnectionStrings.Admin))
+            #endif
+                Transaction(usersDbContext, usersContext =>
             {
                 var query = new GetClaimSetsByApplicationNameQuery(TestContext, usersContext);
                 var results = query.Execute(testApplication.ApplicationName).ToArray();
@@ -60,7 +66,12 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
                 Application = testApplication
             });
 
-            Transaction<SqlServerUsersContext>(usersContext =>
+            #if NET48
+                using (var usersDbContext = new SqlServerUsersContext())
+            #else
+                using (var usersDbContext = new SqlServerUsersContext(Startup.ConfigurationConnectionStrings.Admin))
+            #endif
+                Transaction(usersDbContext, usersContext =>
             {
                 var query = new GetClaimSetsByApplicationNameQuery(TestContext, usersContext);
                 var results = query.Execute(testApplication.ApplicationName).ToArray();
@@ -75,7 +86,12 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
         {
             var testClaimSets = SetupApplicationClaimSets();
 
-            Transaction<SqlServerUsersContext>(usersContext =>
+            #if NET48
+                using (var usersDbContext = new SqlServerUsersContext())
+            #else
+                using (var usersDbContext = new SqlServerUsersContext(Startup.ConfigurationConnectionStrings.Admin))
+            #endif
+                Transaction(usersDbContext, usersContext =>
             {
                 var query = new GetClaimSetsByApplicationNameQuery(TestContext, usersContext);
                 var results = query.Execute(testClaimSets.First().Application.ApplicationName).ToArray();
@@ -93,7 +109,12 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 
             var testClaimSets = SetupApplicationClaimSets();
 
-            Transaction<SqlServerUsersContext>(usersContext =>
+            #if NET48
+                using (var usersDbContext = new SqlServerUsersContext())
+            #else
+                using (var usersDbContext = new SqlServerUsersContext(Startup.ConfigurationConnectionStrings.Admin))
+            #endif
+                Transaction(usersDbContext, usersContext =>
             {
                 var query = new GetClaimSetsByApplicationNameQuery(TestContext, usersContext);
                 var results = query.Execute(testClaimSets.First().Application.ApplicationName).ToArray();
@@ -115,7 +136,12 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
                 Application = testApplication
             });
 
-            Transaction<SqlServerUsersContext>(usersContext =>
+            #if NET48
+                using (var usersDbContext = new SqlServerUsersContext())
+            #else
+                using (var usersDbContext = new SqlServerUsersContext(Startup.ConfigurationConnectionStrings.Admin))
+            #endif
+                Transaction(usersDbContext, usersContext =>
             {
                 var query = new GetClaimSetsByApplicationNameQuery(TestContext, usersContext);
                 var results = query.Execute(testApplication.ApplicationName).ToArray();
@@ -135,7 +161,12 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 
             var testClaimSets = SetupApplicationClaimSets();
 
-            Transaction<SqlServerUsersContext>(usersContext =>
+            #if NET48
+                using (var usersDbContext = new SqlServerUsersContext())
+            #else
+                using (var usersDbContext = new SqlServerUsersContext(Startup.ConfigurationConnectionStrings.Admin))
+            #endif
+                Transaction(usersDbContext, usersContext =>
             {
                 foreach (var claimSet in testClaimSets)
                 {

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetResourcesByClaimSetIdQueryTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetResourcesByClaimSetIdQueryTests.cs
@@ -34,7 +34,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             var testClaimSets = SetupApplicationWithClaimSets(testApplication).ToList();
             var testResourceClaims = SetupParentResourceClaims(testClaimSets, testApplication);
             
-            Transaction<SqlServerSecurityContext>(securityContext =>
+            Transaction(securityContext =>
             {
                 var query = new GetResourcesByClaimSetIdQuery(securityContext, GetMapper());
 
@@ -64,7 +64,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             var testClaimSets = SetupApplicationWithClaimSets(testApplication).ToList();
             var testResourceClaims = SetupParentResourceClaims(testClaimSets, testApplication);
 
-            Transaction<SqlServerSecurityContext>(securityContext =>
+            Transaction(securityContext =>
             {
                 var query = new GetResourcesByClaimSetIdQuery(securityContext, GetMapper());
 
@@ -96,7 +96,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             var testClaimSets = SetupApplicationWithClaimSets(testApplication);
             var testResourceClaims = SetupParentResourceClaimsWithChildren(testClaimSets, testApplication);
 
-            Transaction<SqlServerSecurityContext>(securityContext =>
+            Transaction(securityContext =>
             {
                 var query = new GetResourcesByClaimSetIdQuery(securityContext, GetMapper());
 
@@ -145,7 +145,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             var testResourceClaims = SetupParentResourceClaims(new List<ClaimSet>{testClaimSet}, testApplication);
             var testAuthStrategies = SetupResourcesWithDefaultAuthorizationStrategies(appAuthorizationStrategies, testResourceClaims.ToList());
 
-            Transaction<SqlServerSecurityContext>(securityContext =>
+            Transaction(securityContext =>
             {
                 var query = new GetResourcesByClaimSetIdQuery(securityContext, GetMapper());
 
@@ -174,7 +174,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             var testResourceClaims = SetupParentResourceClaims(new List<ClaimSet> { testClaimSet }, testApplication);
             var testAuthStrategies = SetupResourcesWithDefaultAuthorizationStrategies(appAuthorizationStrategies, testResourceClaims.ToList());
 
-            Transaction<SqlServerSecurityContext>(securityContext =>
+            Transaction(securityContext =>
             {
                 var query = new GetResourcesByClaimSetIdQuery(securityContext, GetMapper());
                 var testResourceClaim =
@@ -216,7 +216,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             var testResourceClaims = SetupParentResourceClaimsWithChildren(new List<ClaimSet> { testClaimSet }, testApplication);
             var testAuthStrategies = SetupResourcesWithDefaultAuthorizationStrategies(appAuthorizationStrategies, testResourceClaims.ToList());
 
-            Transaction<SqlServerSecurityContext>(securityContext =>
+            Transaction(securityContext =>
             {
                 var query = new GetResourcesByClaimSetIdQuery(securityContext, GetMapper());
                 var results = query.AllResources(testClaimSet.ClaimSetId).ToArray();

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/SecurityDataTestBase.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/SecurityDataTestBase.cs
@@ -7,7 +7,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using AutoMapper;
-using EdFi.Ods.AdminApp.Management.Helpers;
+#if NET48
+    using EdFi.Ods.AdminApp.Management.Helpers;
+#else
+    using EdFi.Ods.AdminApp.Web;
+#endif
 using EdFi.Ods.AdminApp.Web.Infrastructure.AutoMapper;
 using EdFi.Security.DataAccess.Contexts;
 using EdFi.Security.DataAccess.Models;

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/SharingModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/SharingModel.cs
@@ -4,7 +4,10 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
 
 namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
 {
@@ -12,6 +15,31 @@ namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
     {
         public string Title { get; set; }
         public SharingTemplate Template { get; set; }
+
+        public static string SerializeFromSharingModel(SharingModel model)
+        {
+            return JsonConvert.SerializeObject(model, UsingIndentedCamelCase());
+        }
+
+        public static SharingModel DeserializeToSharingModel(Stream jsonStream)
+        {
+            using (var streamReader = new StreamReader(jsonStream))
+                using (JsonReader jsonReader = new JsonTextReader(streamReader))
+                {
+                    return JsonSerializer
+                        .Create(UsingIndentedCamelCase())
+                        .Deserialize<SharingModel>(jsonReader);
+                }
+        }
+
+        private static JsonSerializerSettings UsingIndentedCamelCase()
+        {
+            return new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                Formatting = Formatting.Indented
+            };
+        }
     }
 
     public class SharingTemplate

--- a/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
@@ -38,7 +38,7 @@
 
     <Compile Include="../EdFi.Ods.AdminApp.Web/Controllers/ApplicationController.cs" LinkBase="Controllers" />
     <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/Controllers/BulkUploadController.cs" LinkBase="Controllers" /> -->
-    <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/Controllers/ClaimSetsController.cs" LinkBase="Controllers" /> -->
+    <Compile Include="../EdFi.Ods.AdminApp.Web/Controllers/ClaimSetsController.cs" LinkBase="Controllers" />
     <Compile Include="../EdFi.Ods.AdminApp.Web/Controllers/ControllerBase.cs" LinkBase="Controllers" />
     <Compile Include="../EdFi.Ods.AdminApp.Web/Controllers/DescriptorsController.cs" LinkBase="Controllers" />
     <Compile Include="../EdFi.Ods.AdminApp.Web/Controllers/EducationOrganizationsController.cs" LinkBase="Controllers" />
@@ -129,7 +129,7 @@
     <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/Infrastructure/ModelBinding/IFilteredModelBinder.cs" LinkBase="Infrastructure/ModelBinding" /> -->
     <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/Infrastructure/ModelBinding/IFilteredPropertyBinder.cs" LinkBase="Infrastructure/ModelBinding" /> -->
     <Compile Include="../EdFi.Ods.AdminApp.Web/Infrastructure/Property.cs" LinkBase="Infrastructure" />
-    <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/Infrastructure/ResourceClaimSelectListBuilder.cs" LinkBase="Infrastructure" /> -->
+    <Compile Include="../EdFi.Ods.AdminApp.Web/Infrastructure/ResourceClaimSelectListBuilder.cs" LinkBase="Infrastructure" />
     <Compile Include="../EdFi.Ods.AdminApp.Web/Infrastructure/Tags/DefaultDisplayLabelBuilder.cs" LinkBase="Infrastructure/Tags" />
     <Compile Include="../EdFi.Ods.AdminApp.Web/Infrastructure/Tags/OdsAdminHtmlConventionLibrary.cs" LinkBase="Infrastructure/Tags" />
     <Compile Include="../EdFi.Ods.AdminApp.Web/Infrastructure/Tags/OdsAdminHtmlTagConventions.cs" LinkBase="Infrastructure/Tags" />
@@ -146,7 +146,7 @@
     <Compile Include="../EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/AuthStrategyEditorModel.cs" LinkBase="Models/ViewModels/ClaimSets" />
     <Compile Include="../EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/ClaimSetDetailsModel.cs" LinkBase="Models/ViewModels/ClaimSets" />
     <Compile Include="../EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/ClaimSetFileExportModel.cs" LinkBase="Models/ViewModels/ClaimSets" />
-    <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/ClaimSetFileImportModel.cs" LinkBase="Models/ViewModels/ClaimSets" /> -->
+    <Compile Include="../EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/ClaimSetFileImportModel.cs" LinkBase="Models/ViewModels/ClaimSets" />
     <Compile Include="../EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/ClaimSetResourcesModel.cs" LinkBase="Models/ViewModels/ClaimSets" />
     <Compile Include="../EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/CopyClaimSetModel.cs" LinkBase="Models/ViewModels/ClaimSets" />
     <Compile Include="../EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/DeleteClaimSetModel.cs" LinkBase="Models/ViewModels/ClaimSets" />
@@ -209,17 +209,6 @@
     <Content Remove="Views\Application\_ApplicationKeyAndSecretContent.cshtml" />
     <Content Remove="Views\Application\_ApplicationKeyAndSecretModal.cshtml" />
     <Content Remove="Views\Application\_EditApplicationModal.cshtml" />
-    <Content Remove="Views\ClaimSets\_AddClaimSet.cshtml" />
-    <Content Remove="Views\ClaimSets\_AuthStrategiesModal.cshtml" />
-    <Content Remove="Views\ClaimSets\_ClaimSetDetails.cshtml" />
-    <Content Remove="Views\ClaimSets\_CopyClaimSetModal.cshtml" />
-    <Content Remove="Views\ClaimSets\_DeleteClaimSetModal.cshtml" />
-    <Content Remove="Views\ClaimSets\_DeleteClaimSetResourceModal.cshtml" />
-    <Content Remove="Views\ClaimSets\_EditClaimSet.cshtml" />
-    <Content Remove="Views\ClaimSets\_ExportClaimSet.cshtml" />
-    <Content Remove="Views\ClaimSets\_ExportClaimSetPreview.cshtml" />
-    <Content Remove="Views\ClaimSets\_ImportExportClaimSet.cshtml" />
-    <Content Remove="Views\ClaimSets\_ResourceEditor.cshtml" />
     <Content Remove="Views\Descriptors\_Descriptor.cshtml" />
     <Content Remove="Views\Descriptors\_DescriptorCategories.cshtml" />
     <Content Remove="Views\EducationOrganizations\_AddLocalEducationAgencyModal.cshtml" />
@@ -232,7 +221,6 @@
     <Content Remove="Views\Error\MultiInstanceError.cshtml" />
     <Content Remove="Views\Error\NotYetImplemented.cshtml" />
     <Content Remove="Views\GlobalSettings\AdvancedSettings.cshtml" />
-    <Content Remove="Views\GlobalSettings\ClaimSets.cshtml" />
     <Content Remove="Views\OdsInstances\_DeregisterOdsInstanceModal.cshtml" />
     <Content Remove="Views\OdsInstances\BulkRegisterOdsInstances.cshtml" />
     <Content Remove="Views\OdsInstances\Index.cshtml" />

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_AuthStrategiesModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_AuthStrategiesModal.cshtml
@@ -196,4 +196,4 @@ See the LICENSE and NOTICES files in the project root for more information.
                                           StringEscapeHandling = StringEscapeHandling.EscapeHtml
                                       })));
 </script>
-@Scripts.Render("~/bundles/scripts/authstrategy")
+<script type="text/javascript" src="~/bundles/authstrategy.min.js" asp-append-version="true"></script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_AuthStrategiesModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_AuthStrategiesModal.cshtml
@@ -7,6 +7,8 @@ See the LICENSE and NOTICES files in the project root for more information.
 
 @using EdFi.Ods.AdminApp.Web.Helpers
 @using EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
+@using Newtonsoft.Json;
+@using Newtonsoft.Json.Serialization
 @model AuthStrategyEditorModel
 
 <div id="auth-strategies-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="authStrategiesModal" aria-hidden="true">
@@ -189,6 +191,9 @@ See the LICENSE and NOTICES files in the project root for more information.
     var authStrategyOverrideUrl = '@Url.Action("OverrideAuthStrategiesOnResource", "ClaimSets")';
     var getUpdatedResourceUrl = '@Url.Action("GetUpdatedResourceClaim", "ClaimSets")';
     var resetAuthStrategyUrl = '@Url.Action("ResetAuthStrategiesOnResource", "ClaimSets")';
-    var authStrategiesOptions = JSON.parse(@Html.Raw(Json.Encode(Model.AuthStrategies)))
+    var authStrategiesOptions = JSON.parse(@Html.Raw(JsonConvert.SerializeObject(Model.AuthStrategies, new JsonSerializerSettings
+                                      {
+                                          StringEscapeHandling = StringEscapeHandling.EscapeHtml
+                                      })));
 </script>
 @Scripts.Render("~/bundles/scripts/authstrategy")

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_EditClaimSet.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_EditClaimSet.cshtml
@@ -1,4 +1,4 @@
-﻿@*
+@*
 SPDX-License-Identifier: Apache-2.0
 Licensed to the Ed-Fi Alliance under one or more agreements.
 The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
@@ -51,13 +51,13 @@ else
 <br />
 
 <div id="resource-editor-tab">
-    @Html.Partial("_ResourceEditor", new ClaimSetResourcesModel()
+   @{await Html.RenderPartialAsync("_ResourceEditor", new ClaimSetResourcesModel()
     {
         AllResourceClaims = Model.AllResourceClaims,
         ResourceClaims = Model.ResourceClaims,
         ClaimSetId = Model.ClaimSetId,
         ClaimSetName = Model.ClaimSetName
-    })
+    });}
 </div>
 <div class="padding-top-5">
     @Html.Button("Back").AddClass("back-btn back-ajax claimset-back-btn").Data("back-url", Url.Action("ClaimSets", "GlobalSettings"))

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_ExportClaimSet.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_ExportClaimSet.cshtml
@@ -5,7 +5,7 @@ The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2
 See the LICENSE and NOTICES files in the project root for more information.
 *@
 
-@using System.Web.Mvc.Html
+@using Newtonsoft.Json;
 @using EdFi.Ods.AdminApp.Web.Helpers
 @model EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets.ClaimSetFileExportModel
 
@@ -65,7 +65,10 @@ else
         var postData = {
             'Title': $("#Title").val(),
             'SelectedForExport': selectedClaimSetIds,
-            'ClaimSets': @Html.Raw(Json.Encode(Model.ClaimSets)),
+            'ClaimSets': @Html.Raw(JsonConvert.SerializeObject(Model.ClaimSets, new JsonSerializerSettings
+                    {
+                        StringEscapeHandling = StringEscapeHandling.EscapeHtml
+                    })),
             "__RequestVerificationToken": getAntiForgeryToken()
         };
 

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_ExportClaimSetPreview.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_ExportClaimSetPreview.cshtml
@@ -6,6 +6,7 @@ See the LICENSE and NOTICES files in the project root for more information.
 *@
 
 @using EdFi.Ods.AdminApp.Web.Helpers
+@using Newtonsoft.Json
 @model EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets.ExportClaimSetPreviewModel
 
 <h3>Export Claim Set Preview</h3>
@@ -29,7 +30,10 @@ See the LICENSE and NOTICES files in the project root for more information.
 
     var downloadFile = function(e) {
         e.preventDefault();
-        var downloadFileName = @Html.Raw(Json.Encode(Model.DownLoadFileTitle));
+        var downloadFileName = @Html.Raw(JsonConvert.SerializeObject(Model.DownLoadFileTitle, new JsonSerializerSettings
+                          {
+                              StringEscapeHandling = StringEscapeHandling.EscapeHtml
+                          }));
         saveFile($("#exportJson").val(), downloadFileName.concat(".json"), "application/json");
     }
 

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_ResourceEditor.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_ResourceEditor.cshtml
@@ -5,8 +5,9 @@ The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2
 See the LICENSE and NOTICES files in the project root for more information.
 *@
 
-@using System.Web.Mvc.Html
+@using Newtonsoft.Json;
 @using EdFi.Ods.AdminApp.Web.Helpers
+@using Newtonsoft.Json.Serialization
 @model EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets.ClaimSetResourcesModel
 
 <h3>Resources</h3>
@@ -137,8 +138,14 @@ See the LICENSE and NOTICES files in the project root for more information.
     var deleteResourceUrl = '@Url.Action("DeleteResourceOnClaimSet", "ClaimSets")';
     var deleteResourceModalUrl = '@Url.Action("DeleteResourceOnClaimSetModal", "ClaimSets")';
     var overrideAuthStrategyModalUrl = '@Url.Action("AuthStrategyModal", "ClaimSets")';
-    var claimSetInfo = @Html.Raw(Json.Encode(new { claimSetId = Model.ClaimSetId, claimSetName = Model.ClaimSetName}));
-    var existingResources = @Html.Raw(Json.Encode(Model.ResourceClaims));
+    var claimSetInfo = @Html.Raw(JsonConvert.SerializeObject(new { claimSetId = Model.ClaimSetId, claimSetName = Model.ClaimSetName}, new JsonSerializerSettings
+                  {
+                      StringEscapeHandling = StringEscapeHandling.EscapeHtml
+                  }));
+    var existingResources = @Html.Raw(JsonConvert.SerializeObject(Model.ResourceClaims, new JsonSerializerSettings
+                       {
+                           StringEscapeHandling = StringEscapeHandling.EscapeHtml
+                       }));
     var childResourcesForParentUrl = '@Url.Action("GetSelectListForChildResourceClaims", "ClaimSets")';
     InitializeModalLoaders();
 </script>  

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_ResourceEditor.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/ClaimSets/_ResourceEditor.cshtml
@@ -149,4 +149,4 @@ See the LICENSE and NOTICES files in the project root for more information.
     var childResourcesForParentUrl = '@Url.Action("GetSelectListForChildResourceClaims", "ClaimSets")';
     InitializeModalLoaders();
 </script>  
-@Scripts.Render("~/bundles/scripts/claimset")
+<script type="text/javascript" src="~/bundles/claimset.min.js" asp-append-version="true"></script>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/wwwroot/Scripts/resource-editor.js
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/wwwroot/Scripts/resource-editor.js
@@ -291,7 +291,7 @@ var populateChildResourcesForParent = function populateChildResourcesForParent(p
             $(data).each(function () {
                 var dropdown = $("#child-resource-dropdown-".concat(parentResourceId));
                 dropdown[0].selectedIndex = 0;
-                dropdown.append($("<option></option>").val(this.Value).html(this.Text).attr("disabled", this.Disabled));
+                dropdown.append($("<option></option>").val(this.value).html(this.text).attr("disabled", this.disabled));
                 var row = $("td[data-resource-id=".concat(parentResourceId, "]")).parent();
                 row.nextUntil("tr.parent-resource-claim").each(function () {
                     var resourceName = $(this).find(".resource-label").text();

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ClaimSetsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ClaimSetsController.cs
@@ -280,8 +280,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         [HttpPost]
         public ActionResult FileImport(ClaimSetFileImportModel claimSetFileImportModel)
         {
-            var sharingModel = claimSetFileImportModel.ImportFile.DeserializeToSharingModel();
-            _claimSetFileImportCommand.Execute(sharingModel);
+            _claimSetFileImportCommand.Execute(claimSetFileImportModel.AsSharingModel());
             return RedirectToAction("ClaimSets", "GlobalSettings");
         }
 
@@ -293,7 +292,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
             var exportClaimSetModel = new ExportClaimSetPreviewModel
             {
                 DownLoadFileTitle = $"{exports.Title}({currentDate})",
-                ExportPreviewString = InputFileExtensions.SerializeFromSharingModel(exports)
+                ExportPreviewString = SharingModel.SerializeFromSharingModel(exports)
             };
             return PartialView("_ExportClaimSetPreview", exportClaimSetModel);
         }

--- a/Application/EdFi.Ods.AdminApp.Web/Helpers/InputFileExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Helpers/InputFileExtensions.cs
@@ -70,31 +70,5 @@ namespace EdFi.Ods.AdminApp.Web.Helpers
 
             return missingHeaders;
         }
-
-        public static string SerializeFromSharingModel(SharingModel model)
-        {
-            return JsonConvert.SerializeObject(model, UsingIndentedCamelCase());
-        }
-
-        public static SharingModel DeserializeToSharingModel(Stream jsonStream)
-        {
-            using (var streamReader = new StreamReader(jsonStream))
-                using (JsonReader jsonReader = new JsonTextReader(streamReader))
-                {
-                    return JsonSerializer
-                        .Create(UsingIndentedCamelCase())
-                        .Deserialize<SharingModel>(jsonReader);
-                }
-        }
-
-        private static JsonSerializerSettings UsingIndentedCamelCase()
-        {
-            return new JsonSerializerSettings
-            {
-                ContractResolver = new CamelCasePropertyNamesContractResolver(),
-                Formatting = Formatting.Indented
-            };
-        }
-
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Helpers/InputFileExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Helpers/InputFileExtensions.cs
@@ -76,16 +76,15 @@ namespace EdFi.Ods.AdminApp.Web.Helpers
             return JsonConvert.SerializeObject(model, UsingIndentedCamelCase());
         }
 
-        public static SharingModel DeserializeToSharingModel(this HttpPostedFileBase json)
+        public static SharingModel DeserializeToSharingModel(Stream jsonStream)
         {
-            using (var stream = GetMemoryStream(json))
-                using (var streamReader = new StreamReader(stream))
-                    using (JsonReader jsonReader = new JsonTextReader(streamReader))
-                    {
-                        return JsonSerializer
-                            .Create(UsingIndentedCamelCase())
-                            .Deserialize<SharingModel>(jsonReader);
-                    }
+            using (var streamReader = new StreamReader(jsonStream))
+                using (JsonReader jsonReader = new JsonTextReader(streamReader))
+                {
+                    return JsonSerializer
+                        .Create(UsingIndentedCamelCase())
+                        .Deserialize<SharingModel>(jsonReader);
+                }
         }
 
         private static JsonSerializerSettings UsingIndentedCamelCase()

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/ResourceClaimSelectListBuilder.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/ResourceClaimSelectListBuilder.cs
@@ -53,7 +53,11 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure
             }
             parentGroupList = parentGroupList.OrderBy(x => x.Text).ToList();
             parentGroupList.AddRange(childGroupList.OrderBy(x => x.Text));
-            selectList.AddRange(new SelectList(parentGroupList, "Value", "Text", "Group.Name", -1));
+            #if NET48
+                selectList.AddRange(new SelectList(parentGroupList, "Value", "Text", "Group.Name", -1));
+            #else
+                selectList.AddRange(new SelectList(parentGroupList, "Value", "Text", -1, "Group.Name"));
+            #endif
             return selectList;
         }
     }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/ClaimSetFileImportModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/ClaimSetFileImportModel.cs
@@ -7,9 +7,12 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+#if NET48
 using System.Web;
+#else
+using Microsoft.AspNetCore.Http;
+#endif
 using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
-using EdFi.Ods.AdminApp.Web.Helpers;
 using EdFi.Ods.AdminApp.Web.Infrastructure;
 using EdFi.Security.DataAccess.Contexts;
 using FluentValidation;
@@ -24,12 +27,21 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
 
         [DisplayName("Import File")]
         [Accept(".json")]
-        public HttpPostedFileBase ImportFile { get; set; }
+
+        #if NET48
+            public HttpPostedFileBase ImportFile { get; set; }
+        #else
+            public IFormFile ImportFile { get; set; }
+        #endif
 
         public SharingModel AsSharingModel()
         {
+            #if NET48
                 return _sharingModel ??
                        (_sharingModel = SharingModel.DeserializeToSharingModel(ImportFile.InputStream));
+            #else
+                return _sharingModel ??= SharingModel.DeserializeToSharingModel(ImportFile.OpenReadStream());
+            #endif
         }
 
         public class ClaimSetFileImportModelValidator : AbstractValidator<ClaimSetFileImportModel>

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/ClaimSetFileImportModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/ClaimSetFileImportModel.cs
@@ -20,9 +20,17 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
 {
     public class ClaimSetFileImportModel
     {
+        private SharingModel _sharingModel;
+
         [DisplayName("Import File")]
         [Accept(".json")]
         public HttpPostedFileBase ImportFile { get; set; }
+
+        public SharingModel AsSharingModel()
+        {
+                return _sharingModel ??
+                       (_sharingModel = SharingModel.DeserializeToSharingModel(ImportFile.InputStream));
+        }
 
         public class ClaimSetFileImportModelValidator : AbstractValidator<ClaimSetFileImportModel>
         {
@@ -32,12 +40,11 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
 
                 When(m => m.ImportFile != null, () =>
                 {
-                    RuleFor(x => x.ImportFile)
+                    RuleFor(x => x)
                         .SafeCustom((model, context) =>
                         {
                             var validator = new SharingModelValidator(securityContext, context.PropertyName);
-                            var sharingModel = model.DeserializeToSharingModel();
-                            context.AddFailures(validator.Validate(sharingModel));
+                            context.AddFailures(validator.Validate(model.AsSharingModel()));
                         });
                 });
             }


### PR DESCRIPTION
**Description**

**.NET Core Web project**
- Included ClaimSetsController, ResourceClaimSelectListBuilder and ClaimSetFileImportModel in the .NET Core project. Included the claimset related views in the .NET Core project.
- Using Newton.Json on the claimset views instead of System.Web.Mvc and refactored to use JsonConvert.SerializeObject instead of Json.Encode with the StringEscapeHandling setting set to escape HTML in order to avoid security issues.
- Refactored to remove the Scripts.Render sections and include the bundled scripts using the script tag.
- Refactored to use a Stream object as an argument instead of the HttpPostedFileBase object.Moved the Serialization and Deserialization of Sharing Model from InputFileExtensions to SharingModel to as it is no longer dependent on the methods in InputFileExtensions.
- Refactored the ClaimsetFileImportModel to avoid reading the file twice by having the deserialized object in a private SharingModel variable. Added AsSharingModel function to get the file object as the deserialized SharingModel object. Refactored the controller actions to use the SharingModel serialization and AsSharingModel () functions.

**.NET Core Management.Tests project**
- Included the Claimset related tests and files in Management.Core.Tests.
- Added using directives for EdFi.Ods.AdminApp.Web for Startup.cs in AdminAppDataTestBase and SecurityDataTestBase files.
- Refactored to use the correct overload for Transaction.
- Refactored ClaimSetFileImportCommand tests to use IFormFile for .Net Core.