### PR TITLE
[AA-1172] Adjust version number in database-manage powershell script

### DIFF
--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -34,7 +34,7 @@ Import-Module -Force $folders.modules.invoke("Application/Install.psm1") -Scope 
 Import-Module -Force $folders.modules.invoke("Application/Uninstall.psm1") -Scope Global
 Import-Module -Force $folders.modules.invoke("Application/Configuration.psm1") -Scope Global
 
-$DbDeployVersion = "1.1.0"
+$DbDeployVersion = "2.0.0"
 
 function Install-EdFiOdsAdminApp {
     <#
@@ -255,7 +255,7 @@ function Install-EdFiOdsAdminApp {
         [switch]
         $NoDuration,
 
-        # App startup will decide admin app startup type. Valid values are OnPrem, Azure. Installer always used in 
+        # App startup will decide admin app startup type. Valid values are OnPrem, Azure. Installer always used in
         # OnPrem mode. So, the default value set to OnPrem
         [String]
         $AppStartUp = "OnPrem"
@@ -299,7 +299,7 @@ function Install-EdFiOdsAdminApp {
     $elapsed = Use-StopWatch {
         $result += Initialize-Configuration -Config $config
         $result += Get-AdminAppPackage -Config $Config
-        $result += Get-DbDeploy -Config $Config      
+        $result += Get-DbDeploy -Config $Config
         $result += Invoke-TransformAppSettings -Config $Config
         $result += Invoke-TransformConnectionStrings -Config $config
         $result += Install-Application -Config $Config
@@ -489,7 +489,7 @@ function Invoke-TransformAppSettings {
         $settingsFile = Join-Path $Config.WebConfigLocation "appsettings.json"
         $settings = Get-Content $settingsFile | ConvertFrom-Json | ConvertTo-Hashtable
         $settings.AppSettings.ProductionApiUrl = $Config.OdsApiUrl
-        $settings.AppSettings.SecurityMetadataCacheTimeoutMinutes = '10'  
+        $settings.AppSettings.SecurityMetadataCacheTimeoutMinutes = '10'
         $settings.AppSettings.DatabaseEngine = $config.engine
         $settings.AppSettings.AppStartup = $Config.AppStartUp
         if("OnPrem" -ieq $Config.AppStartup)
@@ -516,7 +516,7 @@ function Invoke-TransformAppSettings {
 
         $EmptyHashTable=@{}
         $mergedSettings = Merge-Hashtables $settings, $EmptyHashTable
-        New-JsonFile $settingsFile $mergedSettings -Overwrite        
+        New-JsonFile $settingsFile $mergedSettings -Overwrite
     }
 }
 
@@ -563,7 +563,7 @@ function Invoke-TransformConnectionStrings {
             ConnectionStrings = @{
                 ProductionOds = $odsconnString
                 Admin = $adminconnString
-                Security = $securityConnString 
+                Security = $securityConnString
             }
         }
 

--- a/eng/database-manager.psm1
+++ b/eng/database-manager.psm1
@@ -1,4 +1,4 @@
-﻿# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # Licensed to the Ed-Fi Alliance under one or more agreements.
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
@@ -6,6 +6,7 @@
 #requires -version 5
 
 $ErrorActionPreference = "Stop"
+Set-Variable DbDeployVersion -option Constant -value "2.0.0"
 
 Import-Module -Name "$PSScriptRoot/connection-strings.psm1"
 
@@ -272,7 +273,7 @@ function Install-EdFiAdminDatabase {
 
         # EdFi.Db.Deploy tool version to use.
         [string]
-        $DbDeployVersion = "1.1.0",
+        $DbDeployVersion = $DbDeployVersion,
 
         # Ed-Fi NuGet feed for tool download.
         [string]
@@ -342,7 +343,7 @@ function Install-EdFiODSDatabase {
 
         # EdFi.Db.Deploy tool version to use.
         [string]
-        $DbDeployVersion = "1.1.0",
+        $DbDeployVersion = $DbDeployVersion,
 
         # Ed-Fi NuGet feed for tool download.
         [string]
@@ -412,7 +413,7 @@ function Install-EdFiSecurityDatabase {
 
         # EdFi.Db.Deploy tool version to use.
         [string]
-        $DbDeployVersion = "1.1.0",
+        $DbDeployVersion = $DbDeployVersion,
 
         # Ed-Fi NuGet feed for tool download.
         [string]
@@ -483,7 +484,7 @@ function Install-AdminAppTables {
 
         # EdFi.Db.Deploy tool version to use.
         [string]
-        $DbDeployVersion = "2.0.0",
+        $DbDeployVersion = $DbDeployVersion,
 
         # Ed-Fi NuGet feed for tool download.
         [string]
@@ -559,7 +560,7 @@ function Invoke-PrepareDatabasesForTesting {
 
         # EdFi.Db.Deploy tool version to use.
         [string]
-        $DbDeployVersion = "2.0.0",
+        $DbDeployVersion = $DbDeployVersion,
 
         # Ed-Fi NuGet feed for tool download.
         [string]


### PR DESCRIPTION
As it was done in run-dbup-migrations powershell script, it was necessary to adjust the version in database-manager script.

The idea was to include a constant at the top of the file and reference it where it was needed instead of put string with different versions over all the script.