### PR TITLE
[AA-1225] - Investigate use of "authentication_required" and handle errors related to it

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Controllers/BulkUploadController/WhenRunningBulkUpload.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Controllers/BulkUploadController/WhenRunningBulkUpload.cs
@@ -106,7 +106,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers.BulkUploadController
         }
 
         [Test]
-        public async Task When_Perform_Post_Request_To_BulkFileUpload_With_No_File_Returns_NoContent()
+        public void When_Perform_Post_Request_To_BulkFileUpload_With_No_File_ThrowsException()
         {
             // Arrange
             var model = new BulkFileUploadModel
@@ -114,12 +114,9 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers.BulkUploadController
                     BulkFiles = new List<IFormFile>()
             };
 
-            // Act
-            var result = (NoContentResult)await SystemUnderTest.BulkFileUpload(model);
-
             // Assert
-            result.ShouldNotBeNull();
-            result.StatusCode.ShouldBe((int) HttpStatusCode.NoContent);
+            Assert.ThrowsAsync<Exception>(() => SystemUnderTest.BulkFileUpload(model)).Message
+                .Contains("The given file is empty. Please upload a file compatible with the Ed-Fi Data Standard.").ShouldBeTrue();
         }
 
         [Test]

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/BulkUploadController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/BulkUploadController.cs
@@ -96,7 +96,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
 
             if (!bulkFiles.Any())
             {
-                return NoContent();
+                throw new Exception("The given file is empty. Please upload a file compatible with the Ed-Fi Data Standard.");
             }
 
             if (bulkFiles.Sum(f => f.Length) > BulkFileUploadModel.MaxFileSize)


### PR DESCRIPTION
**Description**
- Refactored the BulkFileUpload action in BulkUploadController to throw an exception instead of NoContent for an empty file. This was done to avoid the ajax request success data for this call to be undefined and result in an "Cannot read property 'authentication_required' of undefined" console error as a result of a call to redirectIfAuthenticationRequired  in site.js
- Refactored the empty file BulkUpload unit test to reflect the changes in the BulkFileUpload action.