### PR TITLE
[AA-932] A user must be both logged in and have a matching Users record to access protected pages.

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web/Startup.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Startup.cs
@@ -23,6 +23,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using FluentValidation.AspNetCore;
 using Hangfire;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Authorization;
@@ -56,7 +57,7 @@ namespace EdFi.Ods.AdminApp.Web
 
             services.AddControllersWithViews(options =>
                     {
-                        options.Filters.Add(new AuthorizeFilter());
+                        options.Filters.Add(new AuthorizeFilter("UserMustExistPolicy"));
                         options.Filters.Add<AutoValidateAntiforgeryTokenAttribute>();
                         options.Filters.Add<JsonValidationFilter>();
                         options.Filters.Add<HandleAjaxErrorAttribute>();
@@ -74,6 +75,17 @@ namespace EdFi.Ods.AdminApp.Web
                                 => memberInfo?
                                     .GetCustomAttribute<System.ComponentModel.DataAnnotations.DisplayAttribute>()?.GetName();
                         });
+
+            services.AddAuthorization(options =>
+            {
+                options.AddPolicy("UserMustExistPolicy",
+                    policyBuilder =>
+                    {
+                        policyBuilder.AddRequirements(new UserMustExistRequirement());
+                    });
+            });
+
+            services.AddScoped<IAuthorizationHandler, UserMustExistHandler>();
 
             services.Configure<IdentityOptions>(options =>
             {

--- a/Application/EdFi.Ods.AdminApp.Web/UserMustExistHandler.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/UserMustExistHandler.cs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using EdFi.Ods.AdminApp.Management.Database;
+using Microsoft.AspNetCore.Authorization;
+
+namespace EdFi.Ods.AdminApp.Web
+{
+    public class UserMustExistRequirement : IAuthorizationRequirement { }
+
+    public class UserMustExistHandler : AuthorizationHandler<UserMustExistRequirement>
+    {
+        private readonly AdminAppIdentityDbContext _identity;
+
+        public UserMustExistHandler(AdminAppIdentityDbContext identity)
+            => _identity = identity;
+
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, UserMustExistRequirement requirement)
+        {
+            var userId = context.User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+            if (userId != null && _identity.Users.SingleOrDefault(x => x.Id == userId) != null)
+                context.Succeed(requirement);
+
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
Using MVC Core Authorization Policies, ensure that users are authorized if they are both authenticated (a valid login cookie exists) *and* a corresponding User record still exists for that user.

This gives a consistent experience for two interesting cases:

* A developer logs in, and while the cookie is still considered valid the developer resets the contents of their Users table. The cookie is still considered valid for Authentication but here we apply more strict Authorization and send them to the Login page again.

* A user logs in, and while they are interacting with the site a Super Admin deletes their account. As the first user tries to continue interacting, they are rightly sent back to the Login page.

Useful links which led to this solution:

* https://andrewlock.net/setting-global-authorization-policies-using-the-defaultpolicy-and-the-fallbackpolicy-in-aspnet-core-3/
* https://docs.microsoft.com/en-us/aspnet/core/security/authorization/policies?view=aspnetcore-5.0