### PR TITLE
[AA-1199] Include tests to Add, Copy and edit claim set actions when name length is too big

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/AddClaimSetCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/AddClaimSetCommandTests.cs
@@ -79,5 +79,26 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
                 validationResults.Errors.Single().ErrorMessage.ShouldBe("'Claim Set Name' must not be empty.");
             });
         }
+
+        [Test]
+        public void ShouldNotAddClaimSetIfNameLengthGreaterThan255Characters()
+        {
+            var testApplication = new Application
+            {
+                ApplicationName = $"Test Application {DateTime.Now:O}"
+            };
+            Save(testApplication);           
+
+            var newClaimSet = new AddClaimSetModel { ClaimSetName = "ThisIsAClaimSetWithNameLengthGreaterThan255CharactersThisIsAClaimSetWithNameLengthGreaterThan255CharactersThisIsAClaimSetWithNameLengthGreaterThan255CharactersThisIsAClaimSetWithNameLengthGreaterThan255CharactersThisIsAClaimSetWithNameLengthGreaterThan255CharactersThisIsAClaimSetWithNameLengthGreaterThan255Characters" };
+
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var validator = new AddClaimSetModelValidator(securityContext);
+                var validationResults = validator.Validate(newClaimSet);
+                validationResults.IsValid.ShouldBe(false);
+                validationResults.Errors.Single().ErrorMessage.ShouldBe("The claim set name must be less than 255 characters.");
+            });
+        }
+
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/CopyClaimSetCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/CopyClaimSetCommandTests.cs
@@ -106,5 +106,33 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
                 validationResults.Errors.Single().ErrorMessage.ShouldBe("The new claim set must have a unique name");
             });
         }
+
+        [Test]
+        public void ShouldNotCopyClaimSetIfNameLengthGreaterThan255Characters()
+        {
+            var testApplication = new Application
+            {
+                ApplicationName = $"Test Application {DateTime.Now:O}"
+            };
+            Save(testApplication);
+
+            var testClaimSet = new ClaimSet { ClaimSetName = "TestClaimSet", Application = testApplication };
+            Save(testClaimSet);
+
+            var newClaimSet = new CopyClaimSetModel()
+            {
+                Name = "ThisIsAClaimSetWithNameLengthGreaterThan255CharactersThisIsAClaimSetWithNameLengthGreaterThan255CharactersThisIsAClaimSetWithNameLengthGreaterThan255CharactersThisIsAClaimSetWithNameLengthGreaterThan255CharactersThisIsAClaimSetWithNameLengthGreaterThan255CharactersThisIsAClaimSetWithNameLengthGreaterThan255Characters",
+                OriginalId = testClaimSet.ClaimSetId
+            };
+
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var validator = new CopyClaimSetModelValidator(securityContext);
+                var validationResults = validator.Validate(newClaimSet);
+                validationResults.IsValid.ShouldBe(false);
+                validationResults.Errors.Single().ErrorMessage.ShouldBe("The claim set name must be less than 255 characters.");
+            });
+        }
+
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/EditClaimSetCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/EditClaimSetCommandTests.cs
@@ -91,5 +91,29 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
                 validationResults.Errors.Single().ErrorMessage.ShouldBe("'Claim Set Name' must not be empty.");
             });
         }
+
+        [Test]
+        public void ShouldNotEditClaimSetIfNameLengthGreaterThan255Characters()
+        {
+            var testApplication = new Application
+            {
+                ApplicationName = $"Test Application {DateTime.Now:O}"
+            };
+            Save(testApplication);
+
+            var testClaimSet = new ClaimSet { ClaimSetName = "TestClaimSet1", Application = testApplication };
+            Save(testClaimSet);
+
+            var editModel = new EditClaimSetModel { ClaimSetName = "ThisIsAClaimSetWithNameLengthGreaterThan255CharactersThisIsAClaimSetWithNameLengthGreaterThan255CharactersThisIsAClaimSetWithNameLengthGreaterThan255CharactersThisIsAClaimSetWithNameLengthGreaterThan255CharactersThisIsAClaimSetWithNameLengthGreaterThan255CharactersThisIsAClaimSetWithNameLengthGreaterThan255Characters", ClaimSetId = testClaimSet.ClaimSetId };
+
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var validator = new EditClaimSetModelValidator(securityContext);
+                var validationResults = validator.Validate(editModel);
+                validationResults.IsValid.ShouldBe(false);
+                validationResults.Errors.Single().ErrorMessage.ShouldBe("The claim set name must be less than 255 characters.");
+            });
+        }
+
     }
 }


### PR DESCRIPTION
Include tests to Add, Copy and edit claim set actions when name length greater than 255 characters. 
This is the second part of the ticket because the first version did not include the tests.