### PR TITLE
AA-1108 Fix error saving application without application name

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web/Helpers/ApplicationExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Helpers/ApplicationExtensions.cs
@@ -12,7 +12,7 @@ namespace EdFi.Ods.AdminApp.Web.Helpers
     {
         public static bool IsSystemReservedApplicationName(string applicationName)
         {
-            return CloudOdsAdminApp.ApplicationName.Equals(applicationName.Trim());
+            return applicationName != null && CloudOdsAdminApp.ApplicationName.Equals(applicationName.Trim());
         }
 
         public static bool IsSystemReservedApplication(this Application application)


### PR DESCRIPTION
Add condition to IsSystemReservedApplicationName method in Application Extension file to do not take null values.
It Fixes Adding and Editing an Application.