### PR TITLE
[AA-1160] - Phase out ConfigurationHelper in favor of IOptions

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests/AzureTestSettingsProvider.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests/AzureTestSettingsProvider.cs
@@ -5,12 +5,15 @@
 
 using System;
 using EdFi.Ods.AdminApp.Management.Helpers;
+using Microsoft.Extensions.Options;
+using Moq;
+using static EdFi.Ods.AdminApp.Management.Azure.IntegrationTests.Testing;
 
 namespace EdFi.Ods.AdminApp.Management.Azure.IntegrationTests
 {
     public static class AzureTestSettingsProvider
     {
-        private static readonly AppSettings _appSettings = ConfigurationHelper.GetAppSettings();
+        private static readonly AppSettings _appSettings = GetAppSettings();
 
         public static string GetTestConfigVariable(string variableName, string defaultValue = null)
         {
@@ -41,5 +44,16 @@ namespace EdFi.Ods.AdminApp.Management.Azure.IntegrationTests
         (
             DefaultTestCloudOdsInstance
         );
+
+        private static AppSettings GetAppSettings()
+        {
+            var appSettingsAccessor = new Mock<IOptions<AppSettings>>();
+            Scoped<IOptions<AppSettings>>(appSettings =>
+            {
+                appSettingsAccessor.Setup(x => x.Value).Returns(appSettings.Value);
+            });
+
+            return appSettingsAccessor.Object.Value;
+        }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests/GetDatabaseConnectionFromConfigFileTester.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests/GetDatabaseConnectionFromConfigFileTester.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System;
 using EdFi.Ods.AdminApp.Management.Database;
 using EdFi.Ods.AdminApp.Management.Helpers;
 using Microsoft.Extensions.Options;
@@ -31,6 +32,7 @@ namespace EdFi.Ods.AdminApp.Management.Azure.IntegrationTests
 
             rawSqlConnectionService.GetDatabaseConnectionFromConfigFile(CloudOdsDatabaseNames.Admin).ConnectionString.ShouldBe(connectionStrings.Admin);
             rawSqlConnectionService.GetDatabaseConnectionFromConfigFile(CloudOdsDatabaseNames.Security).ConnectionString.ShouldBe(connectionStrings.Security);
+            Assert.Throws<Exception>(() => rawSqlConnectionService.GetDatabaseConnectionFromConfigFile(null));
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests/GetDatabaseConnectionFromConfigFileTester.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests/GetDatabaseConnectionFromConfigFileTester.cs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Ods.AdminApp.Management.Database;
+using EdFi.Ods.AdminApp.Management.Helpers;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Shouldly;
+using static EdFi.Ods.AdminApp.Management.Azure.IntegrationTests.Testing;
+
+namespace EdFi.Ods.AdminApp.Management.Azure.IntegrationTests
+{
+    [TestFixture]
+    public class GetDatabaseConnectionFromConfigFileTester : AzureIntegrationTestBase
+    {
+        [Test]
+        public void ShouldMatchExpectedConnectionStringFromAppSettings()
+        {
+            var connectionStringsAccessor = new Mock<IOptions<ConnectionStrings>>();
+            Scoped<IOptions<ConnectionStrings>>(connStrings =>
+            {
+                connectionStringsAccessor.Setup(x => x.Value).Returns(connStrings.Value);
+            });
+
+            var connectionStrings = connectionStringsAccessor.Object.Value;
+
+            var rawSqlConnectionService = new RawSqlConnectionService(connectionStringsAccessor.Object);
+
+            rawSqlConnectionService.GetDatabaseConnectionFromConfigFile(CloudOdsDatabaseNames.Admin).ConnectionString.ShouldBe(connectionStrings.Admin);
+            rawSqlConnectionService.GetDatabaseConnectionFromConfigFile(CloudOdsDatabaseNames.Security).ConnectionString.ShouldBe(connectionStrings.Security);
+        }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Management.OnPrem/GetOnPremOdsInstanceQuery.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.OnPrem/GetOnPremOdsInstanceQuery.cs
@@ -5,17 +5,25 @@
 
 using System.Threading.Tasks;
 using EdFi.Ods.AdminApp.Management.Helpers;
+using Microsoft.Extensions.Options;
 
 namespace EdFi.Ods.AdminApp.Management.OnPrem
 {
     public class GetOnPremOdsInstanceQuery : IGetCloudOdsInstanceQuery
     {
+        private readonly AppSettings _appSettings;
+
+        public GetOnPremOdsInstanceQuery(IOptions<AppSettings> appSettingsAccessor)
+        {
+            _appSettings = appSettingsAccessor.Value;
+        }
+
         public Task<CloudOdsInstance> Execute(string instanceName)
         {
             return Task.FromResult(new CloudOdsInstance
             {
                 FriendlyName = instanceName,
-                Version = ConfigurationHelper.GetAppSettings().AwsCurrentVersion //leaving "AWS" reference for config file compatibility with AWS distribution
+                Version = _appSettings.AwsCurrentVersion //leaving "AWS" reference for config file compatibility with AWS distribution
             });
         }
     }

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Configuration/Configuration/OdsSecretConfigurationProviderTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Configuration/Configuration/OdsSecretConfigurationProviderTests.cs
@@ -9,7 +9,10 @@ using System.Runtime.Caching;
 using System.Threading.Tasks;
 using EdFi.Ods.AdminApp.Management.Database;
 using EdFi.Ods.AdminApp.Management.Database.Models;
+using EdFi.Ods.AdminApp.Management.Helpers;
 using EdFi.Ods.AdminApp.Management.Services;
+using Microsoft.Extensions.Options;
+using Moq;
 using NUnit.Framework;
 using Shouldly;
 using static EdFi.Ods.AdminApp.Management.Tests.Testing;
@@ -20,9 +23,16 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Configuration.Configuration
     {
         private static OdsSecretConfigurationProvider OdsSecretConfigurationProvider(AdminAppDbContext database)
         {
+
+            var appSettingsAccessor = new Mock<IOptions<AppSettings>>();
+            Scoped<IOptions<AppSettings>>(appSettings =>
+            {
+                appSettingsAccessor.Setup(x => x.Value).Returns(appSettings.Value);
+            });
+
             return new OdsSecretConfigurationProvider(
                 new StringEncryptorService(
-                    new EncryptionConfigurationProviderService()), database);
+                    new EncryptionConfigurationProviderService(appSettingsAccessor.Object)), database);
         }
 
         private async Task<OdsSqlConfiguration> GetSqlConfiguration()

--- a/Application/EdFi.Ods.AdminApp.Management/Database/RawSqlConnectionService.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/RawSqlConnectionService.cs
@@ -7,6 +7,7 @@ using System.Configuration;
 using System.Data.SqlClient;
 using System.Threading.Tasks;
 using EdFi.Ods.AdminApp.Management.Helpers;
+using Microsoft.Extensions.Options;
 
 namespace EdFi.Ods.AdminApp.Management.Database
 {
@@ -21,6 +22,13 @@ namespace EdFi.Ods.AdminApp.Management.Database
 
     public class RawSqlConnectionService : IRawSqlConnectionService
     {
+        private readonly ConnectionStrings _connectionStrings;
+
+        public RawSqlConnectionService(IOptions<ConnectionStrings> connectionStrings)
+        {
+            _connectionStrings = connectionStrings.Value;
+        }
+
         public SqlConnection GetDatabaseConnectionFromConfigFile(string databaseName)
         {
             var connectionString = GetConnectionStringFromConfigFile(databaseName);
@@ -29,7 +37,7 @@ namespace EdFi.Ods.AdminApp.Management.Database
 
         private string GetConnectionStringFromConfigFile(string databaseName)
         {
-            return ConfigurationHelper.GetConnectionStringByName(databaseName);
+            return _connectionStrings.GetConnectionStringByName(databaseName);
         }
 
         private SqlConnection GetDatabaseConnection(string connectionString)

--- a/Application/EdFi.Ods.AdminApp.Management/Helpers/AppSettings.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Helpers/AppSettings.cs
@@ -29,26 +29,4 @@ namespace EdFi.Ods.AdminApp.Management.Helpers
         public string OptionalEntropy { get; set; }
         public string Log4NetConfigPath { get; set; }
     }
-
-    public class ConnectionStrings
-    {
-        public string Admin { get; set; }
-        public string Security { get; set; }
-        public string ProductionOds { get; set; }
-
-        public string GetConnectionStringByName(string databaseName)
-        {
-            switch (databaseName)
-            {
-                case CloudOdsDatabaseNames.Admin:
-                    return Admin;
-                case CloudOdsDatabaseNames.Security:
-                    return Security;
-                case CloudOdsDatabaseNames.ProductionOds:
-                    return ProductionOds;
-                default:
-                    return null;
-            }
-        }
-    }
 }

--- a/Application/EdFi.Ods.AdminApp.Management/Helpers/ConfigurationHelper.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Helpers/ConfigurationHelper.cs
@@ -3,55 +3,8 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-using System.Configuration;
-
 namespace EdFi.Ods.AdminApp.Management.Helpers
 {
-    public static class ConfigurationHelper
-    {
-
-        private static readonly AppSettings _appSettings;
-
-        static ConfigurationHelper()
-        {
-            _appSettings = new AppSettings();
-
-            _appSettings.AppStartup = ConfigurationManager.AppSettings["owin:appStartup"];
-            _appSettings.DatabaseEngine = ConfigurationManager.AppSettings["DatabaseEngine"];
-            _appSettings.ApplicationInsightsInstrumentationKey =
-                ConfigurationManager.AppSettings["ApplicationInsightsInstrumentationKey"];
-            _appSettings.XsdFolder = ConfigurationManager.AppSettings["XsdFolder"];
-            _appSettings.DefaultOdsInstance = ConfigurationManager.AppSettings["DefaultOdsInstance"];
-            _appSettings.ProductionApiUrl = ConfigurationManager.AppSettings["ProductionApiUrl"];
-            _appSettings.SystemManagedSqlServer = ConfigurationManager.AppSettings["SystemManagedSqlServer"];
-            _appSettings.DbSetupEnabled = ConfigurationManager.AppSettings["DbSetupEnabled"];
-            _appSettings.SecurityMetadataCacheTimeoutMinutes =
-                ConfigurationManager.AppSettings["SecurityMetadataCacheTimeoutMinutes"];
-            _appSettings.ApiStartupType = ConfigurationManager.AppSettings["apiStartup:type"];
-            _appSettings.LocalEducationAgencyTypeValue = ConfigurationManager.AppSettings["LocalEducationAgencyTypeValue"];
-            _appSettings.SchoolTypeValue = ConfigurationManager.AppSettings["SchoolTypeValue"];
-            _appSettings.BulkUploadHashCache = ConfigurationManager.AppSettings["BulkUploadHashCache"];
-            _appSettings.IdaAADInstance = ConfigurationManager.AppSettings["ida:AADInstance"];
-            _appSettings.IdaClientId = ConfigurationManager.AppSettings["ida:ClientId"];
-            _appSettings.IdaClientSecret = ConfigurationManager.AppSettings["ida:ClientSecret"];
-            _appSettings.IdaTenantId = ConfigurationManager.AppSettings["ida:TenantId"];
-            _appSettings.IdaSubscriptionId = ConfigurationManager.AppSettings["ida:SubscriptionId"];
-            _appSettings.AwsCurrentVersion = ConfigurationManager.AppSettings["AwsCurrentVersion"];
-            _appSettings.OptionalEntropy = ConfigurationManager.AppSettings["OptionalEntropy"];
-            _appSettings.Log4NetConfigPath = ConfigurationManager.AppSettings["log4net.Config"];
-        }
-
-        public static AppSettings GetAppSettings()
-        {
-            return _appSettings;
-        }
-
-        public static string GetConnectionStringByName(string databaseName)
-        {
-            return ConfigurationManager.ConnectionStrings[databaseName]?.ConnectionString;
-        }
-    }
-
     public class AppSettings
     {
         public string AppStartup { get; set; }

--- a/Application/EdFi.Ods.AdminApp.Management/Helpers/ConfigurationHelper.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Helpers/ConfigurationHelper.cs
@@ -82,5 +82,20 @@ namespace EdFi.Ods.AdminApp.Management.Helpers
         public string Admin { get; set; }
         public string Security { get; set; }
         public string ProductionOds { get; set; }
+
+        public string GetConnectionStringByName(string databaseName)
+        {
+            switch (databaseName)
+            {
+                case CloudOdsDatabaseNames.Admin:
+                    return Admin;
+                case CloudOdsDatabaseNames.Security:
+                    return Security;
+                case CloudOdsDatabaseNames.ProductionOds:
+                    return ProductionOds;
+                default:
+                    return null;
+            }
+        }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management/Helpers/ConnectionStrings.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Helpers/ConnectionStrings.cs
@@ -3,6 +3,8 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System;
+
 namespace EdFi.Ods.AdminApp.Management.Helpers
 {
     public class ConnectionStrings
@@ -22,7 +24,7 @@ namespace EdFi.Ods.AdminApp.Management.Helpers
                 case CloudOdsDatabaseNames.ProductionOds:
                     return ProductionOds;
                 default:
-                    return null;
+                    throw new Exception("Invalid Database Name provided.");
             }
         }
     }

--- a/Application/EdFi.Ods.AdminApp.Management/Helpers/ConnectionStrings.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Helpers/ConnectionStrings.cs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.Ods.AdminApp.Management.Helpers
+{
+    public class ConnectionStrings
+    {
+        public string Admin { get; set; }
+        public string Security { get; set; }
+        public string ProductionOds { get; set; }
+
+        public string GetConnectionStringByName(string databaseName)
+        {
+            switch (databaseName)
+            {
+                case CloudOdsDatabaseNames.Admin:
+                    return Admin;
+                case CloudOdsDatabaseNames.Security:
+                    return Security;
+                case CloudOdsDatabaseNames.ProductionOds:
+                    return ProductionOds;
+                default:
+                    return null;
+            }
+        }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Management/Services/EncryptionConfigurationProviderService.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Services/EncryptionConfigurationProviderService.cs
@@ -5,14 +5,22 @@
 
 using System.Text;
 using EdFi.Ods.AdminApp.Management.Helpers;
+using Microsoft.Extensions.Options;
 
 namespace EdFi.Ods.AdminApp.Management.Services
 {
     public class EncryptionConfigurationProviderService : IEncryptionConfigurationProviderService
     {
+        private readonly AppSettings _appSettings;
+
+        public EncryptionConfigurationProviderService(IOptions<AppSettings> appSettingsAccessor)
+        {
+            _appSettings = appSettingsAccessor.Value;
+        }
+
         public byte[] GetEntropy()
         {
-            var optionalEntropyValue = ConfigurationHelper.GetAppSettings().OptionalEntropy;
+            var optionalEntropyValue = _appSettings.OptionalEntropy;
             var entropy = string.IsNullOrEmpty(optionalEntropyValue)
                 ? null
                 : Encoding.ASCII.GetBytes(optionalEntropyValue);


### PR DESCRIPTION
**Description**

- Added GetConnectionStringByName method to the ConnectionStrings class in order to aid in getting the connectionString by database name.
- Refactored GetOnPremOdsInstanceQuery to use the IOptions pattern to access AppSettings and get the AwsCurrentVersion setting value.
- Refactored EncryptionConfigurationProviderService to use the IOptions pattern to access AppSettings and get the OptionalEntropy setting value. Refactored OdsSecretConfigurationProviderTests to provide an IOptions<AppSettings> mock for EncryptionConfigurationProviderService.
- Refactored RawSqlConnectionService to use the IOptions pattern to access ConnectionStrings. Added an azure integration test to test the GetDatabaseConnectionFromConfigFile functionality in RawSqlConnectionService.
- Refactored AzureTestSettingsProvider to use the IOptions pattern to access AppSettings.
- Remove ConfigurationHelper now that it is no longer being used.Extracted AppSettings and ConnectionStrings classes into their own files and removed ConfigurationHelper file.