### PR TITLE
[AA-1063] Add LICENSE, NOTICES, and license metadata to all packages in made by the AdminApp repo

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Database.nuspec
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Database.nuspec
@@ -10,7 +10,6 @@
     <summary>Ed-Fi AdminApp specific Database scripts</summary>
     <description>Ed-Fi AdminApp specific Database scripts</description>
     <license type="expression">Apache-2.0</license>
-    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
   </metadata>
   <files>
        <file src=".\Artifacts\MsSql\Structure\Admin\**" target="MsSql" />

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Database.nuspec
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Database.nuspec
@@ -9,6 +9,8 @@
     <copyright>Copyright © 2021, Ed-Fi Alliance, LLC.</copyright>
     <summary>Ed-Fi AdminApp specific Database scripts</summary>
     <description>Ed-Fi AdminApp specific Database scripts</description>
+    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
   </metadata>
   <files>
        <file src=".\Artifacts\MsSql\Structure\Admin\**" target="MsSql" />

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Database.nuspec
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Database.nuspec
@@ -13,5 +13,7 @@
   <files>
        <file src=".\Artifacts\MsSql\Structure\Admin\**" target="MsSql" />
        <file src=".\Artifacts\PgSql\Structure\Admin\**" target="PgSql" />
+       <file src=".\LICENSE" />
+       <file src=".\NOTICES.md" />
   </files>
 </package>

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -7,6 +7,8 @@
   <ItemGroup>
     <Content Include="EdFi.Ods.AdminApp.Web.nuspec" CopyToPublishDirectory="Always" CopyToOutputDirectory="Never" />
     <Content Include="EdFi.Ods.AdminApp.Database.nuspec" CopyToPublishDirectory="Always" CopyToOutputDirectory="Never" />
+    <Content Include="../../LICENSE" CopyToPublishDirectory="Always" CopyToOutputDirectory="Never" />
+    <Content Include="../../NOTICES.md" CopyToPublishDirectory="Always" CopyToOutputDirectory="Never" />
 
     <Content Include="Artifacts\**" CopyToPublishDirectory="Always" CopyToOutputDirectory="Never" />
     <Content Include="Schema/**/*.*" CopyToPublishDirectory="Always" />

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.nuspec
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.nuspec
@@ -9,6 +9,8 @@
     <copyright>Copyright © 2021, Ed-Fi Alliance, LLC.</copyright>
     <summary>Ed-Fi AdminApp for the ODS</summary>
     <description>Ed-Fi AdminApp for the ODS</description>
+    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
   </metadata>
   <files>
        <file src="**" />

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.nuspec
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.nuspec
@@ -10,7 +10,6 @@
     <summary>Ed-Fi AdminApp for the ODS</summary>
     <description>Ed-Fi AdminApp for the ODS</description>
     <license type="expression">Apache-2.0</license>
-    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
   </metadata>
   <files>
        <file src="**" />

--- a/EdFi.Suite3.Installer.AdminApp/EdFi.Suite3.Installer.AdminApp.nuspec
+++ b/EdFi.Suite3.Installer.AdminApp/EdFi.Suite3.Installer.AdminApp.nuspec
@@ -10,7 +10,6 @@
     <summary>Application installer modules for the Ed-Fi Admin App application</summary>
     <description>Application installer modules for the Ed-Fi Admin App application</description>
     <license type="expression">Apache-2.0</license>
-    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
   </metadata>
   <files>
     <file src="install.ps1" />

--- a/EdFi.Suite3.Installer.AdminApp/EdFi.Suite3.Installer.AdminApp.nuspec
+++ b/EdFi.Suite3.Installer.AdminApp/EdFi.Suite3.Installer.AdminApp.nuspec
@@ -9,6 +9,8 @@
     <copyright>Copyright © 2020, Ed-Fi Alliance, LLC and contributors.</copyright>
     <summary>Application installer modules for the Ed-Fi Admin App application</summary>
     <description>Application installer modules for the Ed-Fi Admin App application</description>
+    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
   </metadata>
   <files>
     <file src="install.ps1" />
@@ -16,5 +18,7 @@
     <file src="Install-EdFiOdsAdminApp.psm1" />
     <file src="Ed-Fi-ODS/**" />
     <file src="Ed-Fi-ODS-Implementation/**" />
+    <file src="../LICENSE" />
+    <file src="../NOTICES.md" />
   </files>
 </package>


### PR DESCRIPTION
This repo produces NuGet packages from 3 nuspec files:

* Application\EdFi.Ods.AdminApp.Web\EdFi.Ods.AdminApp.Web.nuspec
* Application\EdFi.Ods.AdminApp.Web\EdFi.Ods.AdminApp.Database.nuspec
* EdFi.Suite3.Installer.AdminApp/EdFi.Suite3.Installer.AdminApp.nuspec

For all three, we ensure that the root folder's authoritative LICENSE and NOTICES.md files get copied into the package, and that license metadata tags are included in the nuspec. The metadata tags allow for package feed tools to display the fact that these packages are released under Apache 2.0.  As an example of how to properly specify that metadata, we imitated the nuspec syntax found in the HtmlTags third party library, which also releases under Apache 2.0 and which displays that correctly at https://www.nuget.org/packages/HtmlTags

I built the affected packages locally and inspected the resulting package files by renaming to *.zip, unzipping, and inspecting for the presence of the 2 files in the root of the package as well as inspecting the contained nuspec for the new xml tags.