### PR TITLE
[AA-1136] fix regeneration of used secrets

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management/Database/Commands/RegenerateApiClientSecretCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/Commands/RegenerateApiClientSecretCommand.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -24,6 +24,7 @@ namespace EdFi.Ods.AdminApp.Management.Database.Commands
             var apiClient = application.ApiClients.First();
     
             apiClient.GenerateSecret();
+            apiClient.SecretIsHashed = false;
             _context.SaveChanges();
 
             return new RegenerateApiClientSecretResult


### PR DESCRIPTION
When a key and secret is used against the ODS, the ODS ensures that it is hashed and marks it as hashed. When Admin App regenerates a secret, it *should* also reset the corresponding SecretIsHashed flag so that the ApiClient object state is accurate. Otherwise, if a user creates a key and secret, uses it, and then regenerates the secret in Admin App, the new secret is not in fact usable. Users no longer have to create a whole new Application as a workaround.

I detected and fixed this against an example 5.0.1 ODS. The implementation of the ODS side behavior understandably moved during the .NET Core work for 5.1.0, so QA will still need to verify against that as a noteworthy case for completeness, but the fix is expected to work there as well.