### PR TITLE
[TSINSTALL-94] PART-3 Update AppCommon version to 1.3.0 to avoid net 48 pre-requisites checking during installation

### DIFF
--- a/EdFi.Suite3.Installer.AdminApp/prep-installer-package.ps1
+++ b/EdFi.Suite3.Installer.AdminApp/prep-installer-package.ps1
@@ -10,7 +10,7 @@ param (
     $PackageDirectory,
 
     [string]
-    $AppCommonVersion = "1.2.0",
+    $AppCommonVersion = "1.3.0",
 
     [string]
     $PackageSource = "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"


### PR DESCRIPTION
@plioi @saa14 
Please help review and merge the changes.
Thanks