### PR TITLE
Correct the teamcity-get-package-version script to seek the right package name.

### DIFF
--- a/eng/teamcity-get-package-version.ps1
+++ b/eng/teamcity-get-package-version.ps1
@@ -7,14 +7,14 @@
 # was copied over from an upstream dependency.
 
 # There should only be one file here - the pre-release NuGet package from the upstream build artifacts
-$pkg = Get-ChildItem -Filter "*Core*pre*.nupkg"
+$pkg = Get-ChildItem -Filter "*pre*.nupkg"
 
 if (-not $pkg) {
     throw "No pre-release package found."
 }
 
 # Extract the version number
-$result = $pkg -match "Web.Core\.(\d)\.(\d)\.(\d)\-pre(\d+)\.nupkg"
+$result = $pkg -match "Web\.(\d)\.(\d)\.(\d)\-pre(\d+)\.nupkg"
 
 if (-not $result) {
     throw "Package name does not match the expected naming convention."


### PR DESCRIPTION
Now that there is a single package, remove "Core" from the expected name as it is no longer used to distinguish old from new packages.