### PR TITLE
[AA-1183] - Revise validations of CloudOdsAdminApp.ApplicationName

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web/Helpers/ApplicationExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Helpers/ApplicationExtensions.cs
@@ -4,24 +4,14 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using EdFi.Admin.DataAccess.Models;
-using EdFi.Ods.AdminApp.Management;
 
 namespace EdFi.Ods.AdminApp.Web.Helpers
 {
     public static class ApplicationExtensions
     {
-        public static bool IsSystemReservedApplicationName(string applicationName)
-        {
-            return applicationName != null && CloudOdsAdminApp.ApplicationName.Equals(applicationName.Trim());
-        }
-
         public static bool IsSystemReservedApplication(this Application application)
         {
-            return application != null && 
-            (
-                IsSystemReservedApplicationName(application.ApplicationName) ||
-                application.Vendor.IsSystemReservedVendor()
-            );
+            return application != null && application.Vendor.IsSystemReservedVendor();
         }
 
         public static int MaximumApplicationNameLength = 50;

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Application/AddApplicationModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Application/AddApplicationModel.cs
@@ -57,10 +57,6 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.Application
                 .Must(BeWithinApplicationNameMaxLength)
                 .When(x => x.ApplicationName != null);
 
-            RuleFor(m => m.ApplicationName)
-                .Must(name => !ApplicationExtensions.IsSystemReservedApplicationName(name))
-                .WithMessage(p => $"'{p.ApplicationName}' is a reserved name and may not be used. Please choose another name.");
-
             RuleFor(m => m.ClaimSetName)
                 .NotEmpty()
                 .WithMessage("You must choose a Claim Set");

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Application/EditApplicationModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Application/EditApplicationModel.cs
@@ -48,10 +48,6 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.Application
                 .Must(BeWithinApplicationNameMaxLength)
                 .When(x => x.ApplicationName != null);
 
-            RuleFor(m => m.ApplicationName)
-                .Must(name => !ApplicationExtensions.IsSystemReservedApplicationName(name))
-                .WithMessage(p => $"'{ p.ApplicationName}' is a reserved name and may not be used. Please choose another name.");
-
             RuleFor(m => m.ClaimSetName)
                 .NotEmpty()
                 .WithMessage("You must choose a Claim Set");


### PR DESCRIPTION
**Description**
- Removed IsSystemReservedApplicationName extension method because in its current form it is not a truthful check for SystemReservedApplicationName and always returns false for both the sharedinstance mode and multi-instance mode.
- We already have a IsSystemReservedVendor check which is more accurate in determining whether an application with a particular name should be allowed in the database depending on its vendor association.  
- Removed usages of IsSystemReservedApplicationName as well as validation rules depending on it.