### PR TITLE
[AA-1215] await asynchronous job status updates

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/Jobs/BulkUploadJob.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/Jobs/BulkUploadJob.cs
@@ -22,8 +22,8 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure.Jobs
         private const string WorkflowJobName = "Bulk Upload";
         private readonly BulkImportService _bulkImportService;
 
-        public BulkUploadJob(BulkImportService bulkImportService, IBackgroundJobClient backgroundJobClient, BulkUploadHub bulkUploadHub, IHubContext<BulkUploadHub> bulkUploadHubContext)
-            : base(backgroundJobClient, bulkUploadHub, WorkflowJobName, bulkUploadHubContext)
+        public BulkUploadJob(BulkImportService bulkImportService, IBackgroundJobClient backgroundJobClient, IHubContext<BulkUploadHub> bulkUploadHubContext)
+            : base(backgroundJobClient, WorkflowJobName, bulkUploadHubContext)
         {
             _bulkImportService = bulkImportService;
 

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/Jobs/LearningStandardsJob.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/Jobs/LearningStandardsJob.cs
@@ -36,12 +36,11 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure.Jobs
     {
         public ProductionLearningStandardsJob(
             IBackgroundJobClient backgroundJobClient,
-            ProductionLearningStandardsHub hub,
             ILearningStandardsCorePluginConnector learningStandardsPlugin,
             IOdsSecretConfigurationProvider odsSecretConfigurationProvider,
             IHubContext<ProductionLearningStandardsHub> productionLearningStandardsHubContext
             )
-            : base(backgroundJobClient, hub, learningStandardsPlugin, odsSecretConfigurationProvider, productionLearningStandardsHubContext) { }
+            : base(backgroundJobClient, learningStandardsPlugin, odsSecretConfigurationProvider, productionLearningStandardsHubContext) { }
     }
 
     public abstract class LearningStandardsJob<THub> : WorkflowJob<LearningStandardsJobContext, THub>
@@ -54,11 +53,10 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure.Jobs
 
         protected LearningStandardsJob(
             IBackgroundJobClient backgroundJobClient,
-            THub hub,
             ILearningStandardsCorePluginConnector learningStandardsPlugin,
             IOdsSecretConfigurationProvider odsSecretConfigurationProvider
             , IHubContext<THub> hubContext)
-            : base(backgroundJobClient, hub, LearningStandardsJobName, hubContext)
+            : base(backgroundJobClient, LearningStandardsJobName, hubContext)
         {
             _learningStandardsPlugin = learningStandardsPlugin;
             _odsSecretConfigurationProvider = odsSecretConfigurationProvider;

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/Jobs/ProductionSetupJob.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/Jobs/ProductionSetupJob.cs
@@ -28,10 +28,8 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure.Jobs
 
         public ProductionSetupJob(
             ICloudOdsProductionLifecycleManagementService productionDatabaseLifecycleManagementService,
-            IGetOdsSqlConfigurationQuery getOdsSqlConfigurationQuery, IBackgroundJobClient backgroundJobClient,
-            ProductionSetupHub productionSetupHub
-            , IHubContext<ProductionSetupHub> productionSetupHubContext)
-            : base(backgroundJobClient, productionSetupHub, WorkflowJobName, productionSetupHubContext)
+            IGetOdsSqlConfigurationQuery getOdsSqlConfigurationQuery, IBackgroundJobClient backgroundJobClient, IHubContext<ProductionSetupHub> productionSetupHubContext)
+            : base(backgroundJobClient, WorkflowJobName, productionSetupHubContext)
         {
             _productionDatabaseLifecycleManagementService = productionDatabaseLifecycleManagementService;
             _getOdsSqlConfigurationQuery = getOdsSqlConfigurationQuery;

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/Jobs/WorkflowJob.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/Jobs/WorkflowJob.cs
@@ -17,17 +17,15 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure.Jobs
         where THub: Hubs.EdfiOdsHub<THub>
     {
         private readonly ILog _logger = LogManager.GetLogger(typeof(WorkflowJob<,>));
-        private readonly THub _hub;
         private readonly IHubContext<THub> _hubContext;
         private readonly IBackgroundJobClient _backgroundJobClient;
         private static int _runningJobCount = 0;
         private static long _runningJobId = 0;
         public string JobName { get; }
 
-        protected WorkflowJob(IBackgroundJobClient backgroundJobClient, THub hub, string jobName, IHubContext<THub> hubContext)
+        protected WorkflowJob(IBackgroundJobClient backgroundJobClient, string jobName, IHubContext<THub> hubContext)
         {
             _backgroundJobClient = backgroundJobClient;
-            _hub = hub;
             _hubContext = hubContext;
             JobName = jobName;
         }

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/Jobs/WorkflowJob.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/Jobs/WorkflowJob.cs
@@ -10,6 +10,7 @@ using EdFi.Ods.AdminApp.Management.Workflow;
 using Hangfire;
 using log4net;
 using Microsoft.AspNetCore.SignalR;
+using Newtonsoft.Json;
 
 namespace EdFi.Ods.AdminApp.Web.Infrastructure.Jobs
 {
@@ -142,7 +143,11 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure.Jobs
 
         private async Task SendStatusUpdate(WorkflowStatus operationStatus)
         {
+            _logger.Debug("Broadcasting: " + JsonConvert.SerializeObject(operationStatus));
+
             await _hubContext.Clients.Group(typeof(THub).ToString()).SendAsync("UpdateStatus", operationStatus);
+
+            _logger.Debug("Broadcasting Completed: " + JsonConvert.SerializeObject(operationStatus));
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/Jobs/WorkflowJob.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/Jobs/WorkflowJob.cs
@@ -138,10 +138,10 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure.Jobs
 
         protected void OperationStatusUpdated(WorkflowStatus operationStatus)
         {
-            SendStatusUpdate(operationStatus);
+            _backgroundJobClient.Enqueue<WorkflowJob<TContext, THub>>(x => x.SendStatusUpdate(operationStatus));
         }
 
-        private async Task SendStatusUpdate(WorkflowStatus operationStatus)
+        public async Task SendStatusUpdate(WorkflowStatus operationStatus)
         {
             _logger.Debug("Broadcasting: " + JsonConvert.SerializeObject(operationStatus));
 

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/Jobs/WorkflowJob.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/Jobs/WorkflowJob.cs
@@ -143,11 +143,7 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure.Jobs
 
         public async Task SendStatusUpdate(WorkflowStatus operationStatus)
         {
-            _logger.Debug("Broadcasting: " + JsonConvert.SerializeObject(operationStatus));
-
             await _hubContext.Clients.Group(typeof(THub).ToString()).SendAsync("UpdateStatus", operationStatus);
-
-            _logger.Debug("Broadcasting Completed: " + JsonConvert.SerializeObject(operationStatus));
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/Jobs/WorkflowJob.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/Jobs/WorkflowJob.cs
@@ -10,7 +10,6 @@ using EdFi.Ods.AdminApp.Management.Workflow;
 using Hangfire;
 using log4net;
 using Microsoft.AspNetCore.SignalR;
-using Newtonsoft.Json;
 
 namespace EdFi.Ods.AdminApp.Web.Infrastructure.Jobs
 {
@@ -138,10 +137,10 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure.Jobs
 
         protected void OperationStatusUpdated(WorkflowStatus operationStatus)
         {
-            _backgroundJobClient.Enqueue<WorkflowJob<TContext, THub>>(x => x.SendStatusUpdate(operationStatus));
+            SendStatusUpdate(operationStatus).GetAwaiter().GetResult();
         }
 
-        public async Task SendStatusUpdate(WorkflowStatus operationStatus)
+        private async Task SendStatusUpdate(WorkflowStatus operationStatus)
         {
             await _hubContext.Clients.Group(typeof(THub).ToString()).SendAsync("UpdateStatus", operationStatus);
         }

--- a/Application/EdFi.Ods.AdminApp.Web/wwwroot/Scripts/signalr-progress.js
+++ b/Application/EdFi.Ods.AdminApp.Web/wwwroot/Scripts/signalr-progress.js
@@ -74,6 +74,8 @@ $.extend(true, edfiODS, {
             $("#signalr-done-button").parents(".modal").on("hidden.bs.modal", function() {
                 location.reload();
             });
+
+            $("#signalr-progress").data("statusIsFinal", true);
         },
 
         showError: function(errorMessage) {
@@ -109,9 +111,11 @@ $.extend(true, edfiODS, {
                         edfiODS.signalR.showFinalStatus(finalRedirectUrl);
                     }
                 } else {
-                    var percentComplete = status.totalSteps ? Math.max(Math.round((status.currentStep / status.totalSteps) * 100), 1) : 1;
-                    edfiODS.signalR.setProgress(percentComplete, status.error, false);
-                    edfiODS.signalR.setStatusText(status.statusMessage, status.error);
+                    if ($("#signalr-progress").data("statusIsFinal") !== true) {
+                        var percentComplete = status.totalSteps ? Math.max(Math.round((status.currentStep / status.totalSteps) * 100), 1) : 1;
+                        edfiODS.signalR.setProgress(percentComplete, status.error, false);
+                        edfiODS.signalR.setStatusText(status.statusMessage, status.error);
+                    }
                 }
             });
 


### PR DESCRIPTION
Background: Background jobs like those for Bulk Load and Learning Standards use Hangfire for background job processing, and while jobs make progress they use SignalR to broadcast those progress updates to client browsers. Those SignalR messages amount to progress bar percentage values increasing over time as well as some related state and user-facing label text updates. Prior to Admin App's migration to .NET Core, we naturally used the pre-.NET-Core version of SignalR, and the migration included porting to the modern .NET Core compatible version of SignalR. In that upgrade, SignalR changed its primary mechanism of sending a message to clients: what had been a synchronous call before is now an async call with no synchronous overload. Additionally, our background jobs have historically initiated these progress messages through synchronous means such as via C# events (built on synchronous `void` delegates) and for Learning Standards via synchronous `System.Progress<T>`. Before this PR, then, the call to SignalR's `SendAsync` method was suspect, as we were calling it synchronously with no use of `async`/`await`. The asynchronous aspect appeared to work in practice despite the missing `await`, but this is highly suspect and quite likely would behave inconsistently in the field.

It was tempting at first, to simply apply `async`/`await` to the immediate compiler warning and then trace that to the caller, and again to the caller of that, on back along the call chain as necessary in order to be "async all the way down". Doing so would have required a challenging replacement to the existing `event` keyword, but would be doable as a more manually-handled `List<Func<Task>>` or similar. However, that would have been a wasted effort as the remaining sync-over-async usage would still be entirely out of our control: the Learning Standards library, whose implementation is not part of Admin App itself, reports progress back to us via `System.Progress<T>`, which is synchronous. Any attempt to make that *seem* to work would require risky "sync over async" patterns which are not reliable in practice as they can create deadlocks.

So, we needed a way to allow the *initation* of these SignalR messages to be *noted* synchronously, but *actually sent* in an async context. Thankfully Hangfire allows for exactly that. We synchronously enqueue a trivial job, where the job is to finally use SignalR to send the message to client browsers. Since Hangfire allows the jobs themselves to be async, and ensures that they are awaited on the job execution thread, we keep the primary thread moving without deadlock risk and allow all `Task`s to be awaited.

Additionally, we needed to take care with the JavaScript that handles the incoming SignalR messages. It was likely always the case that we could, technically and rarely, receive messages out of order on the client side. The worst case symptom there would be to receive the intended-final 100% message, display it, and then receive the 99% message a brief moment later, which could result in a confusing UI presentation. The use of hangfire for the actual sending increases the chance of that edge case, though it would really need to be handled anyway. The JavaScript change here, then, takes extra care to ensure that once we present the intended-final state to the user, we can safely ignore any subsequent "stale" messages that would only serve to confuse the user. (Note that we already *attempted* such by unsubscribing from messages during final-message handling, but there was still technically a time "window of opportunity" for poor message handling). Since JavaScript runs single-threaded and since we now use an unambiguous bool to protect us, there should no longer be such a window.

Developer testing: Ran Bulk Load to completion for Assessment Metadata, using the AssessmentMetadata-ACT.xml sample from the Ed-Fi-Standard repo. Ran Learning Standards to completion.