### PR TITLE
[AA-1206] Apply the ReSharper "Remove Unused Field" refactoring to address compiler warnings

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/OdsInstances/BulkRegisterOdsInstancesModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/OdsInstances/BulkRegisterOdsInstancesModel.cs
@@ -56,9 +56,6 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstances
     public class BulkRegisterOdsInstancesModelValidator : AbstractValidator<BulkRegisterOdsInstancesModel>
     {
         private readonly ILog _logger = LogManager.GetLogger("BulkRegisterOdsInstancesLog");
-        private static AdminAppDbContext _database;
-        private static IDatabaseConnectionProvider _databaseConnectionProvider;
-        private static ApiMode _mode;        
 
         private bool UniquenessRuleFailed { get; set; }
 


### PR DESCRIPTION
A few fields became no longer used in recent updates to the BulkRegisterOdsInstancesModelValidator. This simply resolves the warnings by applying the ReSharper "Remove Unused Field" refactoring for each offender.

AA-1206 is focused on these simple warnings. The last remaining warning as of this commit will be covered by a separate ticket, AA-1215.