### PR TITLE
[AA-1203] - Add Claimset Loads view twice and ClaimSet Warning Message disappears

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ClaimSetsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ClaimSetsController.cs
@@ -164,28 +164,37 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         [HttpPost]
         public ActionResult AddClaimSet(AddClaimSetModel model)
         {
-            var id = _addClaimSetCommand.Execute(model);
-            return RedirectToAction("EditClaimSet", "ClaimSets", new {claimSetId = id});
+            var claimSetId = _addClaimSetCommand.Execute(model);
+
+            var editClaimSetModel = GetEditClaimSetModel(claimSetId);
+
+            return PartialView("_EditClaimSet",editClaimSetModel);
         }
 
         public ActionResult EditClaimSet(int claimSetId)
         {
-            var existingClaimSet = _getClaimSetByIdQuery.Execute(claimSetId);
-            var allResourceClaims = _getResourceClaimsQuery.Execute().ToList();
             var model = new ClaimSetModel
             {
-                EditClaimSetModel = new EditClaimSetModel
-                {
-                    ClaimSetName = existingClaimSet.Name,
-                    ClaimSetId = claimSetId,
-                    Applications = _getApplicationsByClaimSetIdQuery.Execute(claimSetId),
-                    ResourceClaims = _getResourcesByClaimSetIdQuery.AllResources(claimSetId),
-                    AllResourceClaims = GetSelectListForResourceClaims(allResourceClaims)
-                },
+                EditClaimSetModel = GetEditClaimSetModel(claimSetId),
                 GlobalSettingsTabEnumerations = _tabDisplayService.GetGlobalSettingsTabDisplay(GlobalSettingsTabEnumeration.ClaimSets)
             };
   
             return View(model);
+        }
+
+        private EditClaimSetModel GetEditClaimSetModel(int claimSetId)
+        {
+            var existingClaimSet = _getClaimSetByIdQuery.Execute(claimSetId);
+            var allResourceClaims = _getResourceClaimsQuery.Execute().ToList();
+
+            return new EditClaimSetModel
+            {
+                ClaimSetName = existingClaimSet.Name,
+                ClaimSetId = claimSetId,
+                Applications = _getApplicationsByClaimSetIdQuery.Execute(claimSetId),
+                ResourceClaims = _getResourcesByClaimSetIdQuery.AllResources(claimSetId),
+                AllResourceClaims = GetSelectListForResourceClaims(allResourceClaims)
+            };
         }
 
         [HttpGet]

--- a/Application/EdFi.Ods.AdminApp.Web/Views/GlobalSettings/ClaimSets.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/GlobalSettings/ClaimSets.cshtml
@@ -63,7 +63,6 @@ See the LICENSE and NOTICES files in the project root for more information.
 </div>
 
 <script type="text/javascript">
-    var cacheTimeout = '@CloudOdsAdminAppSettings.Instance.SecurityMetadataCacheTimeoutMinutes';
     $(function () {
         InitializeModalLoaders();
         InitializeNavigationalAjaxButtons();

--- a/Application/EdFi.Ods.AdminApp.Web/Views/GlobalSettings/ClaimSets.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/GlobalSettings/ClaimSets.cshtml
@@ -14,13 +14,13 @@ See the LICENSE and NOTICES files in the project root for more information.
     Layout = "~/Views/Shared/_Settings_Global.cshtml";
     ViewBag.Title = "Global | Claim Sets";
 }
-<div id="claim-set-warning-message" class="alert alert-danger margin-top-10" role="alert" hidden>
-    <p>
-        <strong>Please reset IIS or wait <span id="claim-set-warning-time"></span> for the latest claimset changes to take effect.</strong>
-    </p>
-</div>
 <div class="tab-content margin-top-10" id="claims-list">
     <div id="claim-set-tab" class="tab-pane active navigational-index col-lg-8">
+        <div id="claim-set-warning-message" class="alert alert-danger margin-top-10" role="alert" hidden>
+            <p>
+                <strong>Please reset IIS or wait <span id="claim-set-warning-time"></span> for the latest claimset changes to take effect.</strong>
+            </p>
+        </div>
         <div align="right">
             @Html.Button("Add Claim Set").Attr("href", Url.Action("AddClaimSet", "ClaimSets")).AddClass("add-claimset navigational-ajax").Data("state", "add").Data("page-url", Url.Action("ClaimSets", "GlobalSettings")).Data("action", "opening Add Claim Set")
             @Html.Button("Import/Export Claim Set").Attr("href", Url.Action("ImportExportClaimSet", "ClaimSets")).AddClass("import-export-claimset navigational-ajax").Data("state", "import").Data("page-url", Url.Action("ClaimSets", "GlobalSettings")).Data("action", "opening Import/Export Claim Set")

--- a/Application/EdFi.Ods.AdminApp.Web/Views/Shared/_Layout.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/Shared/_Layout.cshtml
@@ -6,7 +6,7 @@ See the LICENSE and NOTICES files in the project root for more information.
 *@
 
 @using EdFi.Ods.AdminApp.Web.Helpers
-@using Microsoft.AspNetCore.Http
+@using EdFi.Ods.AdminApp.Web.Infrastructure
 
 <!DOCTYPE html>
 <html lang="en">
@@ -91,6 +91,7 @@ See the LICENSE and NOTICES files in the project root for more information.
     </footer>
     @RenderSection("Scripts", required: false)
     <script type="text/javascript">
+        var cacheTimeout = '@CloudOdsAdminAppSettings.Instance.SecurityMetadataCacheTimeoutMinutes';
         GlobalInitialize();
     </script>
 </body>


### PR DESCRIPTION
**Description**
**View Loads Twice issue fix**
- Refactored the EditClaimSet and AddClaimSet actions in the claimet controller to use the new method to get the EditClaimSetmodel from the claimset id. Refactored the AddClaimSet action to return the PartialView for EditClaimSet in order to avoid duplicate views.

**ClaimSet Warning Message disappears fix**
- Moved setting the cacheTimeout variable to the Layout view to avoid removing it on navigating away from the claimsets tab and coming back.
- Moved the claim-set-warning-message div within the claimset listing div to only this div on the claimsets listing view.