### PR TITLE
[AA-1151] - Phase out DatabaseProviderHelper usages on .NET Core builds

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Queries/Ods/OdsDataTestBase.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Queries/Ods/OdsDataTestBase.cs
@@ -15,6 +15,7 @@ using System.Threading.Tasks;
 using EdFi.Ods.AdminApp.Management.Database.Ods.Reports;
 using EdFi.Ods.AdminApp.Management.Helpers;
 using EdFi.Ods.AdminApp.Management.Instances;
+using Microsoft.Extensions.Options;
 using Moq;
 
 
@@ -517,7 +518,15 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Database.Queries.Ods
             var mockReportConfigProvider = new Mock<IReportsConfigProvider>();
             mockReportConfigProvider.Setup(x => x.Create(CloudOdsDatabaseNames.ProductionOds, ApiMode.Sandbox)).Returns(new ReportsConfig
                 { ConnectionString = TestOdsConnectionProvider.ConnectionString, ScriptFolder = "Reports.Sql" });
-            var reportViews = new ReportViewsSetUp(mockReportConfigProvider.Object, new UpgradeEngineFactory());
+            #if NET48
+                var upgradeEngineFactory = new UpgradeEngineFactory();
+            #else
+                var appSettings = new Mock<IOptions<AppSettings>>();
+                appSettings.Setup(x => x.Value).Returns(ConfigurationHelper.GetAppSettings());
+                var options = appSettings.Object;
+                var upgradeEngineFactory = new UpgradeEngineFactory(options);
+            #endif
+            var reportViews = new ReportViewsSetUp(mockReportConfigProvider.Object, upgradeEngineFactory);
             reportViews.CreateReportViews(CloudOdsDatabaseNames.ProductionOds, ApiMode.Sandbox);
         }
 

--- a/Application/EdFi.Ods.AdminApp.Web.Core/ActionFilters/InstanceContextFilter.cs
+++ b/Application/EdFi.Ods.AdminApp.Web.Core/ActionFilters/InstanceContextFilter.cs
@@ -67,7 +67,7 @@ namespace EdFi.Ods.AdminApp.Web.ActionFilters
 
         private bool TryQueryInstanceRegistration(out OdsInstanceRegistration instanceRegistration)
         {
-            var singleInstanceLookup = _adminAppDbContext.OdsInstanceRegistrations.FirstOrDefault(x =>
+            var singleInstanceLookup = _adminAppDbContext.OdsInstanceRegistrations.AsEnumerable().FirstOrDefault(x =>
                 x.Name.Equals(CloudOdsAdminAppSettings.Instance.OdsInstanceName,
                     StringComparison.InvariantCultureIgnoreCase));
 


### PR DESCRIPTION
**Description**

- Refactored UpgradeEngineFactory to use the DatabaseEngine appsetting instead of DatabaseProviderHelper for the .NET Core builds.
- Refactored DatabaseConnectionProvider to use the DatabaseEngine appsetting instead of DatabaseProviderHelper for the .NET Core builds.
- Refactored ReportsConfigProvider to use the DatabaseEngine appsetting instead of DatabaseProviderHelper for the .NET Core builds.