### PR TITLE
[AA-1228] Improve user experience when ODS version lookup throws exceptions

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web/Helpers/HtmlHelperExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Helpers/HtmlHelperExtensions.cs
@@ -24,11 +24,14 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 using Property = EdFi.Ods.AdminApp.Web.Infrastructure.Property;
 using Preconditions = EdFi.Common.Preconditions;
 using EdFi.Ods.AdminApp.Management.Api;
+using log4net;
 
 namespace EdFi.Ods.AdminApp.Web.Helpers
 {
     public static class HtmlHelperExtensions
     {
+        private static readonly ILog _logger = LogManager.GetLogger(typeof(HtmlHelperExtensions));
+
         private static readonly HtmlConventionLibrary HtmlConventionLibrary = OdsAdminHtmlConventionLibrary.CreateHtmlConventionLibrary();
 
         private static IElementGenerator<T> GetGenerator<T>(T model) where T : class
@@ -526,10 +529,19 @@ namespace EdFi.Ods.AdminApp.Web.Helpers
 
         public static HtmlString OdsApiVersion(this IHtmlHelper helper)
         {
-            var odsApiVersion = InMemoryCache.Instance
-                .GetOrSet("OdsApiVersion", () => new InferOdsApiVersion().Version(CloudOdsAdminAppSettings.Instance.ProductionApiUrl));
+            try
+            {
+                var odsApiVersion = InMemoryCache.Instance
+                    .GetOrSet("OdsApiVersion", () => new InferOdsApiVersion().Version(CloudOdsAdminAppSettings.Instance.ProductionApiUrl));
 
-            return !string.IsNullOrEmpty(odsApiVersion.ToString()) ? new HtmlString($"<span>ODS/API Version: {odsApiVersion}</span>") : new HtmlString("");
+                return !string.IsNullOrEmpty(odsApiVersion.ToString()) ? new HtmlString($"<span>ODS/API Version: {odsApiVersion}</span>") : new HtmlString("");
+            }
+            catch (Exception exception)
+            {
+                _logger.Error("Failed to infer ODS / API version. This can happen when the ODS / API is unreachable.", exception);
+
+                return new HtmlString("");
+            }
         }
     }
 }


### PR DESCRIPTION
This prevents ODS version lookup failures from breaking the surrounding page: the version is shown when available, and exceptions are logged, but the page is given the opportunity to otherwise load.