### PR TITLE
[AA-1199] Handle error message when claim set name is too big

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/AddClaimSetModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/AddClaimSetModel.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -25,6 +25,10 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
             RuleFor(m => m.ClaimSetName).NotEmpty()
                 .Must(BeAUniqueName)
                 .WithMessage("A claim set with this name already exists in the database. Please enter a unique name.");
+
+            RuleFor(m => m.ClaimSetName)
+                .MaximumLength(255)
+                .WithMessage("The claim set name must be maximum 255 characters.");
         }
 
         private bool BeAUniqueName(string newName)

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/AddClaimSetModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/AddClaimSetModel.cs
@@ -28,7 +28,7 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
 
             RuleFor(m => m.ClaimSetName)
                 .MaximumLength(255)
-                .WithMessage("The claim set name must be maximum 255 characters.");
+                .WithMessage("The claim set name must be less than 255 characters.");
         }
 
         private bool BeAUniqueName(string newName)

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/CopyClaimSetModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/CopyClaimSetModel.cs
@@ -28,7 +28,7 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
 
             RuleFor(m => m.Name)
                 .MaximumLength(255)
-                .WithMessage("The claim set name must be maximum 255 characters.");
+                .WithMessage("The claim set name must be less than 255 characters.");
         }
 
         private bool BeAUniqueName(string newName)

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/CopyClaimSetModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/CopyClaimSetModel.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -25,6 +25,10 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
         {
             _context = context;
             RuleFor(m => m.Name).NotEmpty().Must(BeAUniqueName).WithMessage("The new claim set must have a unique name");
+
+            RuleFor(m => m.Name)
+                .MaximumLength(255)
+                .WithMessage("The claim set name must be maximum 255 characters.");
         }
 
         private bool BeAUniqueName(string newName)

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/EditClaimSetModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/EditClaimSetModel.cs
@@ -35,6 +35,10 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
                 .Must(BeAUniqueName)
                 .WithMessage("A claim set with this name already exists in the database. Please enter a unique name.")
                 .When(NameIsChanged);
+
+            RuleFor(m => m.ClaimSetName)
+                .MaximumLength(255)
+                .WithMessage("The claim set name must be less than 255 characters.");
         }
 
         private bool NameIsChanged(EditClaimSetModel model)

--- a/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_AddClaimSet.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_AddClaimSet.cshtml
@@ -1,4 +1,4 @@
-﻿@*
+@*
 SPDX-License-Identifier: Apache-2.0
 Licensed to the Ed-Fi Alliance under one or more agreements.
 The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
@@ -13,8 +13,8 @@ See the LICENSE and NOTICES files in the project root for more information.
 {
     @Html.AntiForgeryToken()
     <div id="add-claim-set-validation-summary" class="validationSummary alert alert-danger" hidden></div>
-    <div class="form-group row">
-        @Html.InputBlock(x => x.ClaimSetName)
+    <div class="form-group row">        
+        @Html.InputBlock(m => m.ClaimSetName, inputModifier: x => x.Attr("maxlength", 255))
     </div>
     <br />
     <div class="padding-top-5">

--- a/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_CopyClaimSetModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_CopyClaimSetModal.cshtml
@@ -1,4 +1,4 @@
-﻿@*
+@*
 SPDX-License-Identifier: Apache-2.0
 Licensed to the Ed-Fi Alliance under one or more agreements.
 The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
@@ -23,7 +23,7 @@ See the LICENSE and NOTICES files in the project root for more information.
                 {
                     @Html.Input(m => m.OriginalId).Hide()
                     @Html.ValidationBlock()
-                    @Html.InputBlock(m => m.Name)
+                    @Html.InputBlock(m => m.Name, inputModifier: x => x.Attr("maxlength", 255))
                 }
             </div>
             <div class="modal-footer">

--- a/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_EditClaimSet.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_EditClaimSet.cshtml
@@ -16,7 +16,7 @@ See the LICENSE and NOTICES files in the project root for more information.
     @Html.Input(x => x.ClaimSetId).Hide()
     <div class="form-group row">
         <div class="col-md-8">
-            @Html.InputBlock(x => x.ClaimSetName)
+            @Html.InputBlock(x => x.ClaimSetName, inputModifier: x => x.Attr("maxlength", 255))
         </div>
         <div class="col-md-4">
             @Html.SaveButton("Update Name")


### PR DESCRIPTION
What was happening?
When we wanted to add a new claim set or copy from a pre existing one and the claim set name was greater than 255 characters(max allowed in database) a general error related to database was shown to the user.

What is the Fix?
First of all was added a max length restriction in the UI to restrict the user to type a claim set name greater than 255 characters, and for the other side is was added a Fluent validation rule to AddClaimSetsModel, CopyClaimSetModel and EditClaimSetModel classes to prevent going to database instead of user manually edit the html to remove max length validation.