### PR TITLE
[AA-879] Fix layout issue when opening claim set details in new broser tab

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ClaimSetsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ClaimSetsController.cs
@@ -96,7 +96,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
                     _tabDisplayService.GetGlobalSettingsTabDisplay(
                         GlobalSettingsTabEnumeration.ClaimSets),
                 IsOpenedInSameTab = Request.Query["_"].Any()
-        };
+            };
             
            return PartialView("_ClaimSetDetails", model);
         }

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ClaimSetsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ClaimSetsController.cs
@@ -18,6 +18,7 @@ using EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets;
 using Newtonsoft.Json;
 using static EdFi.Ods.AdminApp.Web.Infrastructure.ResourceClaimSelectListBuilder;
 using AddClaimSetModel = EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets.AddClaimSetModel;
+using EdFi.Ods.AdminApp.Web.Display.TabEnumeration;
 
 namespace EdFi.Ods.AdminApp.Web.Controllers
 {
@@ -42,6 +43,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         private readonly ClaimSetFileExportCommand _claimSetFileExportCommand;
         private readonly OverrideDefaultAuthorizationStrategyCommand _overrideDefaultAuthorizationStrategyCommand;
         private readonly ResetToDefaultAuthStrategyCommand _resetToDefaultAuthStrategyCommand;
+        private readonly ITabDisplayService _tabDisplayService;
 
         public ClaimSetsController(IGetClaimSetByIdQuery getClaimSetByIdQuery
             , IGetApplicationsByClaimSetIdQuery getApplicationsByClaimSetIdQuery
@@ -59,7 +61,8 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
             , ClaimSetFileExportCommand claimSetFileExportCommand
             , ClaimSetFileImportCommand claimSetFileImportCommand
             , OverrideDefaultAuthorizationStrategyCommand overrideDefaultAuthorizationStrategyCommand
-            , ResetToDefaultAuthStrategyCommand resetToDefaultAuthStrategyCommand)
+            , ResetToDefaultAuthStrategyCommand resetToDefaultAuthStrategyCommand
+            , ITabDisplayService tabDisplayService)
         {
             _getClaimSetByIdQuery = getClaimSetByIdQuery;
             _getApplicationsByClaimSetIdQuery = getApplicationsByClaimSetIdQuery;
@@ -79,6 +82,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
             _claimSetFileImportCommand = claimSetFileImportCommand;
             _overrideDefaultAuthorizationStrategyCommand = overrideDefaultAuthorizationStrategyCommand;
             _resetToDefaultAuthStrategyCommand = resetToDefaultAuthStrategyCommand;
+            _tabDisplayService = tabDisplayService;
         }
 
         public ActionResult ClaimSetDetails(int claimSetId)
@@ -87,9 +91,13 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
             {
                 ClaimSet = _getClaimSetByIdQuery.Execute(claimSetId),
                 Applications = _getApplicationsByClaimSetIdQuery.Execute(claimSetId),
-                ResourceClaims = _getResourcesByClaimSetIdQuery.AllResources(claimSetId)
-            };
-
+                ResourceClaims = _getResourcesByClaimSetIdQuery.AllResources(claimSetId),
+                GlobalSettingsTabEnumerations =
+                    _tabDisplayService.GetGlobalSettingsTabDisplay(
+                        GlobalSettingsTabEnumeration.ClaimSets),
+                IsOpenedInSameTab = Request.Query["_"].Any()
+        };
+            
            return PartialView("_ClaimSetDetails", model);
         }
 

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/ClaimSetDetailsModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/ClaimSetDetailsModel.cs
@@ -1,10 +1,11 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Collections.Generic;
 using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
+using EdFi.Ods.AdminApp.Web.Display.TabEnumeration;
 
 namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
 {
@@ -13,5 +14,7 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
         public ClaimSet ClaimSet { get; set; }
         public IEnumerable<Management.ClaimSetEditor.Application> Applications { get; set; }
         public IEnumerable<ResourceClaim> ResourceClaims { get; set; }
+        public List<TabDisplay<GlobalSettingsTabEnumeration>> GlobalSettingsTabEnumerations { get; set; }
+        public bool IsOpenedInSameTab { get; set; }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_ClaimSetDetails.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_ClaimSetDetails.cshtml
@@ -1,12 +1,19 @@
-﻿@*
-SPDX-License-Identifier: Apache-2.0
-Licensed to the Ed-Fi Alliance under one or more agreements.
-The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
-See the LICENSE and NOTICES files in the project root for more information.
+@*
+    SPDX-License-Identifier: Apache-2.0
+    Licensed to the Ed-Fi Alliance under one or more agreements.
+    The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+    See the LICENSE and NOTICES files in the project root for more information.
 *@
 
 @using EdFi.Ods.AdminApp.Web.Helpers
 @model EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets.ClaimSetDetailsModel
+
+@{   
+    if (!Model.IsOpenedInSameTab)
+    {
+        Layout = "~/Views/Shared/_ClaimSetDetailsPartial.cshtml";
+    }
+}
 
 <h3>Claim Set Information</h3>
 <div class="form-group row">
@@ -109,13 +116,13 @@ else
 {
     <div> No resource claims found.</div>
 }
-    <div>
-        @Html.Button("Back").AddClass("back-btn back-ajax claimset-back-btn").Data("back-url", Url.Action("ClaimSets", "GlobalSettings"))
-        @if (Model.ClaimSet.IsEditable)
-        {
-            @Html.Button("Edit Claim Set").Attr("href", Url.Action("EditClaimSet", "ClaimSets", new { claimSetId = Model.ClaimSet.Id })).AddClass("edit-claimset navigational-ajax").Data("state", "edit").Data("page-url", Url.Action("ClaimSets", "GlobalSettings")).Data("action", "editing the Claim Set")
-        }
-    </div>
+<div>
+    @Html.Button("Back").AddClass("back-btn back-ajax claimset-back-btn").Data("back-url", Url.Action("ClaimSets", "GlobalSettings"))
+    @if (Model.ClaimSet.IsEditable)
+    {
+        @Html.Button("Edit Claim Set").Attr("href", Url.Action("EditClaimSet", "ClaimSets", new { claimSetId = Model.ClaimSet.Id })).AddClass("edit-claimset navigational-ajax").Data("state", "edit").Data("page-url", Url.Action("ClaimSets", "GlobalSettings")).Data("action", "editing the Claim Set")
+    }
+</div>
 
 <script type="text/javascript">
     $('.claims-toggle').click(function () {

--- a/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_ClaimSetDetails.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_ClaimSetDetails.cshtml
@@ -1,8 +1,8 @@
 @*
-    SPDX-License-Identifier: Apache-2.0
-    Licensed to the Ed-Fi Alliance under one or more agreements.
-    The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
-    See the LICENSE and NOTICES files in the project root for more information.
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
 *@
 
 @using EdFi.Ods.AdminApp.Web.Helpers
@@ -116,13 +116,13 @@ else
 {
     <div> No resource claims found.</div>
 }
-<div>
-    @Html.Button("Back").AddClass("back-btn back-ajax claimset-back-btn").Data("back-url", Url.Action("ClaimSets", "GlobalSettings"))
-    @if (Model.ClaimSet.IsEditable)
-    {
-        @Html.Button("Edit Claim Set").Attr("href", Url.Action("EditClaimSet", "ClaimSets", new { claimSetId = Model.ClaimSet.Id })).AddClass("edit-claimset navigational-ajax").Data("state", "edit").Data("page-url", Url.Action("ClaimSets", "GlobalSettings")).Data("action", "editing the Claim Set")
-    }
-</div>
+    <div>
+        @Html.Button("Back").AddClass("back-btn back-ajax claimset-back-btn").Data("back-url", Url.Action("ClaimSets", "GlobalSettings"))
+        @if (Model.ClaimSet.IsEditable)
+        {
+            @Html.Button("Edit Claim Set").Attr("href", Url.Action("EditClaimSet", "ClaimSets", new { claimSetId = Model.ClaimSet.Id })).AddClass("edit-claimset navigational-ajax").Data("state", "edit").Data("page-url", Url.Action("ClaimSets", "GlobalSettings")).Data("action", "editing the Claim Set")
+        }
+    </div>
 
 <script type="text/javascript">
     $('.claims-toggle').click(function () {

--- a/Application/EdFi.Ods.AdminApp.Web/Views/Shared/_ClaimSetDetailsPartial.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/Shared/_ClaimSetDetailsPartial.cshtml
@@ -1,0 +1,31 @@
+@*
+    SPDX-License-Identifier: Apache-2.0
+    Licensed to the Ed-Fi Alliance under one or more agreements.
+    The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+    See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets.ClaimSetDetailsModel
+
+@{
+    ViewBag.Title = "Global";
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+
+@{ await Html.RenderPartialAsync("_SettingsGlobalHeader", Model.GlobalSettingsTabEnumerations); }
+
+
+<div class="row">
+    <div class="col-xs-12">
+        <div class="tab-content">
+            <div class="tab-pane active" id="global-tab">
+                <div class="tab-content margin-top-10" id="claims-list">
+                    <div id="claim-set-tab" class="tab-pane active navigational-index col-lg-8">
+                        @RenderBody()
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+


### PR DESCRIPTION
**What was happening?**
When we tried opening claim set details in new browser tab we got the partial view loaded but without background styles.

**What was the solution?**
Include new layout partial view related to Claim set details only to be loaded only when we are trying to access from another browser tab. If we are loading the partial view in the same view(tab) the new layout partial view wont be loaded.