### PR TITLE
The build script sets MSBUILDDISABLENODEREUSE

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -89,6 +89,7 @@ param(
     $PackageFile
 )
 
+$Env:MSBUILDDISABLENODEREUSE = "1"
 
 $solution = "Application\Ed-Fi-ODS-Tools.sln"
 $solutionRoot = "$PSScriptRoot/Application"


### PR DESCRIPTION
We do so similar to how the ODS needs it to build reliably. In our case, it is to introduce stability around builds in combination with the BundlerMinifier as suggested by Jon Skeet here: https://github.com/madskristensen/BundlerMinifier/issues/365