### PR TITLE
AA-1145 Upgrade Platform Packages for Postgres .NET Core

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Azure.UnitTests/TestHashProvider.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Azure.UnitTests/TestHashProvider.cs
@@ -1,9 +1,13 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+#if NET48
 using EdFi.Ods.Common.Security;
+#else
+using EdFi.Common.Security;
+#endif
 
 namespace EdFi.Ods.AdminApp.Management.Azure.UnitTests
 {

--- a/Application/EdFi.Ods.AdminApp.Management.Azure/AzureFirstTimeSetupService.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Azure/AzureFirstTimeSetupService.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -7,7 +7,11 @@ using System.Linq;
 using System.Threading;
 using EdFi.Admin.DataAccess.Contexts;
 using EdFi.Security.DataAccess.Contexts;
+#if NET48
 using EdFi.Ods.Common.Security;
+#else
+using EdFi.Common.Security;
+#endif
 
 namespace EdFi.Ods.AdminApp.Management.Azure
 {

--- a/Application/EdFi.Ods.AdminApp.Management.Azure/RestartAzureAppServicesCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Azure/RestartAzureAppServicesCommand.cs
@@ -1,10 +1,9 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Threading.Tasks;
-using EdFi.Ods.Common.Utils.Extensions;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 
 

--- a/Application/EdFi.Ods.AdminApp.Management.Core.Tests/Testing.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Core.Tests/Testing.cs
@@ -34,6 +34,18 @@ namespace EdFi.Ods.AdminApp.Management.Tests
                 action(scope.ServiceProvider.GetService<TService>());
         }
 
+        public static TResult Scoped<TService, TResult>(Func<TService, TResult> func)
+        {
+            var result = default(TResult);
+
+            Scoped<TService>(service =>
+            {
+                result = func(service);
+            });
+
+            return result;
+        }
+
         public static async Task ScopedAsync<TService>(Func<TService, Task> actionAsync)
         {
             using (var scope = ScopeFactory.CreateScope())

--- a/Application/EdFi.Ods.AdminApp.Management.OnPrem/OnPremFirstTimeSetupService.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.OnPrem/OnPremFirstTimeSetupService.cs
@@ -1,10 +1,14 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using EdFi.Admin.DataAccess.Contexts;
+#if NET48
 using EdFi.Ods.Common.Security;
+#else
+using EdFi.Common.Security;
+#endif
 
 namespace EdFi.Ods.AdminApp.Management.OnPrem
 {

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/App.config
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/App.config
@@ -96,7 +96,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.11.0" newVersion="2.0.11.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ClaimSetFileExportCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ClaimSetFileExportCommandTests.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -14,7 +14,7 @@ using Shouldly;
 using static EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets.ClaimSetFileExportModel;
 using Application = EdFi.Security.DataAccess.Models.Application;
 using ClaimSet = EdFi.Security.DataAccess.Models.ClaimSet;
-
+using static EdFi.Ods.AdminApp.Management.Tests.Testing;
 
 namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 {
@@ -40,29 +40,38 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 
             SetupParentResourceClaimsWithChildren(testClaimSet2, testApplication);
 
-            var getClaimSetById = new GetClaimSetByIdQuery(TestContext);
-
-            var exportModel = new ClaimSetFileExportModel
+            var exportModel = Scoped<IGetClaimSetByIdQuery, ClaimSetFileExportModel>(getClaimSetById =>
             {
-                Title = "TestDownload",
-                ClaimSets = new List<Management.ClaimSetEditor.ClaimSet>
+                var editorClaimSets = new List<Management.ClaimSetEditor.ClaimSet>
                 {
                     getClaimSetById.Execute(testClaimSet1.ClaimSetId),
                     getClaimSetById.Execute(testClaimSet2.ClaimSetId)
-                },
-                SelectedForExport = new List<int>
+                };
+
+                return new ClaimSetFileExportModel
                 {
-                    testClaimSet1.ClaimSetId, testClaimSet2.ClaimSetId
-                }
-            };
+                    Title = "TestDownload",
+                    ClaimSets = editorClaimSets,
+                    SelectedForExport = new List<int>
+                    {
+                        testClaimSet1.ClaimSetId, testClaimSet2.ClaimSetId
+                    }
+                };
+            });
 
-            var getResourceByClaimSetIdQuery = new GetResourcesByClaimSetIdQuery(TestContext, GetMapper());
 
-            var command = new ClaimSetFileExportCommand(TestContext, getResourceByClaimSetIdQuery);
-            var sharingModel = command.Execute(exportModel);
+            var sharingModel = Scoped<IGetResourcesByClaimSetIdQuery, SharingModel>(getResourceByClaimSetIdQuery =>
+            {
+                var command = new ClaimSetFileExportCommand(TestContext, getResourceByClaimSetIdQuery);
+                return command.Execute(exportModel);
+            });
 
-            var resourcesForClaimSet1 = getResourceByClaimSetIdQuery.AllResources(testClaimSet1.ClaimSetId).ToList();
-            var resourcesForClaimSet2 = getResourceByClaimSetIdQuery.AllResources(testClaimSet2.ClaimSetId).ToList();
+            var resourcesForClaimSet1 =
+                Scoped<IGetResourcesByClaimSetIdQuery, Management.ClaimSetEditor.ResourceClaim[]>(
+                    query => query.AllResources(testClaimSet1.ClaimSetId).ToArray());
+            var resourcesForClaimSet2 =
+                Scoped<IGetResourcesByClaimSetIdQuery, Management.ClaimSetEditor.ResourceClaim[]>(
+                    query => query.AllResources(testClaimSet2.ClaimSetId).ToArray());
 
             sharingModel.Title.ShouldContain("TestDownload");
             var sharedClaimSets = sharingModel.Template.ClaimSets;
@@ -114,18 +123,17 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             var testClaimSet2 = new ClaimSet { ClaimSetName = "TestClaimSet2", Application = testApplication };
             Save(testClaimSet2);
 
-            var getClaimSetById = new GetClaimSetByIdQuery(TestContext);
-
-            var exportModel = new ClaimSetFileExportModel
-            {
-                Title = "TestDownload",
-                ClaimSets = new List<Management.ClaimSetEditor.ClaimSet>
+            var exportModel = Scoped<IGetClaimSetByIdQuery, ClaimSetFileExportModel>(
+                getClaimSetById => new ClaimSetFileExportModel
                 {
-                    getClaimSetById.Execute(testClaimSet1.ClaimSetId),
-                    getClaimSetById.Execute(testClaimSet2.ClaimSetId)
-                },
-                SelectedForExport = new List<int>()
-            };
+                    Title = "TestDownload",
+                    ClaimSets = new List<Management.ClaimSetEditor.ClaimSet>
+                    {
+                        getClaimSetById.Execute(testClaimSet1.ClaimSetId),
+                        getClaimSetById.Execute(testClaimSet2.ClaimSetId)
+                    },
+                    SelectedForExport = new List<int>()
+                });
 
             var validator = new ClaimSetFileExportModelValidator();
             var validationResults = validator.Validate(exportModel);
@@ -148,20 +156,19 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             var testClaimSet2 = new ClaimSet { ClaimSetName = "TestClaimSet2", Application = testApplication };
             Save(testClaimSet2);
 
-            var getClaimSetById = new GetClaimSetByIdQuery(TestContext);
-
-            var exportModel = new ClaimSetFileExportModel
-            {
-                ClaimSets = new List<Management.ClaimSetEditor.ClaimSet>
+            var exportModel = Scoped<IGetClaimSetByIdQuery, ClaimSetFileExportModel>(
+                getClaimSetById => new ClaimSetFileExportModel
                 {
-                    getClaimSetById.Execute(testClaimSet1.ClaimSetId),
-                    getClaimSetById.Execute(testClaimSet2.ClaimSetId)
-                },
-                SelectedForExport = new List<int>
-                {
-                    testClaimSet1.ClaimSetId, testClaimSet2.ClaimSetId
-                }
-            };
+                    ClaimSets = new List<Management.ClaimSetEditor.ClaimSet>
+                    {
+                        getClaimSetById.Execute(testClaimSet1.ClaimSetId),
+                        getClaimSetById.Execute(testClaimSet2.ClaimSetId)
+                    },
+                    SelectedForExport = new List<int>
+                    {
+                        testClaimSet1.ClaimSetId, testClaimSet2.ClaimSetId
+                    }
+                });
 
             var validator = new ClaimSetFileExportModelValidator();
             var validationResults = validator.Validate(exportModel);

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ClaimSetFileExportCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ClaimSetFileExportCommandTests.cs
@@ -59,12 +59,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
                 };
             });
 
-
-            var sharingModel = Scoped<IGetResourcesByClaimSetIdQuery, SharingModel>(getResourceByClaimSetIdQuery =>
-            {
-                var command = new ClaimSetFileExportCommand(TestContext, getResourceByClaimSetIdQuery);
-                return command.Execute(exportModel);
-            });
+            var sharingModel = Scoped<ClaimSetFileExportCommand, SharingModel>(command => command.Execute(exportModel));
 
             var resourcesForClaimSet1 =
                 Scoped<IGetResourcesByClaimSetIdQuery, Management.ClaimSetEditor.ResourceClaim[]>(

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ClaimSetFileImportCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ClaimSetFileImportCommandTests.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -81,10 +82,9 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             var importModel = GetImportModel(testJSON);
             #if NET48
                 var importSharingModel = SharingModel.DeserializeToSharingModel(importModel.ImportFile.InputStream);
-            #else
+#else
                 var importSharingModel = SharingModel.DeserializeToSharingModel(importModel.ImportFile.OpenReadStream());
-            #endif
-            var getResourceByClaimSetIdQuery = new GetResourcesByClaimSetIdQuery(TestContext, GetMapper());
+#endif
             var addClaimSetCommand = new AddClaimSetCommand(TestContext);
             var getResourceClaimsQuery = new GetResourceClaimsQuery(TestContext);
             var editResourceOnClaimSetCommand = new EditResourceOnClaimSetCommand(TestContext);
@@ -94,7 +94,11 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 
             var testClaimSet = TestContext.ClaimSets.SingleOrDefault(x => x.ClaimSetName == "Test Claimset");
             testClaimSet.ShouldNotBeNull();
-            var resourcesForClaimSet = getResourceByClaimSetIdQuery.AllResources(testClaimSet.ClaimSetId).ToList();
+
+            var resourcesForClaimSet =
+                Scoped<IGetResourcesByClaimSetIdQuery, List<Management.ClaimSetEditor.ResourceClaim>>(
+                    query => query.AllResources(testClaimSet.ClaimSetId).ToList());
+
             resourcesForClaimSet.Count.ShouldBeGreaterThan(0);
             var testResources = resourcesForClaimSet.Where(x => x.ParentId == 0).ToArray();
             testResources.Count().ShouldBe(3);

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ClaimSetFileImportCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ClaimSetFileImportCommandTests.cs
@@ -85,14 +85,10 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 #else
                 var importSharingModel = SharingModel.DeserializeToSharingModel(importModel.ImportFile.OpenReadStream());
 #endif
-            var addClaimSetCommand = new AddClaimSetCommand(TestContext);
-            var getResourceClaimsQuery = new GetResourceClaimsQuery(TestContext);
-            var editResourceOnClaimSetCommand = new EditResourceOnClaimSetCommand(TestContext);
 
-            var command = new ClaimSetFileImportCommand(addClaimSetCommand, editResourceOnClaimSetCommand, getResourceClaimsQuery);
-            command.Execute(importSharingModel);
+            Scoped<ClaimSetFileImportCommand>(command => command.Execute(importSharingModel));
 
-            var testClaimSet = TestContext.ClaimSets.SingleOrDefault(x => x.ClaimSetName == "Test Claimset");
+            var testClaimSet = Transaction(securityContext => securityContext.ClaimSets.SingleOrDefault(x => x.ClaimSetName == "Test Claimset"));
             testClaimSet.ShouldNotBeNull();
 
             var resourcesForClaimSet =

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/CopyClaimSetCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/CopyClaimSetCommandTests.cs
@@ -39,11 +39,14 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             var newClaimSet = new Mock<ICopyClaimSetModel>();
             newClaimSet.Setup(x => x.Name).Returns("TestClaimSet_Copy");
             newClaimSet.Setup(x => x.OriginalId).Returns(testClaimSet.ClaimSetId);
-            var command = new CopyClaimSetCommand(TestContext);
 
-            var copyClaimSetId = command.Execute(newClaimSet.Object);
+            int copyClaimSetId = Scoped<ISecurityContext, int>(securityContext =>
+            {
+                var command = new CopyClaimSetCommand(securityContext);
+                return command.Execute(newClaimSet.Object);
+            });
 
-            var copiedClaimSet = TestContext.ClaimSets.Single(x => x.ClaimSetId == copyClaimSetId);
+            var copiedClaimSet = Transaction(securityContext => securityContext.ClaimSets.Single(x => x.ClaimSetId == copyClaimSetId));
             copiedClaimSet.ClaimSetName.ShouldBe(newClaimSet.Object.Name);
 
             var results = Scoped<IGetResourcesByClaimSetIdQuery, Management.ClaimSetEditor.ResourceClaim[]>(

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/DeleteResourceOnClaimSetCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/DeleteResourceOnClaimSetCommandTests.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
@@ -92,8 +93,10 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             var command = new DeleteResourceOnClaimSetCommand(TestContext);
             command.Execute(deleteResourceOnClaimSetModel);
 
-            var resourceClaimsForClaimSet = new GetResourcesByClaimSetIdQuery(TestContext, GetMapper()).AllResources(testClaimSet.ClaimSetId).ToList();
-            resourceClaimsForClaimSet.Count().ShouldBe(parentResourcesOnClaimSetOriginalCount);
+            var resourceClaimsForClaimSet =
+                Scoped<IGetResourcesByClaimSetIdQuery, List<Management.ClaimSetEditor.ResourceClaim>>(
+                    query => query.AllResources(testClaimSet.ClaimSetId).ToList());
+            resourceClaimsForClaimSet.Count.ShouldBe(parentResourcesOnClaimSetOriginalCount);
 
             var resultChildResources =
                 TestContext.ClaimSetResourceClaims.Where(x => x.ClaimSet.ClaimSetId == testClaimSet.ClaimSetId && x.ResourceClaim.ParentResourceClaimId == testParentResource.ResourceClaimId);

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/DeleteResourceOnClaimSetCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/DeleteResourceOnClaimSetCommandTests.cs
@@ -49,16 +49,22 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
                 ResourceName = testResourceToDelete.ResourceName
             };
 
-            var command = new DeleteResourceOnClaimSetCommand(TestContext);
-            command.Execute(deleteResourceOnClaimSetModel);
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var command = new DeleteResourceOnClaimSetCommand(securityContext);
+                command.Execute(deleteResourceOnClaimSetModel);
+            });
 
-            var resourceClaimsForClaimSet =
-                TestContext.ClaimSetResourceClaims.Where(x => x.ClaimSet.ClaimSetId == testClaimSet.ClaimSetId && x.ResourceClaim.ParentResourceClaimId == null);
-            resourceClaimsForClaimSet.Count().ShouldBe(parentResourcesOnClaimSetOriginalCount - 1);
+            Transaction(securityContext =>
+            {
+                var resourceClaimsForClaimSet =
+                    securityContext.ClaimSetResourceClaims.Where(x => x.ClaimSet.ClaimSetId == testClaimSet.ClaimSetId && x.ResourceClaim.ParentResourceClaimId == null);
+                resourceClaimsForClaimSet.Count().ShouldBe(parentResourcesOnClaimSetOriginalCount - 1);
 
-            var resultResourceClaim = resourceClaimsForClaimSet.SingleOrDefault(x => x.ResourceClaim.ResourceClaimId == testResourceToDelete.ResourceClaimId);
+                var resultResourceClaim = resourceClaimsForClaimSet.SingleOrDefault(x => x.ResourceClaim.ResourceClaimId == testResourceToDelete.ResourceClaimId);
 
-            resultResourceClaim.ShouldBeNull();
+                resultResourceClaim.ShouldBeNull();
+            });
         }
 
         [Test]
@@ -90,21 +96,27 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
                 ResourceName = testChildResourceToDelete.ResourceName
             };
 
-            var command = new DeleteResourceOnClaimSetCommand(TestContext);
-            command.Execute(deleteResourceOnClaimSetModel);
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var command = new DeleteResourceOnClaimSetCommand(securityContext);
+                command.Execute(deleteResourceOnClaimSetModel);
+            });
 
             var resourceClaimsForClaimSet =
                 Scoped<IGetResourcesByClaimSetIdQuery, List<Management.ClaimSetEditor.ResourceClaim>>(
                     query => query.AllResources(testClaimSet.ClaimSetId).ToList());
             resourceClaimsForClaimSet.Count.ShouldBe(parentResourcesOnClaimSetOriginalCount);
 
-            var resultChildResources =
-                TestContext.ClaimSetResourceClaims.Where(x => x.ClaimSet.ClaimSetId == testClaimSet.ClaimSetId && x.ResourceClaim.ParentResourceClaimId == testParentResource.ResourceClaimId);
-            resultChildResources.Count().ShouldBe(childResourcesForParentOriginalCount - 1);
+            Transaction(securityContext =>
+            {
+                var resultChildResources =
+                    securityContext.ClaimSetResourceClaims.Where(x => x.ClaimSet.ClaimSetId == testClaimSet.ClaimSetId && x.ResourceClaim.ParentResourceClaimId == testParentResource.ResourceClaimId);
+                resultChildResources.Count().ShouldBe(childResourcesForParentOriginalCount - 1);
 
-            var resultResourceClaim = resultChildResources.SingleOrDefault(x => x.ResourceClaim.ResourceClaimId == testChildResourceToDelete.ResourceClaimId);
+                var resultResourceClaim = resultChildResources.SingleOrDefault(x => x.ResourceClaim.ResourceClaimId == testChildResourceToDelete.ResourceClaimId);
 
-            resultResourceClaim.ShouldBeNull();
+                resultResourceClaim.ShouldBeNull();
+            });
         }
 
         [Test]

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/EditClaimSetCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/EditClaimSetCommandTests.cs
@@ -32,12 +32,14 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             Save(alreadyExistingClaimSet);
 
             var editModel = new EditClaimSetModel {ClaimSetName = "TestClaimSetEdited", ClaimSetId = alreadyExistingClaimSet.ClaimSetId};
-            
-            var command = new EditClaimSetCommand(TestContext);
 
-            command.Execute(editModel);
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var command = new EditClaimSetCommand(securityContext);
+                command.Execute(editModel);
+            });
 
-            var editedClaimSet = TestContext.ClaimSets.Single(x => x.ClaimSetId == alreadyExistingClaimSet.ClaimSetId);
+            var editedClaimSet = Transaction(securityContext => securityContext.ClaimSets.Single(x => x.ClaimSetId == alreadyExistingClaimSet.ClaimSetId));
             editedClaimSet.ClaimSetName.ShouldBe(editModel.ClaimSetName);
         }
 

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/EditResourceOnClaimSetCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/EditResourceOnClaimSetCommandTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using NUnit.Framework;
 using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
 using EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets;
+using EdFi.Security.DataAccess.Contexts;
 using Shouldly;
 using Application = EdFi.Security.DataAccess.Models.Application;
 using Moq;
@@ -52,8 +53,11 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             editResourceOnClaimSetModel.Setup(x => x.ClaimSetId).Returns(testClaimSet.ClaimSetId);
             editResourceOnClaimSetModel.Setup(x => x.ResourceClaim).Returns(editedResource);
 
-            var command = new EditResourceOnClaimSetCommand(TestContext);
-            command.Execute(editResourceOnClaimSetModel.Object);
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var command = new EditResourceOnClaimSetCommand(securityContext);
+                command.Execute(editResourceOnClaimSetModel.Object);
+            });
 
             var resourceClaimsForClaimSet = ResourceClaimsForClaimSet(testClaimSet.ClaimSetId);
 
@@ -92,8 +96,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 
             var testParentResource = testResources.Single(x => x.ResourceClaim.ResourceName == "TestParentResourceClaim1");
 
-            var testChildResource1ToEdit = TestContext.ResourceClaims.Single(x => x.ResourceName == "TestChildResourceClaim1" && x.ParentResourceClaimId == testParentResource.ResourceClaim.ResourceClaimId);
-            var testChildResource2NotToEdit = TestContext.ResourceClaims.Single(x => x.ResourceName == "TestChildResourceClaim2" && x.ParentResourceClaimId == testParentResource.ResourceClaim.ResourceClaimId);
+            var testChildResource1ToEdit = Transaction(securityContext => securityContext.ResourceClaims.Single(x => x.ResourceName == "TestChildResourceClaim1" && x.ParentResourceClaimId == testParentResource.ResourceClaim.ResourceClaimId));
+            var testChildResource2NotToEdit = Transaction(securityContext => securityContext.ResourceClaims.Single(x => x.ResourceName == "TestChildResourceClaim2" && x.ParentResourceClaimId == testParentResource.ResourceClaim.ResourceClaimId));
 
             var editedResource = new ResourceClaim
             {
@@ -109,8 +113,11 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             editResourceOnClaimSetModel.Setup(x => x.ClaimSetId).Returns(testClaimSet.ClaimSetId);
             editResourceOnClaimSetModel.Setup(x => x.ResourceClaim).Returns(editedResource);
 
-            var command = new EditResourceOnClaimSetCommand(TestContext);
-            command.Execute(editResourceOnClaimSetModel.Object);
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var command = new EditResourceOnClaimSetCommand(securityContext);
+                command.Execute(editResourceOnClaimSetModel.Object);
+            });
 
             var resourceClaimsForClaimSet = ResourceClaimsForClaimSet(testClaimSet.ClaimSetId);
 
@@ -243,8 +250,11 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
                 ExistingResourceClaims = existingResources
             };
 
-            var command = new EditResourceOnClaimSetCommand(TestContext);
-            command.Execute(editResourceOnClaimSetModel);
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var command = new EditResourceOnClaimSetCommand(securityContext);
+                command.Execute(editResourceOnClaimSetModel);
+            });
 
             var resourceClaimsForClaimSet = ResourceClaimsForClaimSet(testClaimSet.ClaimSetId);
 
@@ -271,7 +281,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             var testResources = SetupResourceClaims(testApplication);
             var testParentResource1 = testResources.Single(x => x.ResourceName == "TestParentResourceClaim1");
 
-            var testChildResource1ToAdd = TestContext.ResourceClaims.Single(x => x.ResourceName == "TestChildResourceClaim1" && x.ParentResourceClaimId == testParentResource1.ResourceClaimId);
+            var testChildResource1ToAdd = Transaction(securityContext => securityContext.ResourceClaims.Single(x => x.ResourceName == "TestChildResourceClaim1" && x.ParentResourceClaimId == testParentResource1.ResourceClaimId));
             var resourceToAdd = new ResourceClaim()
             {
                     Id = testChildResource1ToAdd.ResourceClaimId,
@@ -290,8 +300,11 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
                 ExistingResourceClaims = existingResources
             };
 
-            var command = new EditResourceOnClaimSetCommand(TestContext);
-            command.Execute(editResourceOnClaimSetModel);
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var command = new EditResourceOnClaimSetCommand(securityContext);
+                command.Execute(editResourceOnClaimSetModel);
+            });
 
             var resourceClaimsForClaimSet = ResourceClaimsForClaimSet(testClaimSet.ClaimSetId);
 

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetApplicationsByClaimSetIdQueryTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetApplicationsByClaimSetIdQueryTests.cs
@@ -31,14 +31,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 
             foreach (var testClaimSet in testClaimSets)
             {
-                Management.ClaimSetEditor.Application[] results = null;
-
-                Scoped<IUsersContext>(usersContext =>
-                {
-                    var query = new GetApplicationsByClaimSetIdQuery(TestContext, usersContext);
-
-                    results = query.Execute(testClaimSet.ClaimSetId).ToArray();
-                });
+                var results = Scoped<IGetApplicationsByClaimSetIdQuery, Management.ClaimSetEditor.Application[]>(
+                    query => query.Execute(testClaimSet.ClaimSetId).ToArray());
 
                 Scoped<IUsersContext>(usersContext =>
                 {

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetClaimSetByIdQueryTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetClaimSetByIdQueryTests.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -9,6 +9,7 @@ using Shouldly;
 using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
 using ClaimSet = EdFi.Security.DataAccess.Models.ClaimSet;
 using Application = EdFi.Security.DataAccess.Models.Application;
+using static EdFi.Ods.AdminApp.Management.Tests.Testing;
 
 namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 {
@@ -27,11 +28,13 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             var testClaimSet = new ClaimSet {ClaimSetName = "TestClaimSet", Application = testApplication};
             Save(testClaimSet);
 
-            var query = new GetClaimSetByIdQuery(TestContext);
-            var result = query.Execute(testClaimSet.ClaimSetId);
+            Scoped<IGetClaimSetByIdQuery>(query =>
+            {
+                var result = query.Execute(testClaimSet.ClaimSetId);
 
-            result.Name.ShouldBe(testClaimSet.ClaimSetName);
-            result.Id.ShouldBe(testClaimSet.ClaimSetId);
+                result.Name.ShouldBe(testClaimSet.ClaimSetName);
+                result.Id.ShouldBe(testClaimSet.ClaimSetId);
+            });
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetClaimSetsByApplicationNameQueryTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetClaimSetsByApplicationNameQueryTests.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -34,9 +34,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
                 Application = testApplication
             });
 
-            Scoped<IUsersContext>(usersContext =>
+            Scoped<IGetClaimSetsByApplicationNameQuery>(query =>
             {
-                var query = new GetClaimSetsByApplicationNameQuery(TestContext, usersContext);
                 var results = query.Execute(testApplication.ApplicationName).ToArray();
 
                 results.ShouldNotContain(x => x.Name == CloudOdsAdminApp.InternalAdminAppClaimSet);
@@ -62,9 +61,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
                 Application = testApplication
             });
 
-            Scoped<IUsersContext>(usersContext =>
+            Scoped<IGetClaimSetsByApplicationNameQuery>(query =>
             {
-                var query = new GetClaimSetsByApplicationNameQuery(TestContext, usersContext);
                 var results = query.Execute(testApplication.ApplicationName).ToArray();
 
                 results.ShouldNotContain(x => x.Name == CloudOdsAdminApp.InternalAdminAppClaimSet);
@@ -77,9 +75,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
         {
             var testClaimSets = SetupApplicationClaimSets();
 
-            Scoped<IUsersContext>(usersContext =>
+            Scoped<IGetClaimSetsByApplicationNameQuery>(query =>
             {
-                var query = new GetClaimSetsByApplicationNameQuery(TestContext, usersContext);
                 var results = query.Execute(testClaimSets.First().Application.ApplicationName).ToArray();
 
                 results.Length.ShouldBe(testClaimSets.Count);
@@ -95,9 +92,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 
             var testClaimSets = SetupApplicationClaimSets();
 
-            Scoped<IUsersContext>(usersContext =>
+            Scoped<IGetClaimSetsByApplicationNameQuery>(query =>
             {
-                var query = new GetClaimSetsByApplicationNameQuery(TestContext, usersContext);
                 var results = query.Execute(testClaimSets.First().Application.ApplicationName).ToArray();
 
                 results.Length.ShouldBe(testClaimSets.Count);
@@ -117,9 +113,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
                 Application = testApplication
             });
 
-            Scoped<IUsersContext>(usersContext =>
+            Scoped<IGetClaimSetsByApplicationNameQuery>(query =>
             {
-                var query = new GetClaimSetsByApplicationNameQuery(TestContext, usersContext);
                 var results = query.Execute(testApplication.ApplicationName).ToArray();
 
                 results.Count(x => x.IsEditable).ShouldBe(testClaimSets.Count);
@@ -155,9 +150,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
                 usersContext.SaveChanges();
             });
 
-            Scoped<IUsersContext>(usersContext =>
+            Scoped<IGetClaimSetsByApplicationNameQuery>(query =>
             {
-                var query = new GetClaimSetsByApplicationNameQuery(TestContext, usersContext);
                 var results = query.Execute(testClaimSets.First().Application.ApplicationName).ToArray();
 
                 results.Length.ShouldBe(testClaimSets.Count);

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/OverrideDefaultAuthorizationStrategyCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/OverrideDefaultAuthorizationStrategyCommandTests.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -10,6 +10,8 @@ using EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets;
 using Shouldly;
 using Application = EdFi.Security.DataAccess.Models.Application;
 using ClaimSet = EdFi.Security.DataAccess.Models.ClaimSet;
+using static EdFi.Ods.AdminApp.Management.Tests.Testing;
+using System.Collections.Generic;
 
 namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 {
@@ -52,7 +54,9 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             var command = new OverrideDefaultAuthorizationStrategyCommand(TestContext);
             command.Execute(overrideModel);
 
-            var resourceClaimsForClaimSet = new GetResourcesByClaimSetIdQuery(TestContext, GetMapper()).AllResources(testClaimSet.ClaimSetId).ToList();
+            var resourceClaimsForClaimSet =
+                Scoped<IGetResourcesByClaimSetIdQuery, List<Management.ClaimSetEditor.ResourceClaim>>(
+                    query => query.AllResources(testClaimSet.ClaimSetId).ToList());
 
             var resultResourceClaim1 = resourceClaimsForClaimSet.Single(x => x.Id == overrideModel.ResourceClaimId);
             
@@ -110,7 +114,9 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             var command = new OverrideDefaultAuthorizationStrategyCommand(TestContext);
             command.Execute(overrideModel);
 
-            var resourceClaimsForClaimSet = new GetResourcesByClaimSetIdQuery(TestContext, GetMapper()).AllResources(testClaimSet.ClaimSetId).ToList();
+            var resourceClaimsForClaimSet =
+                Scoped<IGetResourcesByClaimSetIdQuery, List<Management.ClaimSetEditor.ResourceClaim>>(
+                    query => query.AllResources(testClaimSet.ClaimSetId).ToList());
 
             var resultParentResource = resourceClaimsForClaimSet.Single(x => x.Id == testParentResource.ResourceClaimId);
             var resultChildResource1 =

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ResetToDefaultAuthStrategyCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ResetToDefaultAuthStrategyCommandTests.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -10,6 +10,7 @@ using EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets;
 using Shouldly;
 using Application = EdFi.Security.DataAccess.Models.Application;
 using ClaimSet = EdFi.Security.DataAccess.Models.ClaimSet;
+using static EdFi.Ods.AdminApp.Management.Tests.Testing;
 
 namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 {
@@ -36,7 +37,10 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             var testResourceClaims = SetupParentResourceClaimsWithChildren(testClaimSet, testApplication);
             var testResourceToEdit = testResourceClaims.Select(x => x.ResourceClaim).Single(x => x.ResourceName == "TestParentResourceClaim1");
 
-            var resultResourceClaimBeforeOverride = new GetResourcesByClaimSetIdQuery(TestContext, GetMapper()).AllResources(testClaimSet.ClaimSetId).Single(x => x.Id == testResourceToEdit.ResourceClaimId);
+            var resultResourceClaimBeforeOverride =
+                Scoped<IGetResourcesByClaimSetIdQuery, Management.ClaimSetEditor.ResourceClaim>(
+                    query => query.AllResources(testClaimSet.ClaimSetId)
+                        .Single(x => x.Id == testResourceToEdit.ResourceClaimId));
 
             resultResourceClaimBeforeOverride.AuthStrategyOverridesForCRUD[0].ShouldBeNull();
             resultResourceClaimBeforeOverride.AuthStrategyOverridesForCRUD[1].ShouldBeNull();
@@ -47,7 +51,11 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
                 appAuthorizationStrategies.Single(x => x.AuthorizationStrategyName == "TestAuthStrategy4")
                     .AuthorizationStrategyId);
 
-            var resultResourceClaimAfterOverride = new GetResourcesByClaimSetIdQuery(TestContext, GetMapper()).AllResources(testClaimSet.ClaimSetId).Single(x => x.Id == testResourceToEdit.ResourceClaimId);
+            var resultResourceClaimAfterOverride =
+                Scoped<IGetResourcesByClaimSetIdQuery, Management.ClaimSetEditor.ResourceClaim>(
+                    query => query.AllResources(testClaimSet.ClaimSetId)
+                        .Single(x => x.Id == testResourceToEdit.ResourceClaimId));
+
             resultResourceClaimAfterOverride.AuthStrategyOverridesForCRUD[0].ShouldNotBeNull();
             resultResourceClaimAfterOverride.AuthStrategyOverridesForCRUD[0].AuthStrategyName.ShouldBe("TestAuthStrategy4");
 
@@ -65,7 +73,10 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             var command = new ResetToDefaultAuthStrategyCommand(TestContext);
             command.Execute(resetModel);
 
-            var resultResourceClaimAfterReset = new GetResourcesByClaimSetIdQuery(TestContext, GetMapper()).AllResources(testClaimSet.ClaimSetId).Single(x => x.Id == testResourceToEdit.ResourceClaimId);
+            var resultResourceClaimAfterReset =
+                Scoped<IGetResourcesByClaimSetIdQuery, Management.ClaimSetEditor.ResourceClaim>(
+                    query => query.AllResources(testClaimSet.ClaimSetId)
+                        .Single(x => x.Id == testResourceToEdit.ResourceClaimId));
             resultResourceClaimAfterReset.AuthStrategyOverridesForCRUD[0].ShouldBeNull();
             resultResourceClaimAfterReset.AuthStrategyOverridesForCRUD[1].ShouldBeNull();
             resultResourceClaimAfterReset.AuthStrategyOverridesForCRUD[2].ShouldBeNull();
@@ -96,7 +107,10 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
                 x.ResourceName == "TestChildResourceClaim1" &&
                 x.ParentResourceClaimId == testParentResource.ResourceClaimId);
 
-            var resultParentResource = new GetResourcesByClaimSetIdQuery(TestContext, GetMapper()).AllResources(testClaimSet.ClaimSetId).Single(x => x.Id == testParentResource.ResourceClaimId);
+            var resultParentResource =
+                Scoped<IGetResourcesByClaimSetIdQuery, Management.ClaimSetEditor.ResourceClaim>(
+                    query => query.AllResources(testClaimSet.ClaimSetId)
+                        .Single(x => x.Id == testParentResource.ResourceClaimId));
             var resultResourceBeforeOverride =
                 resultParentResource.Children.Single(x => x.Id == testChildResourceToEdit.ResourceClaimId);
 
@@ -109,7 +123,10 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
                 appAuthorizationStrategies.Single(x => x.AuthorizationStrategyName == "TestAuthStrategy4")
                     .AuthorizationStrategyId);
 
-            resultParentResource = new GetResourcesByClaimSetIdQuery(TestContext, GetMapper()).AllResources(testClaimSet.ClaimSetId).Single(x => x.Id == testParentResource.ResourceClaimId);
+            resultParentResource =
+                Scoped<IGetResourcesByClaimSetIdQuery, Management.ClaimSetEditor.ResourceClaim>(
+                    query => query.AllResources(testClaimSet.ClaimSetId)
+                        .Single(x => x.Id == testParentResource.ResourceClaimId));
             var resultResourceClaimAfterOverride = resultParentResource.Children.Single(x => x.Id == testChildResourceToEdit.ResourceClaimId);
             resultResourceClaimAfterOverride.AuthStrategyOverridesForCRUD[0].ShouldNotBeNull();
             resultResourceClaimAfterOverride.AuthStrategyOverridesForCRUD[0].AuthStrategyName.ShouldBe("TestAuthStrategy4");
@@ -128,7 +145,10 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             var command = new ResetToDefaultAuthStrategyCommand(TestContext);
             command.Execute(resetModel);
 
-            resultParentResource = new GetResourcesByClaimSetIdQuery(TestContext, GetMapper()).AllResources(testClaimSet.ClaimSetId).Single(x => x.Id == testParentResource.ResourceClaimId);
+            resultParentResource =
+                Scoped<IGetResourcesByClaimSetIdQuery, Management.ClaimSetEditor.ResourceClaim>(
+                    query => query.AllResources(testClaimSet.ClaimSetId)
+                        .Single(x => x.Id == testParentResource.ResourceClaimId));
             var resultResourceClaimAfterReset = resultParentResource.Children.Single(x => x.Id == testChildResourceToEdit.ResourceClaimId);
             resultResourceClaimAfterReset.AuthStrategyOverridesForCRUD[0].ShouldBeNull();
             resultResourceClaimAfterReset.AuthStrategyOverridesForCRUD[1].ShouldBeNull();

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ResetToDefaultAuthStrategyCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ResetToDefaultAuthStrategyCommandTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using NUnit.Framework;
 using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
 using EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets;
+using EdFi.Security.DataAccess.Contexts;
 using Shouldly;
 using Application = EdFi.Security.DataAccess.Models.Application;
 using ClaimSet = EdFi.Security.DataAccess.Models.ClaimSet;
@@ -70,8 +71,11 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
                 ClaimSetId = testClaimSet.ClaimSetId
             };
 
-            var command = new ResetToDefaultAuthStrategyCommand(TestContext);
-            command.Execute(resetModel);
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var command = new ResetToDefaultAuthStrategyCommand(securityContext);
+                command.Execute(resetModel);
+            });
 
             var resultResourceClaimAfterReset =
                 Scoped<IGetResourcesByClaimSetIdQuery, Management.ClaimSetEditor.ResourceClaim>(
@@ -142,8 +146,11 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
                 ClaimSetId = testClaimSet.ClaimSetId
             };
 
-            var command = new ResetToDefaultAuthStrategyCommand(TestContext);
-            command.Execute(resetModel);
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var command = new ResetToDefaultAuthStrategyCommand(securityContext);
+                command.Execute(resetModel);
+            });
 
             resultParentResource =
                 Scoped<IGetResourcesByClaimSetIdQuery, Management.ClaimSetEditor.ResourceClaim>(
@@ -176,7 +183,9 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 
             var testResourceToEdit = testResourceClaims.Single(x => x.ResourceName == "TestParentResourceClaim1");
 
-            TestContext.ClaimSetResourceClaims.Any(x => x.ResourceClaim.ResourceClaimId == testResourceToEdit.ResourceClaimId && x.ClaimSet.ClaimSetId == testClaimSet.ClaimSetId).ShouldBe(false);
+            Transaction(securityContext => securityContext.ClaimSetResourceClaims
+                .Any(x => x.ResourceClaim.ResourceClaimId == testResourceToEdit.ResourceClaimId && x.ClaimSet.ClaimSetId == testClaimSet.ClaimSetId))
+                .ShouldBe(false);
 
             var invalidResetModel = new ResetToDefaultAuthStrategyModel
             {
@@ -184,13 +193,19 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
                 ClaimSetId = testClaimSet.ClaimSetId
             };
 
-            var command = new ResetToDefaultAuthStrategyCommand(TestContext);
-            command.Execute(invalidResetModel);
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var command = new ResetToDefaultAuthStrategyCommand(securityContext);
+                command.Execute(invalidResetModel);
+            });
 
-            var validator = new ResetToDefaultAuthStrategyModelValidator(TestContext);
-            var validationResults = validator.Validate(invalidResetModel);
-            validationResults.IsValid.ShouldBe(false);
-            validationResults.Errors.Single().ErrorMessage.ShouldBe("No actions for this claimset and resource exist in the system");
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var validator = new ResetToDefaultAuthStrategyModelValidator(securityContext);
+                var validationResults = validator.Validate(invalidResetModel);
+                validationResults.IsValid.ShouldBe(false);
+                validationResults.Errors.Single().ErrorMessage.ShouldBe("No actions for this claimset and resource exist in the system");
+            });
         }
 
         private void SetupOverridesForResourceCreateAction(int resourceClaimId, int claimSetId, int authorizationStrategyId)
@@ -205,8 +220,11 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
                 AuthorizationStrategyForDelete = 0
             };
 
-            var command = new OverrideDefaultAuthorizationStrategyCommand(TestContext);
-            command.Execute(overrideModel);
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var command = new OverrideDefaultAuthorizationStrategyCommand(securityContext);
+                command.Execute(overrideModel);
+            });
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Configuration/Claims/ModifyClaimSetsServiceTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Configuration/Claims/ModifyClaimSetsServiceTests.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -30,12 +30,12 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Configuration.Claims
 
             TestContext.SaveChanges();
 
-            var testAuthorizationStrat = TestContext.ResourceClaimAuthorizationMetadatas
+            var testAuthorizationStrat = Transaction(securityContext => securityContext.ResourceClaimAuthorizationMetadatas
                 .Include(x => x.AuthorizationStrategy)
                 .Single(x =>
                     x.Action.ActionName == CloudOdsClaimAction.Read.ActionName &&
                     x.ResourceClaim.ResourceName == "educationStandards")
-                .AuthorizationStrategy;
+                .AuthorizationStrategy);
 
             testAuthorizationStrat.AuthorizationStrategyName.ShouldBe(CloudOdsClaimAuthorizationStrategy
                 .NoFurtherAuthorizationRequired.StrategyName);

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Queries/GetClaimSetNamesQueryTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Queries/GetClaimSetNamesQueryTests.cs
@@ -1,13 +1,17 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using EdFi.Ods.AdminApp.Management.Database.Queries;
+using EdFi.Security.DataAccess.Contexts;
 using EdFi.Security.DataAccess.Models;
 using NUnit.Framework;
 using Shouldly;
+using static EdFi.Ods.AdminApp.Management.Tests.Testing;
 
 namespace EdFi.Ods.AdminApp.Management.Tests.Database.Queries
 {
@@ -32,8 +36,11 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Database.Queries
             var claimSet2 = GetClaimSet(application);
             Save(claimSet1, claimSet2);
 
-            var query = new GetClaimSetNamesQuery(TestContext);
-            var claimSetNames = query.Execute();
+            var claimSetNames = Scoped<ISecurityContext, string[]>(securityContext =>
+            {
+                var query = new GetClaimSetNamesQuery(securityContext);
+                return query.Execute().ToArray();
+            });
 
             claimSetNames.ShouldContain(claimSet1.ClaimSetName);
             claimSetNames.ShouldContain(claimSet2.ClaimSetName);

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Settings/SetupAcademicBenchmarksConnectIntegrationTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Settings/SetupAcademicBenchmarksConnectIntegrationTests.cs
@@ -9,7 +9,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using EdFi.Admin.DataAccess.Contexts;
 using EdFi.Ods.AdminApp.Management.Instances;
+#if NET48
 using EdFi.Ods.Common.Security;
+#else
+using EdFi.Common.Security;
+#endif
 using Moq;
 using NUnit.Framework;
 using Shouldly;

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Settings/SetupAcademicBenchmarksConnectServiceTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Settings/SetupAcademicBenchmarksConnectServiceTests.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -9,7 +9,11 @@ using System.Threading.Tasks;
 using EdFi.Admin.DataAccess.Contexts;
 using EdFi.Admin.DataAccess.Models;
 using EdFi.Ods.AdminApp.Management.Instances;
+#if NET48
 using EdFi.Ods.Common.Security;
+#else
+using EdFi.Common.Security;
+#endif
 using Moq;
 using NUnit.Framework;
 using Shouldly;

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Setup/FirstTimeSetupTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Setup/FirstTimeSetupTests.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -10,7 +10,11 @@ using EdFi.Admin.DataAccess.Contexts;
 using EdFi.Admin.DataAccess.Models;
 using EdFi.Ods.AdminApp.Management.Azure;
 using EdFi.Ods.AdminApp.Management.Instances;
+#if NET48
 using EdFi.Ods.Common.Security;
+#else
+using EdFi.Common.Security;
+#endif
 using EdFi.Security.DataAccess.Contexts;
 using Moq;
 using NUnit.Framework;

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
@@ -110,8 +110,8 @@
     <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="log4net, Version=2.0.11.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.2.0.11\lib\net45\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNet.Identity.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.Identity.Core.2.2.3\lib\net45\Microsoft.AspNet.Identity.Core.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/SecurityDataTestBase.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/SecurityDataTestBase.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using AutoMapper;
+using EdFi.Ods.AdminApp.Web.Infrastructure;
 #if NET48
     using EdFi.Ods.AdminApp.Management.Helpers;
 #else
@@ -295,13 +296,6 @@ namespace EdFi.Ods.AdminApp.Management.Tests
             Save(resourceClaimWithDefaultAuthStrategies.Cast<object>().ToArray());
 
             return resourceClaimWithDefaultAuthStrategies;
-        }
-
-        protected IMapper GetMapper()
-        {
-            var profile = new AdminWebMappingProfile();
-            var config = new MapperConfiguration(cfg => cfg.AddProfile(profile));
-            return config.CreateMapper();
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Testing.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Testing.cs
@@ -5,6 +5,7 @@ using EdFi.Admin.DataAccess.Contexts;
 using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
 using EdFi.Ods.AdminApp.Management.Database;
 using EdFi.Ods.AdminApp.Management.Database.Models;
+using EdFi.Ods.AdminApp.Management.Database.Queries;
 using EdFi.Ods.AdminApp.Management.Instances;
 using EdFi.Ods.AdminApp.Management.User;
 using EdFi.Ods.AdminApp.Web.Infrastructure;
@@ -102,6 +103,26 @@ namespace EdFi.Ods.AdminApp.Management.Tests
                 using (var securityContext = new SqlServerSecurityContext())
                 {
                     var service = new GetResourcesByClaimSetIdQuery(securityContext, _mapper);
+                    action((TService)(object)service);
+                }
+            }
+            else if (typeof(TService) == typeof(ClaimSetFileImportCommand))
+            {
+                using (var securityContext = new SqlServerSecurityContext())
+                {
+                    var addClaimSetCommand = new AddClaimSetCommand(securityContext);
+                    var getResourceClaimsQuery = new GetResourceClaimsQuery(securityContext);
+                    var editResourceOnClaimSetCommand = new EditResourceOnClaimSetCommand(securityContext);
+                    var service = new ClaimSetFileImportCommand(addClaimSetCommand, editResourceOnClaimSetCommand, getResourceClaimsQuery);
+                    action((TService)(object)service);
+                }
+            }
+            else if (typeof(TService) == typeof(ClaimSetFileExportCommand))
+            {
+                using (var securityContext = new SqlServerSecurityContext())
+                {
+                    var getResourceByClaimSetIdQuery = new GetResourcesByClaimSetIdQuery(securityContext, _mapper);
+                    var service = new ClaimSetFileExportCommand(securityContext, getResourceByClaimSetIdQuery);
                     action((TService)(object)service);
                 }
             }

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Testing.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Testing.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Threading.Tasks;
+using AutoMapper;
 using EdFi.Admin.DataAccess.Contexts;
 using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
 using EdFi.Ods.AdminApp.Management.Database;
 using EdFi.Ods.AdminApp.Management.Database.Models;
 using EdFi.Ods.AdminApp.Management.Instances;
 using EdFi.Ods.AdminApp.Management.User;
+using EdFi.Ods.AdminApp.Web.Infrastructure;
 using EdFi.Ods.AdminApp.Web.Models.ViewModels.User;
 using EdFi.Security.DataAccess.Contexts;
 using Microsoft.AspNet.Identity;
@@ -15,6 +17,20 @@ namespace EdFi.Ods.AdminApp.Management.Tests
 {
     public static class Testing
     {
+        private static IMapper _mapper = AutoMapperBootstrapper.CreateMapper();
+
+        public static TResult Scoped<TService, TResult>(Func<TService, TResult> func)
+        {
+            var result = default(TResult);
+
+            Scoped<TService>(service =>
+            {
+                result = func(service);
+            });
+
+            return result;
+        }
+
         public static void Scoped<TService>(Action<TService> action)
         {
             if (typeof(TService) == typeof(AdminAppIdentityDbContext))
@@ -55,13 +71,38 @@ namespace EdFi.Ods.AdminApp.Management.Tests
                     action((TService)(object)service);
                 }
             }
-            else if (typeof(TService) == typeof(GetClaimSetsByApplicationNameQuery))
+            else if (typeof(TService) == typeof(IGetClaimSetsByApplicationNameQuery))
             {
                 using (var securityContext = new SqlServerSecurityContext())
                 using (var usersContext = new SqlServerUsersContext())
                 {
                     var service = new GetClaimSetsByApplicationNameQuery(securityContext, usersContext);
                     action((TService) (object) service);
+                }
+            }
+            else if (typeof(TService) == typeof(IGetApplicationsByClaimSetIdQuery))
+            {
+                using (var securityContext = new SqlServerSecurityContext())
+                using (var usersContext = new SqlServerUsersContext())
+                {
+                    var service = new GetApplicationsByClaimSetIdQuery(securityContext, usersContext);
+                    action((TService)(object)service);
+                }
+            }
+            else if (typeof(TService) == typeof(IGetClaimSetByIdQuery))
+            {
+                using (var securityContext = new SqlServerSecurityContext())
+                {
+                    var service = new GetClaimSetByIdQuery(securityContext);
+                    action((TService)(object)service);
+                }
+            }
+            else if (typeof(TService) == typeof(IGetResourcesByClaimSetIdQuery))
+            {
+                using (var securityContext = new SqlServerSecurityContext())
+                {
+                    var service = new GetResourcesByClaimSetIdQuery(securityContext, _mapper);
+                    action((TService)(object)service);
                 }
             }
             else if (typeof(TService) == typeof(IUsersContext))

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/packages.config
@@ -16,7 +16,7 @@
   <package id="FluentValidation" version="8.6.3" targetFramework="net48" />
   <package id="Hyak.Common" version="1.0.2" targetFramework="net48" />
   <package id="Iesi.Collections" version="4.0.4" targetFramework="net48" />
-  <package id="log4net" version="2.0.11" targetFramework="net48" />
+  <package id="log4net" version="2.0.12" targetFramework="net48" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.2.3" targetFramework="net48" />
   <package id="Microsoft.AspNet.Identity.EntityFramework" version="2.2.3" targetFramework="net48" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net48" />

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiFacadeFactory.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiFacadeFactory.cs
@@ -1,11 +1,15 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Threading.Tasks;
 using AutoMapper;
+#if NET48
 using EdFi.Ods.Common;
+#else
+using EdFi.Common;
+#endif
 
 namespace EdFi.Ods.AdminApp.Management.Api
 {

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClientFactory.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClientFactory.cs
@@ -1,10 +1,14 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Threading.Tasks;
+#if NET48
 using EdFi.Ods.Common;
+#else
+using EdFi.Common;
+#endif
 using RestSharp;
 
 namespace EdFi.Ods.AdminApp.Management.Api

--- a/Application/EdFi.Ods.AdminApp.Management/ApiClientFactory.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ApiClientFactory.cs
@@ -1,10 +1,14 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using EdFi.Admin.DataAccess.Models;
+#if NET48
 using EdFi.Ods.Common.Security;
+#else
+using EdFi.Common.Security;
+#endif
 
 namespace EdFi.Ods.AdminApp.Management
 {

--- a/Application/EdFi.Ods.AdminApp.Management/Database/ApiClientExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/ApiClientExtensions.cs
@@ -1,10 +1,14 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using EdFi.Admin.DataAccess.Models;
+#if NET48
 using EdFi.Ods.Common.Security;
+#else
+using EdFi.Common.Security;
+#endif
 
 namespace EdFi.Ods.AdminApp.Management.Database
 {

--- a/Application/EdFi.Ods.AdminApp.Management/Database/DatabaseProviderHelper.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/DatabaseProviderHelper.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -8,7 +8,11 @@ using System.Collections.Generic;
 using System.Configuration;
 using System.Linq;
 using EdFi.Ods.AdminApp.Management.Helpers;
+#if NET48
 using EdFi.Ods.Common.Configuration;
+#else
+using EdFi.Common.Configuration;
+#endif
 
 namespace EdFi.Ods.AdminApp.Management.Database
 {

--- a/Application/EdFi.Ods.AdminApp.Management/Database/EntityFramework6DatabaseModelBuilderExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/EntityFramework6DatabaseModelBuilderExtensions.cs
@@ -7,8 +7,13 @@ using System.Data.Entity;
 using System.Data.Entity.Core.Metadata.Edm;
 using System.Data.Entity.Infrastructure;
 using System.Data.Entity.ModelConfiguration.Conventions;
+#if NET48
 using EdFi.Ods.Common;
 using EdFi.Ods.Common.Utils.Extensions;
+#else
+using EdFi.Common;
+using EdFi.Common.Utils.Extensions;
+#endif
 
 namespace EdFi.Ods.AdminApp.Management.Database
 {

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -17,10 +17,17 @@
     <PackageReference Include="dbup-core" Version="4.2.0" />
     <PackageReference Include="dbup-postgresql" Version="4.2.0" />
     <PackageReference Include="dbup-sqlserver" Version="4.2.0" />
-    <PackageReference Include="EdFi.Common" Version="5.1.0-pre0017" />
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.1.0-pre0017" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.1.0-pre0012" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.1.0-pre0007" />
+
+    <!-- The latest stable platform packages do NOT support .NET Framework, so we conditionally reference older packages for NET48 builds. -->
+    <PackageReference Include="EdFi.Common" Version="5.1.0-pre0017" Condition="'$(TargetFramework)' == 'net48'" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.1.0-pre0017" Condition="'$(TargetFramework)' == 'net48'" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.1.0-pre0012" Condition="'$(TargetFramework)' == 'net48'" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.1.0-pre0007" Condition="'$(TargetFramework)' == 'net48'" />
+
+    <!-- The latest stable platform packages do support .NET Core, so we conditionally stable packages for NETCOREAPP builds. -->
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.1.0" Condition="'$(TargetFramework)' != 'net48'" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.1.0" Condition="'$(TargetFramework)' != 'net48'" />
+
     <PackageReference Include="EntityFramework" Version="6.4.0" />
     <PackageReference Include="Flurl" Version="2.8.2" />
     <PackageReference Include="log4net" Version="2.0.12" />

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.1.0-pre0007" />
     <PackageReference Include="EntityFramework" Version="6.4.0" />
     <PackageReference Include="Flurl" Version="2.8.2" />
-    <PackageReference Include="log4net" Version="2.0.11" />
+    <PackageReference Include="log4net" Version="2.0.12" />
     <PackageReference Include="Microsoft.AspNet.Identity.Core" Version="2.2.3" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="Microsoft.AspNet.Identity.EntityFramework" Version="2.2.3" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.9" Condition="'$(TargetFramework)' != 'net48'" />

--- a/Application/EdFi.Ods.AdminApp.Management/IFirstTimeSetupService.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/IFirstTimeSetupService.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -12,7 +12,11 @@ using EdFi.Admin.DataAccess.Contexts;
 using EdFi.Admin.DataAccess.Models;
 using EdFi.Ods.AdminApp.Management.Helpers;
 using EdFi.Ods.AdminApp.Management.Instances;
+#if NET48
 using EdFi.Ods.Common.Security;
+#else
+using EdFi.Common.Security;
+#endif
 
 namespace EdFi.Ods.AdminApp.Management
 {

--- a/Application/EdFi.Ods.AdminApp.Management/SetupAcademicBenchmarksConnectService.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/SetupAcademicBenchmarksConnectService.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -11,7 +11,11 @@ using EdFi.Admin.DataAccess.Contexts;
 using EdFi.Admin.DataAccess.Models;
 using EdFi.Ods.AdminApp.Management.Helpers;
 using EdFi.Ods.AdminApp.Management.Instances;
+#if NET48
 using EdFi.Ods.Common.Security;
+#else
+using EdFi.Common.Security;
+#endif
 
 namespace EdFi.Ods.AdminApp.Management
 {

--- a/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -249,7 +249,7 @@
     <PackageReference Include="Hangfire" Version="1.7.14" />
     <PackageReference Include="Hangfire.PostgreSql" Version="1.7.1" />
     <PackageReference Include="HtmlTags" Version="8.0.0" />
-    <PackageReference Include="log4net" Version="2.0.11" />
+    <PackageReference Include="log4net" Version="2.0.12" />
     <PackageReference Include="Npgsql" Version="4.1.5" />
   </ItemGroup>
 

--- a/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/EdFi.Ods.AdminApp.Web.Core.csproj
@@ -243,7 +243,7 @@
     <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
     <PackageReference Include="CsvHelper" Version="15.0.6" />
     <PackageReference Include="EdFi.Admin.LearningStandards.Core" Version="1.1.0" />
-    <PackageReference Include="EdFi.Suite3.LoadTools" Version="5.1.0-pre0014" />
+    <PackageReference Include="EdFi.Suite3.LoadTools" Version="5.1.0" />
     <PackageReference Include="FluentValidation" Version="9.2.2" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="9.2.0" />
     <PackageReference Include="Hangfire" Version="1.7.14" />

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Helpers/HtmlHelperExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Helpers/HtmlHelperExtensions.cs
@@ -21,7 +21,11 @@ using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Property = EdFi.Ods.AdminApp.Web.Infrastructure.Property;
+#if NET48
 using Preconditions = EdFi.Ods.Common.Preconditions;
+#else
+using Preconditions = EdFi.Common.Preconditions;
+#endif
 
 namespace EdFi.Ods.AdminApp.Web.Helpers
 {

--- a/Application/EdFi.Ods.AdminApp.Web.Core/StubTypes.cs
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/StubTypes.cs
@@ -49,17 +49,6 @@ namespace EdFi.Ods.AdminApp.Web.Hubs
     }
 }
 
-public class StubPbkdf2HmacSha1SecureHasher : ISecureHasher
-{
-    public PackedHash ComputeHash(string secret, int hashAlgorithm, int iterations, byte[] salt)
-        => throw new System.NotImplementedException();
-
-    public PackedHash ComputeHash(string secret, int hashAlgorithm, int iterations, int saltSizeInBytes)
-        => throw new System.NotImplementedException();
-
-    public string Algorithm { get => throw new System.NotImplementedException(); }
-}
-
 public class HandleErrorInfo
 {
     public HandleErrorInfo(Exception exception)

--- a/Application/EdFi.Ods.AdminApp.Web.Core/StubTypes.cs
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/StubTypes.cs
@@ -9,7 +9,7 @@
 using System;
 using EdFi.Ods.AdminApp.Management.Workflow;
 using EdFi.Ods.AdminApp.Web.Infrastructure.Jobs;
-using EdFi.Ods.Common.Security;
+using EdFi.Common.Security;
 
 namespace EdFi.Ods.AdminApp.Web.Controllers
 {

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/UserController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/UserController.cs
@@ -19,11 +19,12 @@ using EdFi.Ods.AdminApp.Management.User;
 using EdFi.Ods.AdminApp.Web.ActionFilters;
 using EdFi.Ods.AdminApp.Web.Display.TabEnumeration;
 using EdFi.Ods.AdminApp.Web.Models.ViewModels.User;
-using EdFi.Ods.Common.Utils.Extensions;
 #if NET48
+using EdFi.Ods.Common.Utils.Extensions;
 using Microsoft.AspNet.Identity;
 using Microsoft.AspNet.Identity.Owin;
 #else
+using EdFi.Common.Utils.Extensions;
 using Microsoft.AspNetCore.Identity;
 #endif
 

--- a/Application/EdFi.Ods.AdminApp.Web/Display/DisplayService/AzureTabDisplayService.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Display/DisplayService/AzureTabDisplayService.cs
@@ -1,12 +1,10 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Collections.Generic;
-using System.Linq;
 using EdFi.Ods.AdminApp.Web.Display.TabEnumeration;
-using EdFi.Ods.Common.Utils.Extensions;
 
 namespace EdFi.Ods.AdminApp.Web.Display.DisplayService
 {

--- a/Application/EdFi.Ods.AdminApp.Web/Display/DisplayService/OnPremTabDisplayService.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Display/DisplayService/OnPremTabDisplayService.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -7,7 +7,11 @@ using System.Collections.Generic;
 using System.Linq;
 using EdFi.Ods.AdminApp.Web.Display.TabEnumeration;
 using EdFi.Ods.AdminApp.Web.Infrastructure;
+#if NET48
 using EdFi.Ods.Common.Utils.Extensions;
+#else
+using EdFi.Common.Utils.Extensions;
+#endif
 
 namespace EdFi.Ods.AdminApp.Web.Display.DisplayService
 {

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -132,8 +132,8 @@
     <Reference Include="JsonSubTypes, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\JsonSubTypes.1.2.0\lib\net47\JsonSubTypes.dll</HintPath>
     </Reference>
-    <Reference Include="log4net, Version=2.0.11.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.2.0.11\lib\net45\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.ApplicationInsights.Agent.Intercept.2.4.0\lib\net45\Microsoft.AI.Agent.Intercept.dll</HintPath>

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/CloudOdsAdminAppSettings.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/CloudOdsAdminAppSettings.cs
@@ -7,7 +7,11 @@ using System;
 using System.Configuration;
 using EdFi.Ods.AdminApp.Management.Helpers;
 using EdFi.Ods.AdminApp.Management.Instances;
+#if NET48
 using EdFi.Ods.Common.Extensions;
+#else
+using EdFi.Common.Extensions;
+#endif
 
 namespace EdFi.Ods.AdminApp.Web.Infrastructure
 {

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/ValidationExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/ValidationExtensions.cs
@@ -1,11 +1,15 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System;
 using System.Linq;
+#if NET48
 using EdFi.Ods.Common.Utils.Extensions;
+#else
+using EdFi.Common.Utils.Extensions;
+#endif
 using FluentValidation;
 using FluentValidation.Results;
 using FluentValidation.Validators;

--- a/Application/EdFi.Ods.AdminApp.Web/Web.base.config
+++ b/Application/EdFi.Ods.AdminApp.Web/Web.base.config
@@ -138,7 +138,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="log4net" publicKeyToken="669E0DDF0BB1AA2A" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.0.11.0" newVersion="2.0.11.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed"/>

--- a/Application/EdFi.Ods.AdminApp.Web/_Installers/CommonConfigurationInstaller.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/_Installers/CommonConfigurationInstaller.cs
@@ -10,8 +10,9 @@ using System.Web.Mvc;
 using Castle.MicroKernel.Registration;
 using Castle.MicroKernel.SubSystems.Configuration;
 using Castle.Windsor;
-#else
 using EdFi.Ods.Common.Extensions;
+#else
+using EdFi.Common.Extensions;
 #endif
 using EdFi.Admin.DataAccess.Contexts;
 using EdFi.Admin.LearningStandards.Core.Configuration;
@@ -26,8 +27,13 @@ using EdFi.Ods.AdminApp.Web.Hubs;
 using EdFi.Ods.AdminApp.Web.Infrastructure;
 using EdFi.Ods.AdminApp.Web.Infrastructure.IO;
 using EdFi.Ods.AdminApp.Web.Infrastructure.Jobs;
+#if NET48
 using EdFi.Ods.Common.Configuration;
 using EdFi.Ods.Common.Security;
+#else
+using EdFi.Common.Configuration;
+using EdFi.Common.Security;
+#endif
 using EdFi.Security.DataAccess.Contexts;
 using FluentValidation;
 using Hangfire;

--- a/Application/EdFi.Ods.AdminApp.Web/_Installers/CommonConfigurationInstaller.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/_Installers/CommonConfigurationInstaller.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 #if NET48
 using System.Web.Mvc;
@@ -147,6 +148,10 @@ namespace EdFi.Ods.AdminApp.Web._Installers
 
             services.AddSingleton<ISecureHasher, Pbkdf2HmacSha1SecureHasher>();
             services.AddSingleton<IPackedHashConverter, PackedHashConverter>();
+#if !NET48
+            services.AddSingleton<ISecureHasherProvider, SecureHasherProvider>(
+                x => new SecureHasherProvider(new List<ISecureHasher> { x.GetService<ISecureHasher>() }));
+#endif
             services.AddSingleton<ISecurePackedHashProvider, SecurePackedHashProvider>();
             services.AddSingleton<IHashConfigurationProvider, DefaultHashConfigurationProvider>();
 

--- a/Application/EdFi.Ods.AdminApp.Web/_Installers/CommonConfigurationInstaller.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/_Installers/CommonConfigurationInstaller.cs
@@ -145,24 +145,7 @@ namespace EdFi.Ods.AdminApp.Web._Installers
             services.AddSingleton<IProductionLearningStandardsJob, ProductionLearningStandardsJob>();
             services.AddSingleton(x => (WorkflowJob<LearningStandardsJobContext, ProductionLearningStandardsHub>) x.GetService<IProductionLearningStandardsJob>());//Resolve previously queued job.
 
-#if NET48
             services.AddSingleton<ISecureHasher, Pbkdf2HmacSha1SecureHasher>();
-#else
-            // The intended type Pbkdf2HmacSha1SecureHasher relies on the NET48-only ODS
-            // ChainOfResponsibilityFacility concept in the currently referenced version
-            // of ODS Platform packages. This appears to the .NET Core IoC container as an
-            // unresolvable circular dependency. Upon upgrading ODS Platform NuGet packages to
-            // a higher, .NET Core-only version, we expect Pbkdf2HmacSha1SecureHasher's constructor
-            // to simplify as it no longer uses ChainOfResponsibilityFacility and will no longer
-            // present as a circular dependency. Until then, we register a stub alternative
-            // to satisfy the IoC container. Upon upgrading packages, this and the stub class
-            // should be removed in favor of registering Pbkdf2HmacSha1SecureHasher like NET48
-            // above.
-            //
-            // Although the type is resolved at runtime, current code paths do not in fact invoke
-            // methods on the type, so this does not pose an immediate risk of defects.
-            services.AddSingleton<ISecureHasher, StubPbkdf2HmacSha1SecureHasher>();
-#endif
             services.AddSingleton<IPackedHashConverter, PackedHashConverter>();
             services.AddSingleton<ISecurePackedHashProvider, SecurePackedHashProvider>();
             services.AddSingleton<IHashConfigurationProvider, DefaultHashConfigurationProvider>();

--- a/Application/EdFi.Ods.AdminApp.Web/packages.config
+++ b/Application/EdFi.Ods.AdminApp.Web/packages.config
@@ -33,7 +33,7 @@
   <package id="jQuery.Validation" version="1.15.0" targetFramework="net48" />
   <package id="JsonSubTypes" version="1.2.0" targetFramework="net48" />
   <package id="lodash" version="4.15.0" targetFramework="net48" />
-  <package id="log4net" version="2.0.11" targetFramework="net48" />
+  <package id="log4net" version="2.0.12" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights" version="2.13.1" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.13.1" targetFramework="net48" />


### PR DESCRIPTION
@saa14 Recall that our previous attempts to make Postgres successful on .NET Core were only partially successful: we previously converted our own DbContext types to be EF Core when building for .NET Core, and that gave us enough control over connection strings and 'provider' detection, but then we started to get the same kinds of errors for the Platform DbContexts. We attempted to resolve that by including Startup-time setup for those DbContexts to work, but then ran into a surprising assembly-loading error.

This PR resolves that issue by upgrading the Platform packages: thankfully it seems the problem was in the intermediate packages themselves and is no longer an issue with the latest packages.

However, there is a complication: the new packages are understandably core-only, so you'll see here that we *conditionally* include the new version of the packages. .NET 48 runs still use the version we've been using for several weeks.

This appears to resolve all the postgres issues, but keep in mind there are a number of combinations to be concerned with: .NET 4.8 SQL Server, .NET 4.8 Postgres usages, .NET Core SQL Server, .NET Core Postgres.

You will also see that I continued some earlier refactoring in the tests to avoid using explicit construction of Platform DbContexts. That is an ongoing effort, but this moves us forward.

I recommend reviewing this commit by commit so you can understand the series of obstacles overcome.