### PR TITLE
[AA-1239] - Display external API URLs under Docker

### DIFF
--- a/.teamcity/_Self/Project.kt
+++ b/.teamcity/_Self/Project.kt
@@ -18,7 +18,7 @@ object AdminAppProject : Project({
             +:refs/(pull/*)/merge
         """.trimIndent())
         param("teamcity.ui.settings.readOnly","true")
-        param("adminApp.version", "2.1.0")
+        param("adminApp.version", "2.1.1")
     }
 
     template(_self.templates.BuildAndTestTemplate)

--- a/Application/EdFi.Ods.AdminApp.Management/Helpers/AppSettings.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Helpers/AppSettings.cs
@@ -13,6 +13,7 @@ namespace EdFi.Ods.AdminApp.Management.Helpers
         public string XsdFolder { get; set; }
         public string DefaultOdsInstance { get; set; }
         public string ProductionApiUrl { get; set; }
+        public string ApiExternalUrl { get; set; }
         public string SystemManagedSqlServer { get; set; }
         public string DbSetupEnabled { get; set; }
         public string SecurityMetadataCacheTimeoutMinutes { get; set; }

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ApplicationController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ApplicationController.cs
@@ -74,14 +74,12 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
             var apiUrl = (await _apiConnectionInformationProvider.GetConnectionInformationForEnvironment())
                 .ApiServerUrl;
 
-            apiUrl = GetApiUrlForDisplay(apiUrl);
-
             var model = new ApplicationsIndexModel
             {
                 OdsInstanceSettingsTabEnumerations =
                     _tabDisplayService.GetOdsInstanceSettingsTabDisplay(OdsInstanceSettingsTabEnumeration.Applications),
                 OdsInstance = _instanceContext,
-                ProductionApiUrl = apiUrl
+                DisplayApiUrl = GetApiUrlForDisplay(apiUrl)
             };
 
             return View("Index", model);
@@ -145,15 +143,13 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
                 new OdsApiCredential(result.Key, result.Secret), _instanceContext.Name,
                 CloudOdsAdminAppSettings.Instance.Mode).ApiBaseUrl;
 
-            apiUrl = GetApiUrlForDisplay(apiUrl);
-
             return PartialView(
                 "_ApplicationKeyAndSecretContent", new ApplicationKeyModel
                 {
                     ApplicationName = model.ApplicationName,
                     Key = result.Key,
                     Secret = result.Secret,
-                    ApiUrl = apiUrl
+                    DisplayApiUrl = GetApiUrlForDisplay(apiUrl)
                 });
         }
 
@@ -228,14 +224,12 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
                 new OdsApiCredential(regenerationResult.Key, regenerationResult.Secret),
                 _instanceContext.Name, CloudOdsAdminAppSettings.Instance.Mode).ApiBaseUrl;
 
-            apiUrl = GetApiUrlForDisplay(apiUrl);
-
             return PartialView("_ApplicationKeyAndSecretContent", new ApplicationKeyModel
             {
                 ApplicationName = application.ApplicationName,
                 Key = regenerationResult.Key,
                 Secret = regenerationResult.Secret,
-                ApiUrl = apiUrl
+                DisplayApiUrl = GetApiUrlForDisplay(apiUrl)
             });
         }
 

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ApplicationController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ApplicationController.cs
@@ -246,10 +246,9 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
 
         private static string GetApiUrlForDisplay(string apiUrl)
         {
-            if (!string.IsNullOrEmpty(CloudOdsAdminAppSettings.Instance.ApiExternalUrl))
-                apiUrl = apiUrl.Replace(CloudOdsAdminAppSettings.Instance.ProductionApiUrl, CloudOdsAdminAppSettings.Instance.ApiExternalUrl);
-
-            return apiUrl;
+            return !string.IsNullOrEmpty(CloudOdsAdminAppSettings.Instance.ApiExternalUrl)
+                ? apiUrl.Replace(CloudOdsAdminAppSettings.Instance.ProductionApiUrl, CloudOdsAdminAppSettings.Instance.ApiExternalUrl)
+                : apiUrl;
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/CloudOdsAdminAppSettings.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/CloudOdsAdminAppSettings.cs
@@ -33,6 +33,8 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure
 
         public string ProductionApiUrl => AppSettings.ProductionApiUrl;
 
+        public string ApiExternalUrl => AppSettings.ApiExternalUrl;
+
         public bool SystemManagedSqlServer
             => AppSettings.SystemManagedSqlServer == null ||
                bool.TrueString.Equals(

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Application/ApplicationKeyModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Application/ApplicationKeyModel.cs
@@ -12,6 +12,6 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.Application
         public string ApplicationName { get; set; }
         public string Key { get; set; }
         public string Secret { get; set; }
-        public string ApiUrl { get; set; }
+        public string DisplayApiUrl { get; set; }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Application/ApplicationsIndexModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Application/ApplicationsIndexModel.cs
@@ -9,6 +9,6 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.Application
 {
     public class ApplicationsIndexModel : BaseOdsInstanceSettingsModel
     {
-        public string ProductionApiUrl { get; set; }
+        public string DisplayApiUrl { get; set; }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Views/Application/Index.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/Application/Index.cshtml
@@ -18,11 +18,11 @@ See the LICENSE and NOTICES files in the project root for more information.
 
 <div class="tab-content">
     <div class="tab-pane active" id="production-applications">
-        @if (!string.IsNullOrEmpty(Model.ProductionApiUrl))
+        @if (!string.IsNullOrEmpty(Model.DisplayApiUrl))
         {
             <div class="alert alert-info">
-                <a href="javascript:void(0)" class="copy-to-clipboard" data-clipboard-text="@Model.ProductionApiUrl">
-                    <span class="fa fa-clipboard"></span><span>Production API URL: </span><strong>@Model.ProductionApiUrl</strong>
+                <a href="javascript:void(0)" class="copy-to-clipboard" data-clipboard-text="@Model.DisplayApiUrl">
+                    <span class="fa fa-clipboard"></span><span>Production API URL: </span><strong>@Model.DisplayApiUrl</strong>
                 </a>
             </div>
             @Html.ActionAjax(Url.Action("ApplicationList", "Application", new { }), 250, "Warming up Production API....")

--- a/Application/EdFi.Ods.AdminApp.Web/Views/Application/_ApplicationKeyAndSecretContent.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/Application/_ApplicationKeyAndSecretContent.cshtml
@@ -18,7 +18,7 @@ See the LICENSE and NOTICES files in the project root for more information.
             <div>@Model.ApplicationName</div>
             <div>Key: <span class="key-generated">@Model.Key</span></div>
             <div>Secret: <span class="key-generated">@Model.Secret</span></div>
-            <div>API URL: <span class="key-generated">@Model.ApiUrl</span></div>
+            <div>API URL: <span class="key-generated">@Model.DisplayApiUrl</span></div>
         </div>
     </div>
     <div class="text-center padding-top">

--- a/Application/EdFi.Ods.AdminApp.Web/appsettings.json
+++ b/Application/EdFi.Ods.AdminApp.Web/appsettings.json
@@ -6,6 +6,7 @@
         "XsdFolder": "Schema",
         "DefaultOdsInstance": "EdFi ODS",
         "ProductionApiUrl": "http://localhost:54746",
+        "ApiExternalUrl": "",
         "SystemManagedSqlServer": "true",
         "DbSetupEnabled": "true",
         "SecurityMetadataCacheTimeoutMinutes": "10",

--- a/BuildDockerDevelopment.ps1
+++ b/BuildDockerDevelopment.ps1
@@ -18,6 +18,7 @@
 
 $p = @{
         ProductionApiUrl = "http://api"
+        ApiExternalUrl = "https://localhost:5001"
         AppStartup = "OnPrem"
         XsdFolder = "/app/Schema"
         ApiStartupType = "SharedInstance"

--- a/BuildDockerDevelopment.ps1
+++ b/BuildDockerDevelopment.ps1
@@ -8,8 +8,8 @@
         Script for running the build operation and copy over the latest files to an existing AdminApp docker container for testing.
 
     .DESCRIPTION
-        Script for facilitating the local docker testing with latest changes. Developer can set the required appsettings values and trigger 
-        the build. Once the build done, the apsettings.json will be updated with values provided and 
+        Script for facilitating the local docker testing with latest changes. Developer can set the required appsettings values and trigger
+        the build. Once the build done, the apsettings.json will be updated with values provided and
         latest files will be copied over to an existing AdminApp docker container folder.
 
     .EXAMPLE
@@ -32,4 +32,4 @@ $p = @{
         ProductionOdsDB = "host=db-ods;port=5432;username=username;password=password;database=EdFi_Ods;Application Name=EdFi.Ods.AdminApp;"
     }
 
-.\build.ps1 -Version 2.1.0 -Configuration Release -DockerEnvValues $p -Command BuildAndDeployToDockerContainer
+.\build.ps1 -Version 2.1.1 -Configuration Release -DockerEnvValues $p -Command BuildAndDeployToDockerContainer

--- a/build.ps1
+++ b/build.ps1
@@ -68,7 +68,7 @@
             ProductionOdsDB = "host=db-ods;port=5432;username=username;password=password;database=EdFi_Ods;Application Name=EdFi.Ods.AdminApp;"
             }
 
-        .\build.ps1 -Version "2.1.0" -Configuration Release -DockerEnvValues $p -Command BuildAndDeployToDockerContainer
+        .\build.ps1 -Version "2.1.1" -Configuration Release -DockerEnvValues $p -Command BuildAndDeployToDockerContainer
 #>
 param(
     # Command to execute, defaults to "Build".
@@ -241,7 +241,7 @@ function RunNuGetPack {
 
         [string]
         $nuspecPath
-    )   
+    )
 
     $arguments = @(
         "pack",  $nugetSpecPath,

--- a/build.ps1
+++ b/build.ps1
@@ -344,6 +344,7 @@ function UpdateAppSettings {
     $filePath = "$solutionRoot/EdFi.Ods.AdminApp.Web/publish/appsettings.json"
     $json = (Get-Content -Path $filePath) | ConvertFrom-Json
     $json.AppSettings.ProductionApiUrl = $DockerEnvValues["ProductionApiUrl"]
+    $json.AppSettings.ApiExternalUrl = $DockerEnvValues["ApiExternalUrl"]
     $json.AppSettings.AppStartup = $DockerEnvValues["AppStartup"]
     $json.AppSettings.ApiStartupType = $DockerEnvValues["ApiStartupType"]
     $json.AppSettings.XsdFolder = $DockerEnvValues["XsdFolder"]

--- a/build.ps1
+++ b/build.ps1
@@ -54,6 +54,7 @@
     .EXAMPLE
        $p = @{
             ProductionApiUrl = "http://api"
+            ApiExternalUrl = "https://localhost:5001"
             AppStartup = "OnPrem"
             XsdFolder = "/app/Schema"
             ApiStartupType = "SharedInstance"


### PR DESCRIPTION
**Description**

**NOTE: This PR is a companion of the  [Docker counterpart](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Docker/pull/50)**

- Added ApiExternalUrl appsetting to set the ods/api url. This appsetting is only supposed to be used for displaying the correct url in docker environments.
- Added a private method GetApiUrlForDisplay to replace the production Api Url with the specified ApiExternalUrl if present. Refactored the controller actions to use the method.
- Updated the build script and BuildDockerDevelopment script to take the new appsetting of ApiExternalUrl into account.