### PR TITLE
[AA 1195] Add "None" value to empty applications profile

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web/Views/Application/_ApplicationsTable.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/Application/_ApplicationsTable.cshtml
@@ -45,7 +45,7 @@ See the LICENSE and NOTICES files in the project root for more information.
                         </div>
                         <div class="col-lg-6">
                             <p>
-                                <strong>Profile: </strong>@application.ProfileName
+                                <strong>Profile: </strong>@(application.ProfileName == null ? "None": @application.ProfileName)
                             </p>
                         </div>
                     </div>


### PR DESCRIPTION
In Current version of the ODS/API  sample profiles were temporarily dropped from v5.1.0 - but coming back in v5.2.0.
For that reason it was defined to Add "None" value to profile field in application list view instead of showing up an empty or blank field.