### PR TITLE
Enable splitting up OdsInstanceSettingsController

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
@@ -283,7 +283,6 @@
     <Content Remove="Views\Shared\_LogSettings.cshtml" />
     <Content Remove="Views\Shared\_ProductionStagingReadOnlyNotice.cshtml" />
     <Content Remove="Views\Shared\_RegenerateApplicationSecretModal.cshtml" />
-    <Content Remove="Views\Shared\_Settings_Production.cshtml" />
     <Content Remove="Views\Shared\_SignalRStatus.cshtml" />
     <Content Remove="Views\Shared\_SignalRStatus_BulkLoad.cshtml" />
     <Content Remove="Views\Shared\_SignalRStatus_LS.cshtml" />

--- a/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
@@ -190,6 +190,7 @@
     <Compile Include="../EdFi.Ods.AdminApp.Web/Models/ViewModels/OdsInstances/DeregisterOdsInstanceModel.cs" LinkBase="Models/ViewModels/OdsInstances" />
     <Compile Include="../EdFi.Ods.AdminApp.Web/Models/ViewModels/OdsInstances/IndexModel.cs" LinkBase="Models/ViewModels/OdsInstances" />
     <Compile Include="../EdFi.Ods.AdminApp.Web/Models/ViewModels/OdsInstances/RegisterOdsInstanceModel.cs" LinkBase="Models/ViewModels/OdsInstances" />
+    <Compile Include="../EdFi.Ods.AdminApp.Web/Models/ViewModels/OdsInstanceSettings/BaseOdsInstanceSettingsModel.cs" LinkBase="Models/ViewModels/OdsInstanceSettings" />
     <!-- <Compile Include="../EdFi.Ods.AdminApp.Web/Models/ViewModels/OdsInstanceSettings/OdsInstanceSettingsModel.cs" LinkBase="Models/ViewModels/OdsInstanceSettings" /> -->
     <Compile Include="../EdFi.Ods.AdminApp.Web/Models/ViewModels/OdsInstanceSettings/OdsInstanceSetupCompletedModel.cs" LinkBase="Models/ViewModels/OdsInstanceSettings" />
     <Compile Include="../EdFi.Ods.AdminApp.Web/Models/ViewModels/ProfileModel.cs" LinkBase="Models/ViewModels" />

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_Settings_Production.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Shared/_Settings_Production.cshtml
@@ -1,4 +1,4 @@
-﻿@*
+@*
 SPDX-License-Identifier: Apache-2.0
 Licensed to the Ed-Fi Alliance under one or more agreements.
 The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
@@ -8,7 +8,7 @@ See the LICENSE and NOTICES files in the project root for more information.
 @using EdFi.Ods.AdminApp.Web.Helpers
 @using EdFi.Ods.AdminApp.Web.Infrastructure
 @using EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstanceSettings
-@model OdsInstanceSettingsModel
+@model BaseOdsInstanceSettingsModel
 
 @{
     ViewBag.Title = "Settings";

--- a/Application/EdFi.Ods.AdminApp.Web/Display/TabEnumeration/OdsInstanceSettingsTabEnumeration.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Display/TabEnumeration/OdsInstanceSettingsTabEnumeration.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -11,21 +11,22 @@ namespace EdFi.Ods.AdminApp.Web.Display.TabEnumeration
 {
     public sealed class OdsInstanceSettingsTabEnumeration : Enumeration<OdsInstanceSettingsTabEnumeration>, ITabEnumeration
     {
-        public string ControllerName => RouteHelpers.GetControllerName<OdsInstanceSettingsController>();
+        public string ControllerName { get; }
         public string ActionName { get; }
 
-        private OdsInstanceSettingsTabEnumeration(int value, string displayName, string actionName) : base(value, displayName)
+        private OdsInstanceSettingsTabEnumeration(int value, string displayName, string controllerName, string actionName) : base(value, displayName)
         {
+            ControllerName = controllerName;
             ActionName = actionName;
         }
 
-        public static readonly OdsInstanceSettingsTabEnumeration Applications = new OdsInstanceSettingsTabEnumeration(1, "Applications", RouteHelpers.GetActionName<OdsInstanceSettingsController>(x => x.Applications()));
-        public static readonly OdsInstanceSettingsTabEnumeration Descriptors = new OdsInstanceSettingsTabEnumeration(2, "Descriptors", RouteHelpers.GetActionName<OdsInstanceSettingsController>(x => x.Descriptors()));
-        public static readonly OdsInstanceSettingsTabEnumeration Logging = new OdsInstanceSettingsTabEnumeration(3, "Logging", RouteHelpers.GetActionName<OdsInstanceSettingsController>(x => x.Logging()));
-        public static readonly OdsInstanceSettingsTabEnumeration EducationOrganizations = new OdsInstanceSettingsTabEnumeration(4, "Education Organizations", RouteHelpers.GetActionName<OdsInstanceSettingsController>(x => x.EducationOrganizations()));
-        public static readonly OdsInstanceSettingsTabEnumeration Setup = new OdsInstanceSettingsTabEnumeration(5, "Setup", RouteHelpers.GetActionName<OdsInstanceSettingsController>(x => x.Setup()));
-        public static readonly OdsInstanceSettingsTabEnumeration BulkLoad = new OdsInstanceSettingsTabEnumeration(6, "Bulk Load", RouteHelpers.GetActionName<OdsInstanceSettingsController>(x => x.BulkLoad()));
-        public static readonly OdsInstanceSettingsTabEnumeration LearningStandards = new OdsInstanceSettingsTabEnumeration(7, "Learning Standards", RouteHelpers.GetActionName<OdsInstanceSettingsController>(x => x.LearningStandards()));
-        public static readonly OdsInstanceSettingsTabEnumeration Reports = new OdsInstanceSettingsTabEnumeration(8, "Reports", RouteHelpers.GetActionName<OdsInstanceSettingsController>(x => x.SelectDistrict(0)));
+        public static readonly OdsInstanceSettingsTabEnumeration Applications = new OdsInstanceSettingsTabEnumeration(1, "Applications", RouteHelpers.GetControllerName<OdsInstanceSettingsController>(), RouteHelpers.GetActionName<OdsInstanceSettingsController>(x => x.Applications()));
+        public static readonly OdsInstanceSettingsTabEnumeration Descriptors = new OdsInstanceSettingsTabEnumeration(2, "Descriptors", RouteHelpers.GetControllerName<OdsInstanceSettingsController>(), RouteHelpers.GetActionName<OdsInstanceSettingsController>(x => x.Descriptors()));
+        public static readonly OdsInstanceSettingsTabEnumeration Logging = new OdsInstanceSettingsTabEnumeration(3, "Logging", RouteHelpers.GetControllerName<OdsInstanceSettingsController>(), RouteHelpers.GetActionName<OdsInstanceSettingsController>(x => x.Logging()));
+        public static readonly OdsInstanceSettingsTabEnumeration EducationOrganizations = new OdsInstanceSettingsTabEnumeration(4, "Education Organizations", RouteHelpers.GetControllerName<OdsInstanceSettingsController>(), RouteHelpers.GetActionName<OdsInstanceSettingsController>(x => x.EducationOrganizations()));
+        public static readonly OdsInstanceSettingsTabEnumeration Setup = new OdsInstanceSettingsTabEnumeration(5, "Setup", RouteHelpers.GetControllerName<OdsInstanceSettingsController>(), RouteHelpers.GetActionName<OdsInstanceSettingsController>(x => x.Setup()));
+        public static readonly OdsInstanceSettingsTabEnumeration BulkLoad = new OdsInstanceSettingsTabEnumeration(6, "Bulk Load", RouteHelpers.GetControllerName<OdsInstanceSettingsController>(), RouteHelpers.GetActionName<OdsInstanceSettingsController>(x => x.BulkLoad()));
+        public static readonly OdsInstanceSettingsTabEnumeration LearningStandards = new OdsInstanceSettingsTabEnumeration(7, "Learning Standards", RouteHelpers.GetControllerName<OdsInstanceSettingsController>(), RouteHelpers.GetActionName<OdsInstanceSettingsController>(x => x.LearningStandards()));
+        public static readonly OdsInstanceSettingsTabEnumeration Reports = new OdsInstanceSettingsTabEnumeration(8, "Reports", RouteHelpers.GetControllerName<OdsInstanceSettingsController>(), RouteHelpers.GetActionName<OdsInstanceSettingsController>(x => x.SelectDistrict(0)));
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -636,6 +636,7 @@
     <Compile Include="Display\DisplayService\AzureTabDisplayService.cs" />
     <Compile Include="Infrastructure\ResourceClaimSelectListBuilder.cs" />
     <Compile Include="Models\ViewModels\Global\UserIndexModel.cs" />
+    <Compile Include="Models\ViewModels\OdsInstanceSettings\BaseOdsInstanceSettingsModel.cs" />
     <Compile Include="Models\ViewModels\OdsInstances\DeregisterOdsInstanceModel.cs" />
     <Compile Include="Models\ViewModels\OdsInstances\BulkRegisterOdsInstancesModel.cs" />
     <Compile Include="Models\ViewModels\OdsInstances\RegisterOdsInstanceModel.cs" />

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/OdsInstanceSettings/BaseOdsInstanceSettingsModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/OdsInstanceSettings/BaseOdsInstanceSettingsModel.cs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Generic;
+using EdFi.Ods.AdminApp.Management;
+using EdFi.Ods.AdminApp.Web.Display.TabEnumeration;
+
+namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstanceSettings
+{
+    public abstract class BaseOdsInstanceSettingsModel
+    {
+        public InstanceContext OdsInstance { get; set; }
+        public List<TabDisplay<OdsInstanceSettingsTabEnumeration>> OdsInstanceSettingsTabEnumerations { get; set; }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/OdsInstanceSettings/OdsInstanceSettingsModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/OdsInstanceSettings/OdsInstanceSettingsModel.cs
@@ -1,24 +1,19 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-using System.Collections.Generic;
-using EdFi.Ods.AdminApp.Management;
-using EdFi.Ods.AdminApp.Web.Display.TabEnumeration;
 using EdFi.Ods.AdminApp.Web.Models.ViewModels.Reports;
 
 namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstanceSettings
 {
-    public class OdsInstanceSettingsModel
+    public class OdsInstanceSettingsModel : BaseOdsInstanceSettingsModel
     {
         public OdsInstanceSetupCompletedModel ProductionSetupCompletedModel { get; set; }
         public LogSettingsModel LogSettingsModel { get; set; }
         public LearningStandardsModel LearningStandardsModel { get; set; }
         public BulkFileUploadModel BulkFileUploadModel { get; set; }
         public ReportsModel ReportsModel { get; set; }
-        public List<TabDisplay<OdsInstanceSettingsTabEnumeration>> OdsInstanceSettingsTabEnumerations { get; set; }
         public string ProductionApiUrl { get; set; }
-        public InstanceContext OdsInstance { get; set; }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Views/Shared/_Settings_Production.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/Shared/_Settings_Production.cshtml
@@ -1,4 +1,4 @@
-﻿@*
+@*
 SPDX-License-Identifier: Apache-2.0
 Licensed to the Ed-Fi Alliance under one or more agreements.
 The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
@@ -8,7 +8,7 @@ See the LICENSE and NOTICES files in the project root for more information.
 @using EdFi.Ods.AdminApp.Web.Helpers
 @using EdFi.Ods.AdminApp.Web.Infrastructure
 @using EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstanceSettings
-@model OdsInstanceSettingsModel
+@model BaseOdsInstanceSettingsModel
 
 @{
     ViewBag.Title = "Settings";


### PR DESCRIPTION
As we approach the work to port ODS Instance Settings tab pages to .NET Core, we see a few obstacles which would push us to do too much all at once with excess developer friction and risk: OdsInstanceSettingsController and the related OdsInstanceSettingsModel needlessly mixes together concerns from many different features, all just so that they can share the tab layout look and feel.

Thankfully we can get ahead of those pains by first enabling us to split up those unrelated concerns. This PR does that prep work and should therefore have zero impact on behavior.

After this PR, each ODS Instance Settings tab conversion to .NET Core will follow a pattern:

1. Introduce a new subclass of OdsInstanceSettingsModel specific to that tab, containing only the properties needed by that tab.
2. Use that new dedicated model in that tab's OdsInstanceSettingsController actions and views.
3. Now that the features is completely untied from OdsInstanceSettingsModel, move those controller actions to their already-existing related controller (ie. the Descriptors entry point action in OdsInstanceSettingsController always belonged in DescriptorsController in the first place, so move it there now). The views naturally move with it.
4. As soon as you move the action to the better controller, visit OdsInstanceSettingsTabEnumeration and fix up the Controller value to match the new "home" of the action.
4. Ensure that the same view moves takes place for Web.Core.
5. Now that the code is in the right place, even in the NET48 builds, begin to wake up the code files in Web.Core and react to compilation challenges.

In other words, porting to .NET Core is the final step, where most of the work is just about untangling the existing code from OdsInstanceSettingsController.

This PR applies the common ground work:

* Make it so that OdsInstanceSettingsTabEnumeration can refer to actions on various controllers.
* Make it so that _Settings_Production is written in terms of a base class for the few properties it needs access to.
* Extract that base class from OdsInstanceSettingsModel.