### PR TITLE
[AA-1176] Display ODS / API version number in ODS instance pages of Admin App

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web/Helpers/HtmlHelperExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Helpers/HtmlHelperExtensions.cs
@@ -23,7 +23,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Property = EdFi.Ods.AdminApp.Web.Infrastructure.Property;
 using Preconditions = EdFi.Common.Preconditions;
-using System.Runtime.Caching;
 using EdFi.Ods.AdminApp.Management.Api;
 
 namespace EdFi.Ods.AdminApp.Web.Helpers
@@ -507,9 +506,10 @@ namespace EdFi.Ods.AdminApp.Web.Helpers
         }
 
         public static HtmlString ApplicationVersion(this IHtmlHelper helper)
-        {
-            var assembly = Assembly.GetExecutingAssembly();
-            var informationVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        {            
+            var informationVersion = InMemoryCache.Instance
+                .GetOrSet("informationVersion",
+                    () => Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion);
 
             return !string.IsNullOrEmpty(informationVersion) ? new HtmlString($"<span>Admin App Version: {informationVersion}</span>") : new HtmlString("");
         }
@@ -526,12 +526,8 @@ namespace EdFi.Ods.AdminApp.Web.Helpers
 
         public static HtmlString OdsApiVersion(this IHtmlHelper helper)
         {
-            var odsApiVersion = MemoryCache.Default["odsApiVersion"];
-            if (odsApiVersion == null)
-            {
-                odsApiVersion = new InferOdsApiVersion().Version(CloudOdsAdminAppSettings.Instance.ProductionApiUrl);
-                MemoryCache.Default["odsApiVersion"] = odsApiVersion;
-            }
+            var odsApiVersion = InMemoryCache.Instance
+                .GetOrSet("OdsApiVersion", () => new InferOdsApiVersion().Version(CloudOdsAdminAppSettings.Instance.ProductionApiUrl));
 
             return !string.IsNullOrEmpty(odsApiVersion.ToString()) ? new HtmlString($"<span>ODS/API Version: {odsApiVersion}</span>") : new HtmlString("");
         }

--- a/Application/EdFi.Ods.AdminApp.Web/Helpers/HtmlHelperExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Helpers/HtmlHelperExtensions.cs
@@ -23,6 +23,8 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Property = EdFi.Ods.AdminApp.Web.Infrastructure.Property;
 using Preconditions = EdFi.Common.Preconditions;
+using System.Runtime.Caching;
+using EdFi.Ods.AdminApp.Management.Api;
 
 namespace EdFi.Ods.AdminApp.Web.Helpers
 {
@@ -509,7 +511,7 @@ namespace EdFi.Ods.AdminApp.Web.Helpers
             var assembly = Assembly.GetExecutingAssembly();
             var informationVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
 
-            return !string.IsNullOrEmpty(informationVersion) ? new HtmlString($"<span>{informationVersion}</span>") : new HtmlString("");
+            return !string.IsNullOrEmpty(informationVersion) ? new HtmlString($"<span>Admin App Version: {informationVersion}</span>") : new HtmlString("");
         }
 
         public static HtmlTag CheckBoxSquare<T>(this IHtmlHelper<T> helper, bool expression, string action) where T : class
@@ -520,6 +522,18 @@ namespace EdFi.Ods.AdminApp.Web.Helpers
             if (expression)
                 label.Append(input).AppendHtml(icon);
             return label;
+        }
+
+        public static HtmlString OdsApiVersion(this IHtmlHelper helper)
+        {
+            var odsApiVersion = MemoryCache.Default["odsApiVersion"];
+            if (odsApiVersion == null)
+            {
+                odsApiVersion = new InferOdsApiVersion().Version(CloudOdsAdminAppSettings.Instance.ProductionApiUrl);
+                MemoryCache.Default["odsApiVersion"] = odsApiVersion;
+            }
+
+            return !string.IsNullOrEmpty(odsApiVersion.ToString()) ? new HtmlString($"<span>ODS/API Version: {odsApiVersion}</span>") : new HtmlString("");
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Views/Shared/_Settings_Production.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/Shared/_Settings_Production.cshtml
@@ -36,6 +36,11 @@ See the LICENSE and NOTICES files in the project root for more information.
         </div>
     </div>
 </div>
+
+<div class="row">
+    <p class="text-right application-version col-lg-12 margin-top-10">@Html.OdsApiVersion()</p>
+</div>
+
 <script type="text/javascript">
     $(function () {
         InitializeBackNavigationalAjaxButtons();


### PR DESCRIPTION
The idea of this Story was to add a little tag over the ODS instances pages with the current version of the ODS/API that the admin app is connected to.

Also it was added a label to the number at the right bottom of the footer to identify that number like Admin App version

I also did a little improvement getting the Admin App version. For that i added the cache approach there to avoid constantly go to server to get the same variable