### PR TITLE
[AA-1174] Improve developer-facing guidance for setting up locally

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -89,7 +89,8 @@ instructions](#running-on-docker) use PostgreSQL.
 
    ```powershell
    # From AdminApp clone directory
-   .\eng\run-dbup-migrations.ps1
+   cd eng
+   .\run-dbup-migrations.ps1
    ```
 
    :warning: you may wish to review the default configuration at the top of this
@@ -101,7 +102,13 @@ instructions](#running-on-docker) use PostgreSQL.
 
    :warning: Make sure you don't commit this change to source control.
 
-5. Run Admin App from Visual Studio, choosing either the "Shared Instance (SQL
+5. Run the build script and exercise tests to verify your setup:
+
+    ```powershell
+    .\build.ps1 buildandtest
+    ```
+
+6. Run Admin App from Visual Studio, choosing either the "Shared Instance (SQL
    Server)" profile (uses IIS Express) or "mssql-shared" profile (runs the
    Kestrel built-in web server).
 
@@ -121,9 +128,25 @@ and return to step 3 above.
    initdev -InstallType YearSpecific -OdsTokens '2020;2021'
    ```
 
-4. Run `run-dbup-migrations.ps1` in the AdminApp clone directory to
-   install the Admin App database support.
-5. Run Admin App from Visual Studio, choosing either the "Year Specific (SQL
+4. Install the AdminApp database support by running the following command in a
+   PowerShell window:
+
+   ```powershell
+   # From AdminApp clone directory
+   cd eng
+   .\run-dbup-migrations.ps1
+   ```
+
+   :warning: you may wish to review the default configuration at the top of this
+   script to ensure that it is appropriate for your situation.
+
+5. Run the build script and exercise tests to verify your setup:
+
+    ```powershell
+    .\build.ps1 buildandtest
+    ```
+
+6. Run Admin App from Visual Studio, choosing either the "Year Specific (SQL
    Server)" profile (uses IIS Express) or "mssql-year" profile (runs the Kestrel
    built-in web server).
 
@@ -143,9 +166,25 @@ above.
    initdev -InstallType DistrictSpecific -OdsTokens '255901;255902;255903;255904;255905'
    ```
 
-4. Re-run `run-dbup-migrations.ps1` in the AdminApp clone directory to
-   install the Admin App database support.
-5. Run Admin App from Visual Studio, choosing either the "District Specific (SQL
+4. Install the AdminApp database support by running the following command in a
+   PowerShell window:
+
+   ```powershell
+   # From AdminApp clone directory
+   cd eng
+   .\run-dbup-migrations.ps1
+   ```
+
+   :warning: you may wish to review the default configuration at the top of this
+   script to ensure that it is appropriate for your situation.
+
+5. Run the build script and exercise tests to verify your setup:
+
+    ```powershell
+    .\build.ps1 buildandtest
+    ```
+
+6. Run Admin App from Visual Studio, choosing either the "District Specific (SQL
    Server)" profile (uses IIS Express) or "mssql-district" profile (runs the
    Kestrel built-in web server).
 


### PR DESCRIPTION
Improve developer-facing guidance on getting a new local Admin App development environment up and running such that all integration tests can be expected to pass.

* Fixes mentions of the migration script so they consistently refer to its true location in the eng folder.
* Suggests running the build script in 'buildandtest' mode to verify the setup.
* Having migrations and a successful run of the tests ensures that subsequent Test Explorer runs complete successfully without further intervention, just like in the build server.