### PR TITLE
[AA-879] - When opening in a new tab, page loads without styles fix

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ClaimSetsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ClaimSetsController.cs
@@ -13,6 +13,7 @@ using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
 using EdFi.Ods.AdminApp.Management.Database.Models;
 using EdFi.Ods.AdminApp.Management.Database.Queries;
 using EdFi.Ods.AdminApp.Web.ActionFilters;
+using EdFi.Ods.AdminApp.Web.Display.TabEnumeration;
 using EdFi.Ods.AdminApp.Web.Helpers;
 using EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets;
 using Newtonsoft.Json;
@@ -30,6 +31,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         private readonly IGetResourcesByClaimSetIdQuery _getResourcesByClaimSetIdQuery;
         private readonly IGetClaimSetsByApplicationNameQuery _getClaimSetsByApplicationNameQuery;
         private readonly IGetAuthStrategiesByApplicationNameQuery _getAuthStrategiesByApplicationNameQuery;
+        private readonly ITabDisplayService _tabDisplayService;
         private readonly CopyClaimSetCommand _copyClaimSetCommand;
         private readonly AddClaimSetCommand _addClaimSetCommand;
         private readonly EditClaimSetCommand _editClaimSetCommand;
@@ -48,6 +50,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
             , IGetResourcesByClaimSetIdQuery getResourcesByClaimSetIdQuery
             , IGetClaimSetsByApplicationNameQuery getClaimSetsByApplicationNameQuery
             , IGetAuthStrategiesByApplicationNameQuery getAuthStrategiesByApplicationNameQuery
+            , ITabDisplayService tabDisplayService
             , CopyClaimSetCommand copyClaimSetCommand
             , AddClaimSetCommand addClaimSetCommand
             , EditClaimSetCommand editClaimSetCommand
@@ -66,6 +69,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
             _getResourcesByClaimSetIdQuery = getResourcesByClaimSetIdQuery;
             _getClaimSetsByApplicationNameQuery = getClaimSetsByApplicationNameQuery;
             _getAuthStrategiesByApplicationNameQuery = getAuthStrategiesByApplicationNameQuery;
+            _tabDisplayService = tabDisplayService;
             _copyClaimSetCommand = copyClaimSetCommand;
             _addClaimSetCommand = addClaimSetCommand;
             _editClaimSetCommand = editClaimSetCommand;
@@ -83,14 +87,19 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
 
         public ActionResult ClaimSetDetails(int claimSetId)
         {
-            var model = new ClaimSetDetailsModel
+            var model = new ClaimSetModel
             {
-                ClaimSet = _getClaimSetByIdQuery.Execute(claimSetId),
-                Applications = _getApplicationsByClaimSetIdQuery.Execute(claimSetId),
-                ResourceClaims = _getResourcesByClaimSetIdQuery.AllResources(claimSetId)
+                ClaimSetDetailsModel = new ClaimSetDetailsModel
+                {
+                    ClaimSet = _getClaimSetByIdQuery.Execute(claimSetId),
+                    Applications = _getApplicationsByClaimSetIdQuery.Execute(claimSetId),
+                    ResourceClaims = _getResourcesByClaimSetIdQuery.AllResources(claimSetId)
+                },
+                GlobalSettingsTabEnumerations = _tabDisplayService.GetGlobalSettingsTabDisplay(
+                    GlobalSettingsTabEnumeration.ClaimSets)
             };
 
-           return PartialView("_ClaimSetDetails", model);
+           return View(model);
         }
 
         public ActionResult AuthStrategyModal(int claimSetId, int resourceClaimId)
@@ -163,16 +172,20 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         {
             var existingClaimSet = _getClaimSetByIdQuery.Execute(claimSetId);
             var allResourceClaims = _getResourceClaimsQuery.Execute().ToList();
-            var model = new EditClaimSetModel
+            var model = new ClaimSetModel
             {
-                ClaimSetName = existingClaimSet.Name,
-                ClaimSetId = claimSetId,
-                Applications = _getApplicationsByClaimSetIdQuery.Execute(claimSetId),
-                ResourceClaims = _getResourcesByClaimSetIdQuery.AllResources(claimSetId),
-                AllResourceClaims = GetSelectListForResourceClaims(allResourceClaims)
+                EditClaimSetModel = new EditClaimSetModel
+                {
+                    ClaimSetName = existingClaimSet.Name,
+                    ClaimSetId = claimSetId,
+                    Applications = _getApplicationsByClaimSetIdQuery.Execute(claimSetId),
+                    ResourceClaims = _getResourcesByClaimSetIdQuery.AllResources(claimSetId),
+                    AllResourceClaims = GetSelectListForResourceClaims(allResourceClaims)
+                },
+                GlobalSettingsTabEnumerations = _tabDisplayService.GetGlobalSettingsTabDisplay(GlobalSettingsTabEnumeration.ClaimSets)
             };
   
-            return PartialView("_EditClaimSet", model);
+            return View(model);
         }
 
         [HttpGet]

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/ClaimSetModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/ClaimSetModel.cs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Ods.AdminApp.Web.Models.ViewModels.Global;
+
+namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
+{
+    public class ClaimSetModel: BaseGlobalSettingsModel
+    {
+        public EditClaimSetModel EditClaimSetModel { get; set; }
+        public ClaimSetDetailsModel ClaimSetDetailsModel { get; set; }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Global/BaseGlobalSettingsModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Global/BaseGlobalSettingsModel.cs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Generic;
+using EdFi.Ods.AdminApp.Web.Display.TabEnumeration;
+
+namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.Global
+{
+    public abstract class BaseGlobalSettingsModel
+    {
+        public List<TabDisplay<GlobalSettingsTabEnumeration>> GlobalSettingsTabEnumerations{ get; set; }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Global/GlobalSettingsModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Global/GlobalSettingsModel.cs
@@ -3,16 +3,12 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-using System.Collections.Generic;
-using EdFi.Ods.AdminApp.Web.Display.TabEnumeration;
-
 namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.Global
 {
-    public class GlobalSettingsModel
+    public class GlobalSettingsModel: BaseGlobalSettingsModel
     {
         public VendorsListModel VendorListModel { get; set; }
         public AdvancedSettingsModel AdvancedSettingsModel { get; set; }
-        public List<TabDisplay<GlobalSettingsTabEnumeration>> GlobalSettingsTabEnumerations{ get; set; }
         public ClaimSetEditorModel ClaimSetEditorModel { get; set; }
         public UserIndexModel UserIndexModel { get; set; }
     }

--- a/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/ClaimSetDetails.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/ClaimSetDetails.cshtml
@@ -15,9 +15,9 @@
 @{ await Html.RenderPartialAsync("_SettingsGlobalHeader", Model.GlobalSettingsTabEnumerations); }
 
 <div class="row">
-    <div class="col-xs-10">
+    <div class="col-lg-10">
         <div class="tab-content">
-            <div class="tab-pane active" id="global-tab">
+            <div class="tab-pane active col-lg-10" id="claim-set-tab">
                 @{ await Html.RenderPartialAsync("_ClaimSetDetails", Model.ClaimSetDetailsModel); }
             </div>
         </div>

--- a/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/ClaimSetDetails.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/ClaimSetDetails.cshtml
@@ -1,0 +1,25 @@
+@*
+    SPDX-License-Identifier: Apache-2.0
+    Licensed to the Ed-Fi Alliance under one or more agreements.
+    The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+    See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets.ClaimSetModel
+
+@{
+    ViewBag.Title = "Claim Set Details";
+}
+
+@{ await Html.RenderPartialAsync("_SettingsGlobalHeader", Model.GlobalSettingsTabEnumerations); }
+
+<div class="row">
+    <div class="col-xs-10">
+        <div class="tab-content">
+            <div class="tab-pane active" id="global-tab">
+                @{ await Html.RenderPartialAsync("_ClaimSetDetails", Model.ClaimSetDetailsModel); }
+            </div>
+        </div>
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/EditClaimSet.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/EditClaimSet.cshtml
@@ -13,9 +13,9 @@
 @{ await Html.RenderPartialAsync("_SettingsGlobalHeader", Model.GlobalSettingsTabEnumerations); }
 
 <div class="row">
-    <div class="col-xs-10">
+    <div class="col-lg-10">
         <div class="tab-content">
-            <div class="tab-pane active" id="global-tab">
+            <div class="tab-pane active col-lg-10" id="claim-set-tab">
                 @{ await Html.RenderPartialAsync("_EditClaimSet", Model.EditClaimSetModel); }
             </div>
         </div>

--- a/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/EditClaimSet.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/EditClaimSet.cshtml
@@ -1,0 +1,23 @@
+@*
+    SPDX-License-Identifier: Apache-2.0
+    Licensed to the Ed-Fi Alliance under one or more agreements.
+    The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+    See the LICENSE and NOTICES files in the project root for more information.
+*@
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets.ClaimSetModel
+
+@{
+    ViewBag.Title = "Edit Claim Set";
+}
+
+@{ await Html.RenderPartialAsync("_SettingsGlobalHeader", Model.GlobalSettingsTabEnumerations); }
+
+<div class="row">
+    <div class="col-xs-10">
+        <div class="tab-content">
+            <div class="tab-pane active" id="global-tab">
+                @{ await Html.RenderPartialAsync("_EditClaimSet", Model.EditClaimSetModel); }
+            </div>
+        </div>
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_ClaimSetDetails.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_ClaimSetDetails.cshtml
@@ -110,10 +110,10 @@ else
     <div> No resource claims found.</div>
 }
     <div>
-        @Html.Button("Back").AddClass("back-btn back-ajax claimset-back-btn").Data("back-url", Url.Action("ClaimSets", "GlobalSettings"))
+        @Html.ActionLink("Back", "ClaimSets", "GlobalSettings", null, new { @class = "btn btn-primary cta" })
         @if (Model.ClaimSet.IsEditable)
         {
-            @Html.Button("Edit Claim Set").Attr("href", Url.Action("EditClaimSet", "ClaimSets", new { claimSetId = Model.ClaimSet.Id })).AddClass("edit-claimset navigational-ajax").Data("state", "edit").Data("page-url", Url.Action("ClaimSets", "GlobalSettings")).Data("action", "editing the Claim Set")
+            @Html.ActionLink("Edit Claim Set", "EditClaimSet", "ClaimSets", new { claimSetId = Model.ClaimSet.Id }, new { @class = "btn btn-primary cta edit-claimset" })
         }
     </div>
 

--- a/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_EditClaimSet.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_EditClaimSet.cshtml
@@ -19,8 +19,8 @@ See the LICENSE and NOTICES files in the project root for more information.
             @Html.InputBlock(x => x.ClaimSetName, inputModifier: x => x.Attr("maxlength", 255))
         </div>
         <div class="col-md-4">
-            @Html.SaveButton("Update Name")
-        </div>        
+            @Html.SaveButton("Update Name").AddClass("no-ajax")
+        </div>
     </div>
 }
 <h3>Applications</h3>
@@ -60,7 +60,7 @@ else
     });}
 </div>
 <div class="padding-top-5">
-    @Html.Button("Back").AddClass("back-btn back-ajax claimset-back-btn").Data("back-url", Url.Action("ClaimSets", "GlobalSettings"))
+    @Html.ActionLink("Back", "ClaimSets", "GlobalSettings", null, new { @class = "btn btn-primary cta" })
 </div>
 <script type="text/javascript">
     $('#edit-claim-set-form').submit(function (e) {

--- a/Application/EdFi.Ods.AdminApp.Web/Views/GlobalSettings/ClaimSets.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/GlobalSettings/ClaimSets.cshtml
@@ -38,7 +38,7 @@ See the LICENSE and NOTICES files in the project root for more information.
                 {
                     <tr>
                         <th scope="row">
-                            <a class="details-link navigational-ajax" data-state="details" data-page-url="@Url.Action("ClaimSets", "GlobalSettings")" data-action="loading the Claim Set" href="@Url.Action("ClaimSetDetails", "ClaimSets", new {claimSetId = claimSet.Id})">
+                            <a class="details-link" href="@Url.Action("ClaimSetDetails", "ClaimSets", new {claimSetId = claimSet.Id})">
                                 @claimSet.Name
                             </a>
                         </th>
@@ -48,7 +48,7 @@ See the LICENSE and NOTICES files in the project root for more information.
                                 <a class="loads-ajax-modal" data-url="@Url.Action("CopyClaimSetModal","ClaimSets", new {claimSetId = claimSet.Id})"> <span class="fa fa-copy action-icons"></span></a>
                                 @if (claimSet.IsEditable)
                                 {
-                                    <a class="edit-claimset navigational-ajax" data-state="edit" data-page-url="@Url.Action("ClaimSets", "GlobalSettings")" data-action="editing the Claim Set" href="@Url.Action("EditClaimSet", "ClaimSets", new {claimSetId = claimSet.Id})">
+                                    <a class="edit-claimset" href="@Url.Action("EditClaimSet", "ClaimSets", new {claimSetId = claimSet.Id})">
                                          <span class="fa fa-pencil action-icons"></span>
                                     </a>
                                     <a class="loads-ajax-modal" data-url="@Url.Action("DeleteClaimSetModal","ClaimSets", new {claimSetId = claimSet.Id})"> <span class="fa fa-trash-o action-icons"></span></a>

--- a/Application/EdFi.Ods.AdminApp.Web/Views/Shared/_Settings_Global.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/Shared/_Settings_Global.cshtml
@@ -6,7 +6,7 @@ See the LICENSE and NOTICES files in the project root for more information.
 *@
 
 @using EdFi.Ods.AdminApp.Web.Models.ViewModels.Global
-@model GlobalSettingsModel
+@model BaseGlobalSettingsModel
 
 @{
     ViewBag.Title = "Global";


### PR DESCRIPTION
**Description**

- Added an abstract BaseGlobalSettingsModel. Refactored GlobalSettingsModel to inherit from BaseGlobalSettingsModel. Refactored _Settings_Global.cshtml to use BaseGlobalsettingsModel.
- Added ClaimSetModel to use as the base model for EditClaimSet and ClaimSetDetails views.
- Added EditClaimSet and ClaimSetDetails views to render the _EditClaimSet and _ClaimSetDetails partials. Refactored the views and links on ClaimSets view to not use ajax classes.
- Refactored ClaimSet controller actions ClaimSetDetails and EditClaimSet to use the ClaimSetModel and new views.
- Changed the col sizing on the claimset details adn edit tabs to macth the older version.