### PR TITLE
[AA-1251] - Improve phrasing of the claim set editor's ODS restart suggestions to be environment-agnostic

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web/Views/GlobalSettings/ClaimSets.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/GlobalSettings/ClaimSets.cshtml
@@ -18,7 +18,7 @@ See the LICENSE and NOTICES files in the project root for more information.
     <div id="claim-set-tab" class="tab-pane active navigational-index col-lg-8">
         <div id="claim-set-warning-message" class="alert alert-danger margin-top-10" role="alert" hidden>
             <p>
-                <strong>Please restart the ODS / API or wait <span id="claim-set-warning-time"></span> for the latest claimset changes to take effect.</strong>
+                <strong>Please restart the ODS / API or wait <span id="claim-set-warning-time"></span> for the latest claim set changes to take effect.</strong>
             </p>
         </div>
         <div align="right">

--- a/Application/EdFi.Ods.AdminApp.Web/Views/GlobalSettings/ClaimSets.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/GlobalSettings/ClaimSets.cshtml
@@ -1,4 +1,4 @@
-﻿@*
+@*
 SPDX-License-Identifier: Apache-2.0
 Licensed to the Ed-Fi Alliance under one or more agreements.
 The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
@@ -18,7 +18,7 @@ See the LICENSE and NOTICES files in the project root for more information.
     <div id="claim-set-tab" class="tab-pane active navigational-index col-lg-8">
         <div id="claim-set-warning-message" class="alert alert-danger margin-top-10" role="alert" hidden>
             <p>
-                <strong>Please reset IIS or wait <span id="claim-set-warning-time"></span> for the latest claimset changes to take effect.</strong>
+                <strong>Please restart the ODS / API or wait <span id="claim-set-warning-time"></span> for the latest claimset changes to take effect.</strong>
             </p>
         </div>
         <div align="right">

--- a/Application/EdFi.Ods.AdminApp.Web/wwwroot/Scripts/site.js
+++ b/Application/EdFi.Ods.AdminApp.Web/wwwroot/Scripts/site.js
@@ -455,7 +455,7 @@ function UpdateWarningTimer() {
             setTimeout(UpdateWarningTimer, 1000);
         }
     } else {
-        $("#claim-set-warning-message").find("p").html("<strong>Please restart the ODS / API for the latest claimset changes to take effect.</strong>");
+        $("#claim-set-warning-message").find("p").html("<strong>Please restart the ODS / API for the latest claim set changes to take effect.</strong>");
     }
 
 };

--- a/Application/EdFi.Ods.AdminApp.Web/wwwroot/Scripts/site.js
+++ b/Application/EdFi.Ods.AdminApp.Web/wwwroot/Scripts/site.js
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -455,7 +455,7 @@ function UpdateWarningTimer() {
             setTimeout(UpdateWarningTimer, 1000);
         }
     } else {
-        $("#claim-set-warning-message").find("p").html("<strong>Please reset IIS for the latest claimset changes to take effect.</strong>");
+        $("#claim-set-warning-message").find("p").html("<strong>Please restart the ODS / API for the latest claimset changes to take effect.</strong>");
     }
 
 };


### PR DESCRIPTION
**Description**
Rephrased the claim set editor's ODS restart suggestions to be environment-agnostic by using "restart the ODS/API" instead of "reset IIS". This also matches the restart suggestion on first time setup.