### PR TITLE
[AA-1172] Resolve version number warning when running migration script

### DIFF
--- a/eng/run-dbup-migrations.ps1
+++ b/eng/run-dbup-migrations.ps1
@@ -24,7 +24,6 @@ Import-Module -Name "$PSScriptRoot/database-manager.psm1" -Force
 
 $arguments = @{
     ToolsPath = ".tools"
-    DbDeployVersion = "1.1.0"
     ForPostgreSQL = "postgresql" -eq $config.engine.ToLower()
     Server = $config.databaseServer
     DatabaseName = $config.adminDatabaseName


### PR DESCRIPTION
Remove DbDeployVersion argument from run-dbup-migrations.ps1 script to avoid warnings running the script to generate the admin app tables.

As you can see now in the image below, the script runs without warning messages:
![WITHOUT warning](https://user-images.githubusercontent.com/74211153/102413861-996a8680-3fc3-11eb-8acb-27ca5b4781cc.PNG)
