### PR TITLE
AA-1182 generalize connection string token replacement to match ODS token replacement

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Services/ConnectionStringServiceTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Services/ConnectionStringServiceTests.cs
@@ -32,6 +32,23 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Services
         }
 
         [Test]
+        public void Sandbox()
+        {
+            // When the ODS/API is configured to use Sandbox mode, the intention is to use the Sandbox Admin
+            // tool *instead* of Admin App. Still, if an Admin App developer ever bothers to explicitly point at
+            // and ODS Database that is in fact a sandbox, the hardcoded connection string should be passed
+            // through and used similar to non-template SharedInstance connection strings.
+
+            const string DefaultOdsInstanceName = "EdFi ODS";
+            var apiKey = Guid.NewGuid().ToString().Replace("-", "");
+
+            var sandboxConnectionString = "Data Source=.\\;Initial Catalog=EdFi_Ods_"+apiKey+";Integrated Security=True";
+
+            GetConnectionString(sandboxConnectionString, DefaultOdsInstanceName, ApiMode.Sandbox)
+                .ShouldBe(sandboxConnectionString);
+        }
+
+        [Test]
         public void YearSpecific()
         {
             GetConnectionString(Template, "EdFi_Ods_2009", ApiMode.YearSpecific)

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Services/ConnectionStringServiceTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Services/ConnectionStringServiceTests.cs
@@ -17,13 +17,18 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Services
         [Test]
         public void SharedInstance()
         {
+            const string DefaultOdsInstanceName = "EdFi ODS";
             const string TypicalDefaultValue = "Data Source=.\\;Initial Catalog=EdFi_Ods;Integrated Security=True";
-            GetConnectionString(TypicalDefaultValue, "EdFi ODS", ApiMode.SharedInstance)
+            const string ArbitraryFixedValue = "Data Source=.\\;Initial Catalog=EdFi_Ods_ArbitraryFixedName;Integrated Security=True";
+
+            GetConnectionString(TypicalDefaultValue, DefaultOdsInstanceName, ApiMode.SharedInstance)
                 .ShouldBe(TypicalDefaultValue);
 
-            const string ArbitraryFixedValue = "Data Source=.\\;Initial Catalog=EdFi_Ods_ArbitraryFixedName;Integrated Security=True";
-            GetConnectionString(ArbitraryFixedValue, "EdFi ODS", ApiMode.SharedInstance)
+            GetConnectionString(ArbitraryFixedValue, DefaultOdsInstanceName, ApiMode.SharedInstance)
                 .ShouldBe(ArbitraryFixedValue);
+
+            GetConnectionString(Template, DefaultOdsInstanceName, ApiMode.SharedInstance)
+                .ShouldBe(TypicalDefaultValue);
         }
 
         [Test]

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Services/ConnectionStringServiceTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Services/ConnectionStringServiceTests.cs
@@ -1,0 +1,83 @@
+using System;
+using EdFi.Ods.AdminApp.Management.Helpers;
+using EdFi.Ods.AdminApp.Management.Instances;
+using EdFi.Ods.AdminApp.Management.Services;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Shouldly;
+
+namespace EdFi.Ods.AdminApp.Management.Tests.Services
+{
+    public class ConnectionStringServiceTests
+    {
+        const string Template = "Data Source=.\\;Initial Catalog=EdFi_{0};Integrated Security=True";
+        const string FixedTemplate = "Data Source=.\\;Initial Catalog=EdFi_Ods;Integrated Security=True";
+
+        [Test]
+        public void SharedInstance()
+        {
+            const string TypicalDefaultValue = "Data Source=.\\;Initial Catalog=EdFi_Ods;Integrated Security=True";
+            GetConnectionString(TypicalDefaultValue, "EdFi ODS", ApiMode.SharedInstance)
+                .ShouldBe(TypicalDefaultValue);
+
+            const string ArbitraryFixedValue = "Data Source=.\\;Initial Catalog=EdFi_Ods_ArbitraryFixedName;Integrated Security=True";
+            GetConnectionString(ArbitraryFixedValue, "EdFi ODS", ApiMode.SharedInstance)
+                .ShouldBe(ArbitraryFixedValue);
+        }
+
+        [Test]
+        public void YearSpecific()
+        {
+            GetConnectionString(Template, "EdFi_Ods_2009", ApiMode.YearSpecific)
+                .ShouldBe("Data Source=.\\;Initial Catalog=EdFi_Ods_2009;Integrated Security=True");
+
+           GetConnectionString(Template, "EdFi_Ods_2010", ApiMode.YearSpecific)
+                .ShouldBe("Data Source=.\\;Initial Catalog=EdFi_Ods_2010;Integrated Security=True");
+        }
+
+        [Test]
+        public void YearSpecificFixedValue()
+        {
+            Action ambiguousRequest = () => GetConnectionString(FixedTemplate, "EdFi_Ods_2009", ApiMode.YearSpecific);
+
+            ambiguousRequest.ShouldThrow<InvalidOperationException>(
+                "The connection string must contain a placeholder {0} for the multi-instance modes to work!");
+        }
+
+        [Test]
+        public void DistrictSpecific()
+        {
+            GetConnectionString(Template, "EdFi_Ods_2995001", ApiMode.DistrictSpecific)
+                .ShouldBe("Data Source=.\\;Initial Catalog=EdFi_Ods_2995001;Integrated Security=True");
+
+            GetConnectionString(Template, "EdFi_Ods_2995002", ApiMode.DistrictSpecific)
+                .ShouldBe("Data Source=.\\;Initial Catalog=EdFi_Ods_2995002;Integrated Security=True");
+        }
+
+        [Test]
+        public void DistrictSpecificFixedValue()
+        {
+            Action ambiguousRequest = () => GetConnectionString(FixedTemplate, "EdFi_Ods_2995001", ApiMode.DistrictSpecific);
+
+            ambiguousRequest.ShouldThrow<InvalidOperationException>(
+                "The connection string must contain a placeholder {0} for the multi-instance modes to work!");
+        }
+
+        private string GetConnectionString(string odsConnectionStringTemplate, string odsInstanceName, ApiMode apiMode)
+            => new ConnectionStringService(GetConnectionStringsAccessor(odsConnectionStringTemplate))
+                .GetConnectionString(odsInstanceName, apiMode);
+
+        private IOptions<ConnectionStrings> GetConnectionStringsAccessor(string productionOdsTemplate)
+        {
+            var connectionStrings = new Mock<IOptions<ConnectionStrings>>();
+
+            connectionStrings.Setup(x => x.Value).Returns(new ConnectionStrings
+            {
+                ProductionOds = productionOdsTemplate
+            });
+
+            return connectionStrings.Object;
+        }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Management/Services/ConnectionStringService.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Services/ConnectionStringService.cs
@@ -25,19 +25,32 @@ namespace EdFi.Ods.AdminApp.Management.Services
 
             if (apiMode.SupportsMultipleInstances)
             {
-                if(!connectionString.Contains("{0}"))
+                if (IsTemplate(connectionString))
+                {
+                    connectionString = GetModifiedConnectionString(
+                        connectionString, $"Ods_{odsInstanceName.ExtractNumericInstanceSuffix()}");
+                }
+                else
+                {
                     throw new InvalidOperationException(
                         "The connection string must contain a placeholder {0} for the multi-instance modes to work.");
-
-                connectionString = GetModifiedConnectionString(connectionString, odsInstanceName);
+                }
+            }
+            else if (apiMode == ApiMode.SharedInstance)
+            {
+                if (IsTemplate(connectionString))
+                {
+                    connectionString = GetModifiedConnectionString(connectionString, "Ods");
+                }
             }
 
             return connectionString;
         }
 
-        private static string GetModifiedConnectionString(string connectionString, string odsInstanceName)
-        {
-            return connectionString.Replace("{0}", $"Ods_{odsInstanceName.ExtractNumericInstanceSuffix()}");
-        }
+        private static bool IsTemplate(string connectionString)
+            => connectionString.Contains("{0}");
+
+        private static string GetModifiedConnectionString(string connectionString, string replacement)
+            => connectionString.Replace("{0}", replacement);
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management/Services/ConnectionStringService.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Services/ConnectionStringService.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -22,21 +22,22 @@ namespace EdFi.Ods.AdminApp.Management.Services
         public string GetConnectionString(string odsInstanceName, ApiMode apiMode)
         {
             var connectionString = _connectionStrings.ProductionOds;
+
             if (apiMode.SupportsMultipleInstances)
             {
+                if(!connectionString.Contains("{0}"))
+                    throw new InvalidOperationException(
+                        "The connection string must contain a placeholder {0} for the multi-instance modes to work.");
+
                 connectionString = GetModifiedConnectionString(connectionString, odsInstanceName);
             }
 
             return connectionString;
         }
 
-        private string GetModifiedConnectionString(string connectionString, string odsInstanceName)
+        private static string GetModifiedConnectionString(string connectionString, string odsInstanceName)
         {
-            if(!connectionString.Contains("{0}"))
-                throw new InvalidOperationException(
-                    "The connection string must contain a placeholder {0} for the multi-instance modes to work.");
-            var modifiedConnectionString = connectionString.Replace("{0}", $"Ods_{odsInstanceName.ExtractNumericInstanceSuffix()}");
-            return modifiedConnectionString;
+            return connectionString.Replace("{0}", $"Ods_{odsInstanceName.ExtractNumericInstanceSuffix()}");
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/appsettings.Docker-SharedInstance.json
+++ b/Application/EdFi.Ods.AdminApp.Web/appsettings.Docker-SharedInstance.json
@@ -10,7 +10,7 @@
     "ConnectionStrings": {
         "Admin": "Host=localhost; Port=5401; Database=EdFi_Admin; username=username; password=password; Application Name=EdFi.Ods.WebApi;",
         "Security": "Host=localhost; Port=5401; Database=EdFi_Security; username=username; password=password; Application Name=EdFi.Ods.WebApi;",
-        "ProductionOds": "Host=localhost; Port=5402; Database=EdFi_Ods; username=username; password=password; Application Name=EdFi.Ods.WebApi;"
+        "ProductionOds": "Host=localhost; Port=5402; Database=EdFi_{0}; username=username; password=password; Application Name=EdFi.Ods.WebApi;"
     },
     "Log4NetCore": {
         "Log4NetConfigFileName": "log4net\\log4net.Development.config"

--- a/Application/EdFi.Ods.AdminApp.Web/appsettings.PostgreSql-SharedInstance.json
+++ b/Application/EdFi.Ods.AdminApp.Web/appsettings.PostgreSql-SharedInstance.json
@@ -7,7 +7,7 @@
     "ConnectionStrings": {
         "Admin": "Host=localhost; Port=5432; Database=EdFi_Admin; username=username; Integrated Security=true; Application Name=EdFi.Ods.WebApi;",
         "Security": "Host=localhost; Port=5432; Database=EdFi_Security; username=username; Integrated Security=true; Application Name=EdFi.Ods.WebApi;",
-        "ProductionOds": "Host=localhost; Port=5432; Database=EdFi_Ods; username=username; Integrated Security=true; Application Name=EdFi.Ods.WebApi;"
+        "ProductionOds": "Host=localhost; Port=5432; Database=EdFi_{0}; username=username; Integrated Security=true; Application Name=EdFi.Ods.WebApi;"
     },
     "Log4NetCore": {
         "Log4NetConfigFileName": "log4net\\log4net.Development.config"

--- a/Application/EdFi.Ods.AdminApp.Web/appsettings.SqlServer-SharedInstance.json
+++ b/Application/EdFi.Ods.AdminApp.Web/appsettings.SqlServer-SharedInstance.json
@@ -5,7 +5,7 @@
         "DatabaseEngine": "SqlServer"
     },
     "ConnectionStrings": {
-        "ProductionOds": "Data Source=.\\;Initial Catalog=EdFi_Ods;Integrated Security=True"
+        "ProductionOds": "Data Source=.\\;Initial Catalog=EdFi_{0};Integrated Security=True"
     },
     "Log4NetCore": {
         "Log4NetConfigFileName": "log4net\\log4net.Development.config"

--- a/BuildDockerDevelopment.ps1
+++ b/BuildDockerDevelopment.ps1
@@ -28,7 +28,7 @@ $p = @{
         EncryptionKey = "<Generated encryption key>"
         AdminDB = "host=db-admin;port=5432;username=username;password=password;database=EdFi_Admin;Application Name=EdFi.Ods.AdminApp;"
         SecurityDB = "host=db-admin;port=5432;username=username;password=password;database=EdFi_Security;Application Name=EdFi.Ods.AdminApp;"
-        ProductionOdsDB = "host=db-ods;port=5432;username=username;password=password;database=EdFi_Ods;Application Name=EdFi.Ods.AdminApp;"
+        ProductionOdsDB = "host=db-ods;port=5432;username=username;password=password;database=EdFi_{0};Application Name=EdFi.Ods.AdminApp;"
     }
 
 .\build.ps1 -Version 2.1.1 -Configuration Release -DockerEnvValues $p -Command BuildAndDeployToDockerContainer

--- a/build.ps1
+++ b/build.ps1
@@ -340,7 +340,7 @@ function Invoke-PushPackage {
     Invoke-Step { PushPackage }
 }
 
-function UpdateAppSettings {
+function UpdateAppSettingsForDocker {
     $filePath = "$solutionRoot/EdFi.Ods.AdminApp.Web/publish/appsettings.json"
     $json = (Get-Content -Path $filePath) | ConvertFrom-Json
     $json.AppSettings.ProductionApiUrl = $DockerEnvValues["ProductionApiUrl"]
@@ -377,7 +377,7 @@ function RestartAdminAppContainer {
 }
 
 function Invoke-DockerDeploy {
-   Invoke-Step { UpdateAppSettings }
+   Invoke-Step { UpdateAppSettingsForDocker }
    Invoke-Step { CopyLatestFilesToContainer }
    Invoke-Step { RestartAdminAppContainer }
 }

--- a/build.ps1
+++ b/build.ps1
@@ -64,7 +64,7 @@
             EncryptionKey = "<Generated encryption key>"
             AdminDB = "host=db-admin;port=5432;username=username;password=password;database=EdFi_Admin;Application Name=EdFi.Ods.AdminApp;"
             SecurityDB = "host=db-admin;port=5432;username=username;password=password;database=EdFi_Security;Application Name=EdFi.Ods.AdminApp;"
-            ProductionOdsDB = "host=db-ods;port=5432;username=username;password=password;database=EdFi_Ods;Application Name=EdFi.Ods.AdminApp;"
+            ProductionOdsDB = "host=db-ods;port=5432;username=username;password=password;database=EdFi_{0};Application Name=EdFi.Ods.AdminApp;"
             }
 
         .\build.ps1 -Version "2.1.1" -Configuration Release -DockerEnvValues $p -Command BuildAndDeployToDockerContainer

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -82,8 +82,9 @@ instructions](#running-on-docker) use PostgreSQL.
 1. Get started with the ODS/API until the point where you are ready to have the
    ODS/API running in Visual Studio.
 2. Change the ODS/API `web.config` (v3.x) or `appsettings.json` (v5.x) to run in
-   SharedInstance mode and change the ODS connection string to use database  
-   `EdFi_Ods_Populated_Template` or a copy thereof.
+   "SharedInstance" mode and ensure that the ODS connection string points to
+   database `EdFi_{0}`. At runtime, the software will substitute "Ods" for
+   the replacement token `{0}`.
 3. Install the AdminApp database support by running the following command in a
    PowerShell window:
 
@@ -96,21 +97,15 @@ instructions](#running-on-docker) use PostgreSQL.
    :warning: you may wish to review the default configuration at the top of this
    script to ensure that it is appropriate for your situation.
 
-4. Adjust AdminApp's `appsettings.SqlServer-SharedInstance.json` by setting the
-   `ProductionOds` connection string to point to the
-   `EdFi_Ods_Populated_Template` database.
-
-   :warning: Make sure you don't commit this change to source control.
-
-5. Run the build script and exercise tests to verify your setup:
+4. Run the build script and exercise tests to verify your setup:
 
     ```powershell
     .\build.ps1 buildandtest
     ```
 
-6. Run Admin App from Visual Studio, choosing either the "Shared Instance (SQL
-   Server)" profile (uses IIS Express) or "mssql-shared" profile (runs the
-   Kestrel built-in web server).
+5. Run Admin App from Visual Studio, choosing either the "Shared Instance (SQL
+   Server)" profile (uses IIS Express) or "mssql-shared" profile (runs the Kestrel
+   built-in web server).
 
 To reset the databases so that you start from a clean slate, re-run `initdev`
 and return to step 3 above.
@@ -119,9 +114,10 @@ and return to step 3 above.
 
 1. Stop the ODS/API and/or Admin App if running in Visual Studio.
 2. Change the ODS/API `web.config` (v3.x) or `appsettings.json` (v5.x) to run in
-   "YearSpecific" mode and change the ODS connection string to point to database
-   `EdFi_Ods_{0}`. At runtime, the software will substitute the correct year for
-   the replacement token `{0}`.
+   "YearSpecific" mode and ensure that the ODS connection string points to
+   database `EdFi_{0}`. At runtime, the software will substitute "Ods_yyyy" for
+   the replacement token `{0}`, where "yyyy" is the four digit year of a given
+   year instance database.
 3. Re-run `initdev` with the following command, changing the years as desired:
 
    ```powershell
@@ -158,8 +154,10 @@ above.
 1. Stop the ODS/API and/or Admin App if running in Visual Studio.
 2. Change the ODS/API `web.config` (v3.x) or `appsettings.json` (v5.x) to run in
    "DistrictSpecific" mode and ensure that the ODS connection string points to
-   database `EdFi_Ods_{0}`. At runtime, the software will substitute the correct
-   district name for the replacement token `{0}`.
+   database `EdFi_{0}`. At runtime, the software will substitute "Ods_ddddd" for
+   the replacement token `{0}`, where "ddddd" is the numeric identifier of a given
+   district instance database.
+
 3. Re-run `initdev` with the following command:
 
    ```powershell


### PR DESCRIPTION
This generalizes connection string `"{0}"` replacement patterns so that, just like the ODS implementation itself, we too allow for token replacement for *all* supported API modes, not just the multi-instance modes.

Specifically, just like the ODS, we now support a connection string for Shared Instance mode with the template database name `"EdFi_{0}"` which naturally gets substituted to `"EdFi_Ods"`. The primary effect is that our various sample appsettings files become that much more alike. The ability to use some alternate specific database name is unharmed, which for example happens in Cloud ODS deployments.

I began with characterization test coverage of the affected ConnectionStringService and then extended the tests as the handling of Shared Instance evolved.

This also includes an update to developer-facing documentation to better match the typical moves a developer would make as they switch between modes. Superficial edits here also bring the 3 similar sections into alignment so they are less likely to drift again and so they use similar phrasing for similar things.