### PR TITLE
Revert upgrading HtmlTags from 8.0.0 to 8.1.1 due to apparent instabilities

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="FluentValidation.AspNetCore" Version="9.2.0" />
     <PackageReference Include="Hangfire" Version="1.7.14" />
     <PackageReference Include="Hangfire.PostgreSql" Version="1.7.1" />
-    <PackageReference Include="HtmlTags" Version="8.1.1" />
+    <PackageReference Include="HtmlTags" Version="8.0.0" />
     <PackageReference Include="log4net" Version="2.0.12" />
     <PackageReference Include="Npgsql" Version="4.1.5" />
   </ItemGroup>


### PR DESCRIPTION
During experimentation, signalr began failing unexpectedly after this upgrade, and becomes stable when we revert to 8.0.0.