### PR TITLE
[AA-1144] - First Time Setup Success should direct users to restart ODS

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web.Core/ActionFilters/HandleAjaxErrorAttribute.cs
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/ActionFilters/HandleAjaxErrorAttribute.cs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Net;
+using EdFi.Ods.AdminApp.Web.Controllers;
+using EdFi.Ods.AdminApp.Web.Helpers;
+using log4net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Data.SqlClient;
+
+namespace EdFi.Ods.AdminApp.Web.ActionFilters
+{
+    public class HandleAjaxErrorAttribute : ExceptionFilterAttribute
+    {
+        private readonly ILog _logger = LogManager.GetLogger(typeof(HandleAjaxErrorAttribute));
+
+        public override void OnException(ExceptionContext filterContext)
+        {
+            if (filterContext.HttpContext.Request.IsAjaxRequest())
+            {
+                _logger.Error(filterContext.Exception);
+                filterContext.ExceptionHandled = true;
+                filterContext.HttpContext.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+                var responseText = IsReportsController(filterContext.ActionDescriptor as ControllerActionDescriptor) && filterContext.Exception is SqlException
+                    ? "An error occurred trying to access the SQL views for reports."
+                    : filterContext.Exception.Message;
+                filterContext.HttpContext.Response.WriteAsync(responseText);
+            }
+            else
+            {
+                base.OnException(filterContext);
+            }
+        }
+
+        private static bool IsReportsController(ControllerActionDescriptor actionDescriptor)
+        {
+            if (actionDescriptor == null)
+                return false;
+
+            return actionDescriptor.ControllerTypeInfo == typeof(ReportsController);
+        }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Helpers/HtmlHelperExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Helpers/HtmlHelperExtensions.cs
@@ -443,7 +443,12 @@ namespace EdFi.Ods.AdminApp.Web.Helpers
             var spinnerTag = new DivTag();
             spinnerTag.Append(new HtmlTag("i").AddClasses("fa", "fa-spinner", "fa-pulse", "fa-fw"));
 
-            var contentLoadingArea = new DivTag().Data("source-url", url).AddClass("load-action-async");
+            var errorMessage = "Restarting the ODS / API is known to solve issues with first time setup or previously cached information, and may help resolve this issue on its own." +
+                               " Please try restarting the ODS / API now and reload this to see if this same error occurs." +
+                               " If the error persists, please feel to schedule a ticket via <a href='https://tracker.ed-fi.org/projects/EDFI/issues'>Ed-Fi Tracker</a>" +
+                               " or visit <a href='https://techdocs.ed-fi.org/display/ADMIN'>Admin App documentation</a> for more information.";
+
+            var contentLoadingArea = new DivTag().Data("source-url", url).Data("error-message", errorMessage).AddClass("load-action-async");
             if (minHeight > 0)
             {
                 //adding a minimum height is optional, but can help prevent the page scrollbar from jumping around while content loads

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Helpers/HtmlHelperExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Helpers/HtmlHelperExtensions.cs
@@ -445,7 +445,7 @@ namespace EdFi.Ods.AdminApp.Web.Helpers
 
             var errorMessage = "Restarting the ODS / API is known to solve issues with first time setup or previously cached information, and may help resolve this issue on its own." +
                                " Please try restarting the ODS / API now and reload this to see if this same error occurs." +
-                               " If the error persists, please feel to schedule a ticket via <a href='https://tracker.ed-fi.org/projects/EDFI/issues'>Ed-Fi Tracker</a>" +
+                               " If the error persists, please check the application logs and then feel to schedule a ticket via <a href='https://tracker.ed-fi.org/projects/EDFI/issues'>Ed-Fi Tracker</a>" +
                                " or visit <a href='https://techdocs.ed-fi.org/display/ADMIN'>Admin App documentation</a> for more information.";
 
             var contentLoadingArea = new DivTag().Data("source-url", url).Data("error-message", errorMessage).AddClass("load-action-async");

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Startup.cs
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Startup.cs
@@ -64,6 +64,7 @@ namespace EdFi.Ods.AdminApp.Web
                         options.Filters.Add<AutoValidateAntiforgeryTokenAttribute>();
                         options.Filters.Add<PasswordChangeRequiredFilter>();
                         options.Filters.Add<InstanceContextFilter>();
+                        options.Filters.Add<HandleAjaxErrorAttribute>();
                     })
                     .AddFluentValidation(
                         opt =>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Home/PostSetup.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Home/PostSetup.cshtml
@@ -1,0 +1,21 @@
+@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+
+@{
+    ViewBag.Title = "Post Setup | ODS Restart Needed";
+}
+
+<div class="row">
+    <div class="col-md-12">
+        <h2>ODS Restart Needed</h2>
+        <div class="alert alert-info">
+            Admin App has prepared the ODS / API for use, including updates to its Claim Sets security rules and other items that may be cached. For those rules to take effect, <b> please restart the ODS now before proceeding.</b>
+        </div>
+        @Html.ActionLink("Proceed", "Index", "Home", new {setupCompleted = true}, new {@class = "btn btn-primary"})
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Setup/FirstTimeSetup.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Setup/FirstTimeSetup.cshtml
@@ -60,7 +60,7 @@ See the LICENSE and NOTICES files in the project root for more information.
         var handleSuccess = function() {
             $('#finish-setup-link').removeClass('btn-primary btn-danger').addClass('btn-success');
             $('#finish-setup-link').html('Success <span class="padding-left"><i class="fa fa-check-circle"></i></span>');
-            window.location = '@Url.Action("Index", "Home", new { setupCompleted = true })';
+            window.location = '@Url.Action("PostSetup", "Home", new { setupCompleted = true })';
         };
 
         var handleFailure = function (data) {

--- a/Application/EdFi.Ods.AdminApp.Web.Core/Views/Setup/PostUpdateSetup.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/Views/Setup/PostUpdateSetup.cshtml
@@ -49,7 +49,7 @@ See the LICENSE and NOTICES files in the project root for more information.
         .done(function(data) {
                 $('#finish-setup-link').removeClass("btn-primary btn-danger").addClass("btn-success");
                 $('#finish-setup-link').html('Success <span class="padding-left"><i class="fa fa-check-circle"></i></span>');
-                window.location = '@Url.Action("Index", "Home", new { setupCompleted = true })';
+                window.location = '@Url.Action("PostSetup", "Home", new { setupCompleted = true })';
             })
         .fail(function (data) {
                 $('#finish-setup-link').removeClass("btn-primary").addClass("btn-danger");

--- a/Application/EdFi.Ods.AdminApp.Web.Core/wwwroot/Scripts/site.js
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/wwwroot/Scripts/site.js
@@ -351,6 +351,7 @@ function LoadAsyncActions() {
     $(".load-action-async").each(function () {
         var $target = $(this);
         var sourceUrl = $target.attr("data-source-url");
+        var customErrorMessage = $target.attr("data-error-message");
 
         $.ajax({
             async: true,
@@ -371,7 +372,11 @@ function LoadAsyncActions() {
                     errorMessage = errorMessage + "No response from server";
                 }
 
-                $target.html("<em class='text-danger'>"+ errorMessage + "</em>");
+                if (!StringIsNullOrWhitespace(customErrorMessage)) {
+                    errorMessage = errorMessage + ". <br/><b>" + customErrorMessage + "</b>";
+                }
+
+                $target.html("<em class='text-danger'>" + errorMessage + "</em>");
             },
             complete: function() {
                 $target.removeClass("load-action-async");

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/HomeController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/HomeController.cs
@@ -51,6 +51,16 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
             return View(model);
         }
 
+        public ActionResult PostSetup(bool setupCompleted = false)
+        {
+            if (setupCompleted)
+            {
+                return View();
+            }
+
+            return RedirectToAction("Index");
+        }
+
         public ActionResult Error(string message)
         {
             #if NET48

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -1099,6 +1099,7 @@
     <Content Include="Views\Shared\_SignalRStatus_BulkLoad.cshtml" />
     <Content Include="Views\OdsInstanceSettings\_SaveBulkUploadCredentialsForm.cshtml" />
     <Content Include="Views\OdsInstances\BulkRegisterOdsInstances.cshtml" />
+    <Content Include="Views\Home\PostSetup.cshtml" />
     <None Include="Web.base.config" />
     <Content Include="Views\OdsInstances\RegisterOdsInstance.cshtml" />
     <Content Include="Views\OdsInstances\Index.cshtml" />

--- a/Application/EdFi.Ods.AdminApp.Web/Helpers/HtmlHelperExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Helpers/HtmlHelperExtensions.cs
@@ -440,7 +440,7 @@ namespace EdFi.Ods.AdminApp.Web.Helpers
 
             var errorMessage = "Restarting the ODS / API is known to solve issues with first time setup or previously cached information, and may help resolve this issue on its own." +
                                " Please try restarting the ODS / API now and reload this to see if this same error occurs." +
-                               " If the error persists, please feel to schedule a ticket via <a href='https://tracker.ed-fi.org/projects/EDFI/issues'>Ed-Fi Tracker</a>" +
+                               " If the error persists, please check the application logs and then feel to schedule a ticket via <a href='https://tracker.ed-fi.org/projects/EDFI/issues'>Ed-Fi Tracker</a>" +
                                " or visit <a href='https://techdocs.ed-fi.org/display/ADMIN'>Admin App documentation</a> for more information.";
 
             var contentLoadingArea = new DivTag().Data("source-url", url).Data("error-message", errorMessage).AddClass("load-action-async");

--- a/Application/EdFi.Ods.AdminApp.Web/Helpers/HtmlHelperExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Helpers/HtmlHelperExtensions.cs
@@ -438,7 +438,12 @@ namespace EdFi.Ods.AdminApp.Web.Helpers
             var spinnerTag = new DivTag();
             spinnerTag.Append(new HtmlTag("i").AddClasses("fa", "fa-spinner", "fa-pulse", "fa-fw"));
 
-            var contentLoadingArea = new DivTag().Data("source-url", url).AddClass("load-action-async");
+            var errorMessage = "Restarting the ODS / API is known to solve issues with first time setup or previously cached information, and may help resolve this issue on its own." +
+                               " Please try restarting the ODS / API now and reload this to see if this same error occurs." +
+                               " If the error persists, please feel to schedule a ticket via <a href='https://tracker.ed-fi.org/projects/EDFI/issues'>Ed-Fi Tracker</a>" +
+                               " or visit <a href='https://techdocs.ed-fi.org/display/ADMIN'>Admin App documentation</a> for more information.";
+
+            var contentLoadingArea = new DivTag().Data("source-url", url).Data("error-message", errorMessage).AddClass("load-action-async");
             if (minHeight > 0)
             {
                 //adding a minimum height is optional, but can help prevent the page scrollbar from jumping around while content loads

--- a/Application/EdFi.Ods.AdminApp.Web/Scripts/site.js
+++ b/Application/EdFi.Ods.AdminApp.Web/Scripts/site.js
@@ -351,6 +351,7 @@ function LoadAsyncActions() {
     $(".load-action-async").each(function () {
         var $target = $(this);
         var sourceUrl = $target.attr("data-source-url");
+        var customErrorMessage = $target.attr("data-error-message");
 
         $.ajax({
             async: true,
@@ -371,7 +372,11 @@ function LoadAsyncActions() {
                     errorMessage = errorMessage + "No response from server";
                 }
 
-                $target.html("<em class='text-danger'>"+ errorMessage + "</em>");
+                if (!StringIsNullOrWhitespace(customErrorMessage)) {
+                    errorMessage = errorMessage + ". <br/><b>" + customErrorMessage + "</b>";
+                }
+
+                $target.html("<em class='text-danger'>" + errorMessage + "</em>");
             },
             complete: function() {
                 $target.removeClass("load-action-async");

--- a/Application/EdFi.Ods.AdminApp.Web/Views/Home/PostSetup.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/Home/PostSetup.cshtml
@@ -1,0 +1,21 @@
+@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+
+@{
+    ViewBag.Title = "Post Setup | ODS Restart Needed";
+}
+
+<div class="row">
+    <div class="col-md-12">
+        <h2>ODS Restart Needed</h2>
+        <div class="alert alert-info">
+            Admin App has prepared the ODS / API for use, including updates to its Claim Sets security rules and other items that may be cached. For those rules to take effect, <b> please restart the ODS now before proceeding.</b>
+        </div>
+        @Html.ActionLink("Proceed", "Index", "Home", new {setupCompleted = true}, new {@class = "btn btn-primary"})
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web/Views/Setup/FirstTimeSetup.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/Setup/FirstTimeSetup.cshtml
@@ -60,7 +60,7 @@ See the LICENSE and NOTICES files in the project root for more information.
         var handleSuccess = function() {
             $('#finish-setup-link').removeClass('btn-primary btn-danger').addClass('btn-success');
             $('#finish-setup-link').html('Success <span class="padding-left"><i class="fa fa-check-circle"></i></span>');
-            window.location = '@Url.Action("Index", "Home", new { setupCompleted = true })';
+            window.location = '@Url.Action("PostSetup", "Home", new { setupCompleted = true })';
         };
 
         var handleFailure = function (data) {

--- a/Application/EdFi.Ods.AdminApp.Web/Views/Setup/PostUpdateSetup.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/Setup/PostUpdateSetup.cshtml
@@ -49,7 +49,7 @@ See the LICENSE and NOTICES files in the project root for more information.
         .done(function(data) {
                 $('#finish-setup-link').removeClass("btn-primary btn-danger").addClass("btn-success");
                 $('#finish-setup-link').html('Success <span class="padding-left"><i class="fa fa-check-circle"></i></span>');
-                window.location = '@Url.Action("Index", "Home", new { setupCompleted = true })';
+                window.location = '@Url.Action("PostSetup", "Home", new { setupCompleted = true })';
             })
         .fail(function (data) {
                 $('#finish-setup-link').removeClass("btn-primary").addClass("btn-danger");


### PR DESCRIPTION
**Description**

- Added the intermediate screen PostSetup.cshtml for .NET Core and .NET48 projects.
- Added PostSetup action to the Home Controller and updated the redirect urls for PostUpdateSetup.cshtml and FirstTimeSetup.cshtml for both .NET 48 and .NET Core projects.
- Added custom error message to ActionAjax Html helper structure to display the "ODS restart" guidance message along with the server error for both .NET48 and .NET Core projects.
- Added .NET Core compatible HandleAjaxErrorAttribute similar to the one in .NET48 project. Registered the HandleAjaxErrorAttribute globally in .NET Core Startup.