### PR TITLE
[AA-1137] - Descriptors page - Load all descriptors regardless of namespace

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Helpers/StringExtensionsTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Helpers/StringExtensionsTests.cs
@@ -1,0 +1,23 @@
+using NUnit.Framework;
+using Shouldly;
+using static EdFi.Ods.AdminApp.Web.Helpers.StringExtensions;
+
+namespace EdFi.Ods.AdminApp.Management.Tests.Helpers
+{
+    class StringExtensionsTests
+    {
+        [Test]
+        public void ShouldParseUserFacingCategoryNameFromDescriptorPath()
+        {
+            "/ed-fi/builtInDescriptors".GetDescriptorCategoryName().ShouldBe("BuiltInDescriptor");
+            "/tpdm/extensionDescriptors".GetDescriptorCategoryName().ShouldBe("ExtensionDescriptor [Tpdm]");
+
+            //Resilience against inputs that don't conform to the basic expected path naming convention:
+            "/ed-fi/builtInDescriptor".GetDescriptorCategoryName().ShouldBe("BuiltInDescriptor");
+            "/sample/extension/Unexpected/Long/Path".GetDescriptorCategoryName().ShouldBe("Extension/Unexpected/Long/Path [Sample]");
+
+            //Fail safe, passing through the original path for inputs that cannot parse at all.
+            "/unexpectedlyShortPath".GetDescriptorCategoryName().ShouldBe("/unexpectedlyShortPath");
+        }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Management.UnitTests/Api/OdsApiFacadeTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.UnitTests/Api/OdsApiFacadeTests.cs
@@ -241,7 +241,7 @@ namespace EdFi.Ods.AdminApp.Management.UnitTests.Api
         {
             // Arrange
             const string content =
-                "{\r\n  \"swagger\": \"2.0\",\r\n  \"basePath\": \"/v3.1.1/api/data/v3\",\r\n  \"consumes\": [\r\n    \"application/json\"\r\n  ],\r\n  \"definitions\": {\r\n    \"edFi_test1Descriptor\": {\r\n    },\r\n    \"edFi_test2Descriptor\": {\r\n    }\r\n  }\r\n}";
+                "{\r\n  \"swagger\": \"2.0\",\r\n  \"basePath\": \"/v3.1.1/api/data/v3\",\r\n  \"consumes\": [\r\n    \"application/json\"\r\n  ],\r\n  \"definitions\": {\r\n    \"edFi_test1Descriptor\": {\r\n    },\r\n    \"edFi_test2Descriptor\": {\r\n    }\r\n  }, \"paths\": {\r\n    \"/ed-fi/testCategory1Descriptors\": {\r\n    },\r\n    \"/ed-fi/testCategory2Descriptors\": {\r\n    }\r\n  }\r\n}";
             var mockRestClient = new Mock<IRestClient>();
             mockRestClient.Setup(x => x.BaseUrl).Returns(new Uri(_connectionInformation.ApiBaseUrl));
             mockRestClient.Setup(x => x.Execute(It.IsAny<RestRequest>())).Returns(new RestResponse
@@ -260,7 +260,7 @@ namespace EdFi.Ods.AdminApp.Management.UnitTests.Api
 
             // Assert
             result.ShouldNotBeNull();
-            result.First().ShouldBe("Test1Descriptor");
+            result.First().ShouldBe("/ed-fi/testCategory1Descriptors");
         }
 
         [Test]

--- a/Application/EdFi.Ods.AdminApp.Management.UnitTests/Api/OdsApiFacadeTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.UnitTests/Api/OdsApiFacadeTests.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -241,7 +241,7 @@ namespace EdFi.Ods.AdminApp.Management.UnitTests.Api
         {
             // Arrange
             const string content =
-                "{\r\n  \"swagger\": \"2.0\",\r\n  \"basePath\": \"/v3.1.1/api/data/v3\",\r\n  \"consumes\": [\r\n    \"application/json\"\r\n  ],\r\n  \"definitions\": {\r\n    \"edFi_test1Descriptor\": {\r\n    },\r\n    \"edFi_test2Descriptor\": {\r\n    }\r\n  }, \"paths\": {\r\n    \"/ed-fi/testCategory1Descriptors\": {\r\n    },\r\n    \"/ed-fi/testCategory2Descriptors\": {\r\n    }\r\n  }\r\n}";
+                "{\r\n  \"swagger\": \"2.0\",\r\n  \"basePath\": \"/v3.1.1/api/data/v3\",\r\n  \"consumes\": [\r\n    \"application/json\"\r\n  ],\r\n  \"definitions\": {\r\n    \"edFi_test1Descriptor\": {\r\n    },\r\n    \"edFi_test2Descriptor\": {\r\n    }\r\n  }, \"paths\": {\r\n    \"/ed-fi/testCategory1Descriptors\": {\r\n    },\r\n   \"/ed-fi/testCategory1Descriptors/{id}\": {\r\n    },\r\n   \"/ed-fi/testCategory1Descriptors/deletes\": {\r\n    },\r\n    \"/ed-fi/testCategory2Descriptors\": {\r\n    },\r\n   \"/ed-fi/testCategory2Descriptors/{id}\": {\r\n    },\r\n   \"/ed-fi/testCategory2Descriptors/deletes\": {\r\n    }\r\n  }\r\n}";
             var mockRestClient = new Mock<IRestClient>();
             mockRestClient.Setup(x => x.BaseUrl).Returns(new Uri(_connectionInformation.ApiBaseUrl));
             mockRestClient.Setup(x => x.Execute(It.IsAny<RestRequest>())).Returns(new RestResponse
@@ -260,7 +260,9 @@ namespace EdFi.Ods.AdminApp.Management.UnitTests.Api
 
             // Assert
             result.ShouldNotBeNull();
-            result.First().ShouldBe("/ed-fi/testCategory1Descriptors");
+            result.Count.ShouldBe(2);
+            result[0].ShouldBe("/ed-fi/testCategory1Descriptors");
+            result[1].ShouldBe("/ed-fi/testCategory2Descriptors");
         }
 
         [Test]

--- a/Application/EdFi.Ods.AdminApp.Management/Api/IOdsApiFacade.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/IOdsApiFacade.cs
@@ -19,7 +19,7 @@ namespace EdFi.Ods.AdminApp.Management.Api
         List<SelectOptionModel> GetLocalEducationAgencyCategories();
         List<SelectOptionModel> GetAllGradeLevels();
         IReadOnlyList<string> GetAllDescriptors();
-        List<Descriptor> GetDescriptorsByName(string descriptorPath);
+        List<Descriptor> GetDescriptorsByPath(string descriptorPath);
         bool DoesApiDataExist();
         bool DoesLearningStandardsDataExist();
         LocalEducationAgency GetLocalEducationAgencyById(string id);

--- a/Application/EdFi.Ods.AdminApp.Management/Api/IOdsApiFacade.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/IOdsApiFacade.cs
@@ -19,7 +19,7 @@ namespace EdFi.Ods.AdminApp.Management.Api
         List<SelectOptionModel> GetLocalEducationAgencyCategories();
         List<SelectOptionModel> GetAllGradeLevels();
         IReadOnlyList<string> GetAllDescriptors();
-        List<Descriptor> GetDescriptorsByName(string name);
+        List<Descriptor> GetDescriptorsByName(string descriptorPath);
         bool DoesApiDataExist();
         bool DoesLearningStandardsDataExist();
         LocalEducationAgency GetLocalEducationAgencyById(string id);

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiFacade.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiFacade.cs
@@ -92,9 +92,10 @@ namespace EdFi.Ods.AdminApp.Management.Api
             return _restClient.GetAllDescriptors();
         }
 
-        public List<Descriptor> GetDescriptorsByName(string descriptorName)
+        public List<Descriptor> GetDescriptorsByName(string descriptorPath)
         {
-            var response = _restClient.GetAll<DomainModels.EdFiDescriptor>($"/ed-fi/{descriptorName}s");
+
+            var response = _restClient.GetAll<DomainModels.EdFiDescriptor>(descriptorPath);
 
             var descriptors = new List<Descriptor>();
             foreach (var descriptor in response)

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiFacade.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiFacade.cs
@@ -92,9 +92,8 @@ namespace EdFi.Ods.AdminApp.Management.Api
             return _restClient.GetAllDescriptors();
         }
 
-        public List<Descriptor> GetDescriptorsByName(string descriptorPath)
+        public List<Descriptor> GetDescriptorsByPath(string descriptorPath)
         {
-
             var response = _restClient.GetAll<DomainModels.EdFiDescriptor>(descriptorPath);
 
             var descriptors = new List<Descriptor>();

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
@@ -166,18 +166,19 @@ namespace EdFi.Ods.AdminApp.Management.Api
             var response = _restClient.Execute(request);
             HandleErrorResponse(response);
             var swaggerDocument = JsonConvert.DeserializeObject<JObject>(response.Content);
-            var descriptorsList = swaggerDocument["definitions"].ToObject<Dictionary<string, JObject>>();
+            var descriptorPaths = swaggerDocument["paths"].ToObject<Dictionary<string, JObject>>();
 
-            return descriptorsList.Keys.Where(x => x.StartsWith("edFi_"))
-                .Select(x => CapitalizeFirstLetter(x.Substring("edFi_".Length))).ToList();
+            var descriptorsList = new SortedSet<string>();
 
-            string CapitalizeFirstLetter(string descriptorName)
+            if (descriptorPaths != null)
             {
-                if (descriptorName.Length > 0)
-                    return char.ToUpper(descriptorName[0]) + descriptorName.Substring(1);
-
-                return descriptorName;
+                foreach (var descriptorPath in descriptorPaths.Keys)
+                {
+                    descriptorsList.Add(descriptorPath);
+                }
             }
+
+            return descriptorsList.ToList();
         }
 
         public OdsApiResult DeleteResource(string elementPath, string id, bool refreshToken = false)

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
@@ -174,7 +174,12 @@ namespace EdFi.Ods.AdminApp.Management.Api
             {
                 foreach (var descriptorPath in descriptorPaths.Keys)
                 {
-                    descriptorsList.Add(descriptorPath);
+                    //Paths take the form /extension/name, /extension/name/{id}, /extension/name/deletes, etc.
+                    //Here we extract distinct /extension/name.
+                    var resourceParts = descriptorPath.TrimStart('/').Split('/').Take(2).ToArray();
+
+                    if (resourceParts.Length >= 2)
+                        descriptorsList.Add($"/{resourceParts[0]}/{resourceParts[1]}");
                 }
             }
 

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/DescriptorsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/DescriptorsController.cs
@@ -7,9 +7,11 @@ using AutoMapper;
 using EdFi.Ods.AdminApp.Management.Api;
 using EdFi.Ods.AdminApp.Web.Models.ViewModels.Descriptors;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using EdFi.Ods.AdminApp.Management;
 using EdFi.Ods.AdminApp.Web.Display.TabEnumeration;
+using EdFi.Ods.AdminApp.Web.Helpers;
 using Microsoft.AspNetCore.Mvc;
 
 namespace EdFi.Ods.AdminApp.Web.Controllers
@@ -46,9 +48,15 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
 
         public async Task<ActionResult> DescriptorCategoryList()
         {
+            var descriptorCategoryPaths = (await _odsApiFacadeFactory.Create()).GetAllDescriptors();
+
             var model = new DescriptorCategoriesModel
             {
-                DescriptorCategoryPaths = (await _odsApiFacadeFactory.Create()).GetAllDescriptors()
+                DescriptorCategories = descriptorCategoryPaths.Select(path => new DescriptorCategoriesModel.Category
+                {
+                    Path = path,
+                    Name = path.GetDescriptorCategoryName()
+                }).OrderBy(x => x.Name).ToList()
             };
 
            return PartialView("_DescriptorCategories", model);

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/DescriptorsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/DescriptorsController.cs
@@ -48,7 +48,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         {
             var model = new DescriptorCategoriesModel
             {
-                DescriptorCategories = (await _odsApiFacadeFactory.Create()).GetAllDescriptors()
+                DescriptorCategoryPaths = (await _odsApiFacadeFactory.Create()).GetAllDescriptors()
             };
 
            return PartialView("_DescriptorCategories", model);

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/DescriptorsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/DescriptorsController.cs
@@ -56,7 +56,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
 
         public async Task<ActionResult> GetDescriptorsFromCategory(string categoryPath)
         {
-            var descriptors = (await _odsApiFacadeFactory.Create()).GetDescriptorsByName(category);
+            var descriptors = (await _odsApiFacadeFactory.Create()).GetDescriptorsByPath(categoryPath);
             return PartialView("_Descriptor", _mapper.Map<List<DescriptorModel>>(descriptors));
         }
     }

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/DescriptorsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/DescriptorsController.cs
@@ -54,7 +54,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
            return PartialView("_DescriptorCategories", model);
         }
 
-        public async Task<ActionResult> GetDescriptorsFromCategoryName(string category)
+        public async Task<ActionResult> GetDescriptorsFromCategory(string categoryPath)
         {
             var descriptors = (await _odsApiFacadeFactory.Create()).GetDescriptorsByName(category);
             return PartialView("_Descriptor", _mapper.Map<List<DescriptorModel>>(descriptors));

--- a/Application/EdFi.Ods.AdminApp.Web/Helpers/StringExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Helpers/StringExtensions.cs
@@ -42,5 +42,55 @@ namespace EdFi.Ods.AdminApp.Web.Helpers
                 return null;
             }
         }
+
+        public static string GetDescriptorCategoryName(this string descriptorPath)
+        {
+            var descriptorPathParts = DescriptorPathParts(descriptorPath);
+
+            string descriptorName = null;
+
+            if (descriptorPathParts.Length == 2)
+            {
+                var routePrefix = descriptorPathParts[0];
+                var name = descriptorPathParts[1];
+
+                descriptorName = name.Remove(name.Length - 1, 1).CapitalizeFirstLetter();
+
+                if (routePrefix != "ed-fi")
+                    descriptorName = $"{descriptorName} [{routePrefix.CapitalizeFirstLetter()}]";
+            }
+
+            return descriptorName;
+        }
+
+        public static string GetDescriptorCategoryIdentifier(this string descriptorPath)
+        {
+            var descriptorPathParts = DescriptorPathParts(descriptorPath);
+
+            string descriptorId = null;
+
+            if (descriptorPathParts.Length == 2)
+            {
+                var routePrefix = descriptorPathParts[0];
+                var name = descriptorPathParts[1];
+
+                descriptorId = $"{name}-{routePrefix}";
+            }
+
+            return descriptorId;
+        }
+
+        private static string CapitalizeFirstLetter(this string text)
+        {
+            if (text.Length > 0)
+                return char.ToUpper(text[0]) + text.Substring(1);
+            return text;
+        }
+
+        private static string[] DescriptorPathParts(string descriptorPath)
+        {
+            var descriptorPathParts = descriptorPath.TrimStart('/').Split('/', 3);
+            return descriptorPathParts;
+        }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Helpers/StringExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Helpers/StringExtensions.cs
@@ -63,23 +63,6 @@ namespace EdFi.Ods.AdminApp.Web.Helpers
             return descriptorName;
         }
 
-        public static string GetDescriptorCategoryIdentifier(this string descriptorPath)
-        {
-            var descriptorPathParts = DescriptorPathParts(descriptorPath);
-
-            string descriptorId = null;
-
-            if (descriptorPathParts.Length == 2)
-            {
-                var routePrefix = descriptorPathParts[0];
-                var name = descriptorPathParts[1];
-
-                descriptorId = $"{name}-{routePrefix}";
-            }
-
-            return descriptorId;
-        }
-
         private static string CapitalizeFirstLetter(this string text)
         {
             if (text.Length > 0)

--- a/Application/EdFi.Ods.AdminApp.Web/Helpers/StringExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Helpers/StringExtensions.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -45,22 +45,25 @@ namespace EdFi.Ods.AdminApp.Web.Helpers
 
         public static string GetDescriptorCategoryName(this string descriptorPath)
         {
-            var descriptorPathParts = DescriptorPathParts(descriptorPath);
-
-            string descriptorName = null;
+            var descriptorPathParts = descriptorPath.TrimStart('/').Split('/', 2);
 
             if (descriptorPathParts.Length == 2)
             {
                 var routePrefix = descriptorPathParts[0];
                 var name = descriptorPathParts[1];
 
-                descriptorName = name.Remove(name.Length - 1, 1).CapitalizeFirstLetter();
+                if (name.EndsWith("Descriptors"))
+                    name = name.Remove(name.Length - 1, 1);
+
+                var descriptorName = name.CapitalizeFirstLetter();
 
                 if (routePrefix != "ed-fi")
                     descriptorName = $"{descriptorName} [{routePrefix.CapitalizeFirstLetter()}]";
+
+                return descriptorName;
             }
 
-            return descriptorName;
+            return descriptorPath;
         }
 
         private static string CapitalizeFirstLetter(this string text)
@@ -68,12 +71,6 @@ namespace EdFi.Ods.AdminApp.Web.Helpers
             if (text.Length > 0)
                 return char.ToUpper(text[0]) + text.Substring(1);
             return text;
-        }
-
-        private static string[] DescriptorPathParts(string descriptorPath)
-        {
-            var descriptorPathParts = descriptorPath.TrimStart('/').Split('/', 3);
-            return descriptorPathParts;
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Descriptors/DescriptorCategoriesModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Descriptors/DescriptorCategoriesModel.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -9,6 +9,12 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.Descriptors
 {
     public class DescriptorCategoriesModel
     {
-        public IReadOnlyList<string> DescriptorCategoryPaths { get; set; }
+        public IReadOnlyList<Category> DescriptorCategories { get; set; }
+
+        public class Category
+        {
+            public string Path { get; set; }
+            public string Name { get; set; }
+        }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Descriptors/DescriptorCategoriesModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Descriptors/DescriptorCategoriesModel.cs
@@ -9,6 +9,6 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.Descriptors
 {
     public class DescriptorCategoriesModel
     {
-        public IReadOnlyList<string> DescriptorCategories { get; set; }
+        public IReadOnlyList<string> DescriptorCategoryPaths { get; set; }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Views/Descriptors/_DescriptorCategories.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/Descriptors/_DescriptorCategories.cshtml
@@ -1,4 +1,4 @@
-﻿@*
+@*
 SPDX-License-Identifier: Apache-2.0
 Licensed to the Ed-Fi Alliance under one or more agreements.
 The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
@@ -14,12 +14,14 @@ See the LICENSE and NOTICES files in the project root for more information.
     </div>
 </div>
 
+@{
+    int descriptorCount = 0;
+}
 @foreach (var categoryPath in Model.DescriptorCategoryPaths)
 {
     var categoryName = categoryPath.GetDescriptorCategoryName();
-    var categoryId = categoryPath.GetDescriptorCategoryIdentifier();
 
-    if (categoryName != null && categoryId != null)
+    if (categoryName != null)
     {
         <div class="panel-section">
             <div class="row heading">
@@ -28,13 +30,14 @@ See the LICENSE and NOTICES files in the project root for more information.
                 </div>
                 <div class="col-xs-4 text-right">
                     <span class="custom-divider"> |</span>
-                    <a href="javascript:void(0)" class="descriptor-panel-toggle" data-target="#descriptor-@(categoryId)"><span class="fa fa-chevron-down caret-custom panel-toggle"></span></a>
+                    <a href="javascript:void(0)" class="descriptor-panel-toggle" data-target="#descriptor-@(descriptorCount)"><span class="fa fa-chevron-down caret-custom panel-toggle"></span></a>
                 </div>
-                <div id="descriptor-@(categoryId)" data-category-path="@categoryPath" class="row content collapse panel-loading">
+                <div id="descriptor-@(descriptorCount)" data-category-path="@categoryPath" class="row content collapse panel-loading">
                     <i class="fa fa-spinner fa-pulse fa-fw"></i>
                 </div>
             </div>
         </div>
+        descriptorCount++;
     }
 }
 

--- a/Application/EdFi.Ods.AdminApp.Web/Views/Descriptors/_DescriptorCategories.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/Descriptors/_DescriptorCategories.cshtml
@@ -5,6 +5,7 @@ The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2
 See the LICENSE and NOTICES files in the project root for more information.
 *@
 
+@using EdFi.Ods.AdminApp.Web.Helpers
 @model EdFi.Ods.AdminApp.Web.Models.ViewModels.Descriptors.DescriptorCategoriesModel
 
 <div class="row margin-bottom">
@@ -15,20 +16,26 @@ See the LICENSE and NOTICES files in the project root for more information.
 
 @foreach (var category in Model.DescriptorCategories)
 {
-    <div class="panel-section">
-        <div class="row heading">
-            <div class="col-xs-8">
-                <h7>@category</h7>
-            </div>
-            <div class="col-xs-4 text-right">
-                <span class="custom-divider"> |</span>
-                <a href="javascript:void(0)" class="descriptor-panel-toggle" data-target="#descriptor-@(category)"><span class="fa fa-chevron-down caret-custom panel-toggle"></span></a>
-            </div>
-            <div id="descriptor-@(category)" data-category="@category" class="row content collapse panel-loading">
-                <i class="fa fa-spinner fa-pulse fa-fw"></i>
+    var categoryName = category.GetDescriptorCategoryName();
+    var categoryId = category.GetDescriptorCategoryIdentifier();
+
+    if (categoryName != null && categoryId != null)
+    {
+        <div class="panel-section">
+            <div class="row heading">
+                <div class="col-xs-8">
+                    <h7>@categoryName</h7>
+                </div>
+                <div class="col-xs-4 text-right">
+                    <span class="custom-divider"> |</span>
+                    <a href="javascript:void(0)" class="descriptor-panel-toggle" data-target="#descriptor-@(categoryId)"><span class="fa fa-chevron-down caret-custom panel-toggle"></span></a>
+                </div>
+                <div id="descriptor-@(categoryId)" data-category="@category" class="row content collapse panel-loading">
+                    <i class="fa fa-spinner fa-pulse fa-fw"></i>
+                </div>
             </div>
         </div>
-    </div>
+    }
 }
 
 <script type="text/javascript">

--- a/Application/EdFi.Ods.AdminApp.Web/Views/Descriptors/_DescriptorCategories.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/Descriptors/_DescriptorCategories.cshtml
@@ -14,10 +14,10 @@ See the LICENSE and NOTICES files in the project root for more information.
     </div>
 </div>
 
-@foreach (var category in Model.DescriptorCategories)
+@foreach (var categoryPath in Model.DescriptorCategoryPaths)
 {
-    var categoryName = category.GetDescriptorCategoryName();
-    var categoryId = category.GetDescriptorCategoryIdentifier();
+    var categoryName = categoryPath.GetDescriptorCategoryName();
+    var categoryId = categoryPath.GetDescriptorCategoryIdentifier();
 
     if (categoryName != null && categoryId != null)
     {
@@ -30,7 +30,7 @@ See the LICENSE and NOTICES files in the project root for more information.
                     <span class="custom-divider"> |</span>
                     <a href="javascript:void(0)" class="descriptor-panel-toggle" data-target="#descriptor-@(categoryId)"><span class="fa fa-chevron-down caret-custom panel-toggle"></span></a>
                 </div>
-                <div id="descriptor-@(categoryId)" data-category="@category" class="row content collapse panel-loading">
+                <div id="descriptor-@(categoryId)" data-category-path="@categoryPath" class="row content collapse panel-loading">
                     <i class="fa fa-spinner fa-pulse fa-fw"></i>
                 </div>
             </div>
@@ -51,8 +51,8 @@ See the LICENSE and NOTICES files in the project root for more information.
         $toggleLink.addClass("initialized");
 
         if ($panel.hasClass("panel-loading")) {
-            var category = $panel.attr("data-category");
-            var url = "@Html.Raw(Url.Action("GetDescriptorsFromCategoryName", "Descriptors", new { }))" + "?category=" + category;
+            var categoryPath = $panel.attr("data-category-path");
+            var url = "@Html.Raw(Url.Action("GetDescriptorsFromCategory", "Descriptors", new { }))" + "?categoryPath=" + categoryPath;
             $.ajax({
                 url: url,
                 success: function (data) {

--- a/Application/EdFi.Ods.AdminApp.Web/Views/Descriptors/_DescriptorCategories.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/Descriptors/_DescriptorCategories.cshtml
@@ -17,20 +17,18 @@ See the LICENSE and NOTICES files in the project root for more information.
 @{
     int descriptorCount = 0;
 }
-@foreach (var categoryPath in Model.DescriptorCategoryPaths)
+@foreach (var category in Model.DescriptorCategories)
 {
-    var categoryName = categoryPath.GetDescriptorCategoryName();
-
     <div class="panel-section">
         <div class="row heading">
             <div class="col-xs-8">
-                <h7>@categoryName</h7>
+                <h7>@category.Name</h7>
             </div>
             <div class="col-xs-4 text-right">
                 <span class="custom-divider"> |</span>
                 <a href="javascript:void(0)" class="descriptor-panel-toggle" data-target="#descriptor-@(descriptorCount)"><span class="fa fa-chevron-down caret-custom panel-toggle"></span></a>
             </div>
-            <div id="descriptor-@(descriptorCount)" data-category-path="@categoryPath" class="row content collapse panel-loading">
+            <div id="descriptor-@(descriptorCount)" data-category-path="@category.Path" class="row content collapse panel-loading">
                 <i class="fa fa-spinner fa-pulse fa-fw"></i>
             </div>
         </div>

--- a/Application/EdFi.Ods.AdminApp.Web/Views/Descriptors/_DescriptorCategories.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/Descriptors/_DescriptorCategories.cshtml
@@ -21,24 +21,21 @@ See the LICENSE and NOTICES files in the project root for more information.
 {
     var categoryName = categoryPath.GetDescriptorCategoryName();
 
-    if (categoryName != null)
-    {
-        <div class="panel-section">
-            <div class="row heading">
-                <div class="col-xs-8">
-                    <h7>@categoryName</h7>
-                </div>
-                <div class="col-xs-4 text-right">
-                    <span class="custom-divider"> |</span>
-                    <a href="javascript:void(0)" class="descriptor-panel-toggle" data-target="#descriptor-@(descriptorCount)"><span class="fa fa-chevron-down caret-custom panel-toggle"></span></a>
-                </div>
-                <div id="descriptor-@(descriptorCount)" data-category-path="@categoryPath" class="row content collapse panel-loading">
-                    <i class="fa fa-spinner fa-pulse fa-fw"></i>
-                </div>
+    <div class="panel-section">
+        <div class="row heading">
+            <div class="col-xs-8">
+                <h7>@categoryName</h7>
+            </div>
+            <div class="col-xs-4 text-right">
+                <span class="custom-divider"> |</span>
+                <a href="javascript:void(0)" class="descriptor-panel-toggle" data-target="#descriptor-@(descriptorCount)"><span class="fa fa-chevron-down caret-custom panel-toggle"></span></a>
+            </div>
+            <div id="descriptor-@(descriptorCount)" data-category-path="@categoryPath" class="row content collapse panel-loading">
+                <i class="fa fa-spinner fa-pulse fa-fw"></i>
             </div>
         </div>
-        descriptorCount++;
-    }
+    </div>
+    descriptorCount++;
 }
 
 <script type="text/javascript">


### PR DESCRIPTION
**Description**
- Refactored GetAllDescriptors to use the "paths" property of the swagger response instead of "definitions". Returned the complete descriptor path instead of category names from the function.
- Added GetDescriptorCategoryName, GetDescriptorCategoryIdentifier, CapitalizeFirstLetter, DescriptorPathParts to StringExtensions. These extension methods are used to get the appropriate descriptor category name and category id from the descriptor path.
- Used GetDescriptorCategoryName and GetDescriptorCategoryIdentifier to refactor the view html to use category name only for the display, category id for the div panel expansion logic and the complete category route as the action parameter.
- Refactored GetDescriptorsByName to use the updated descriptorPath parameter.Renamed DescriptorCategory to DescriptorCategoryPaths in DescriptorCategoriesModel to accurately reflect the value of the property. Renamed GetDescriptorsFromCategoryName to GetDescriptorsFromCategory and refactored the parameter to the action to accurately reflect the value of the property. Renamed GetDescriptorsByName to GetDescriptorsByPath to accurately reflect the value of the parameter being passed in.
- Refactored the GetAllDescriptors unit test to check for the paths instead of definitions.