### PR TITLE
[AA-1201] - Separate claimset import and export to remove additional screen

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ClaimSetsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ClaimSetsController.cs
@@ -277,9 +277,9 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
             return RedirectToAction("EditClaimSet", "ClaimSets", new { claimSetId = model.ClaimSetId });
         }
 
-        public ActionResult ImportExportClaimSet()
+        public ActionResult ImportClaimSet()
         {
-            return PartialView("_ImportExportClaimSet", new ClaimSetFileImportModel());
+            return PartialView("_ImportClaimSet", new ClaimSetFileImportModel());
         }
 
         public ActionResult ExportClaimSetIndex()

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ClaimSetsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ClaimSetsController.cs
@@ -282,7 +282,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
             return PartialView("_ImportClaimSet", new ClaimSetFileImportModel());
         }
 
-        public ActionResult ExportClaimSetIndex()
+        public ActionResult ExportClaimSet()
         {
             var claimSets = _getClaimSetsByApplicationNameQuery.Execute(CloudOdsAdminApp.SecurityContextApplicationName);
             return PartialView("_ExportClaimSet", new ClaimSetFileExportModel()

--- a/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_ImportClaimSet.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_ImportClaimSet.cshtml
@@ -1,4 +1,4 @@
-﻿@*
+@*
 SPDX-License-Identifier: Apache-2.0
 Licensed to the Ed-Fi Alliance under one or more agreements.
 The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
@@ -8,7 +8,7 @@ See the LICENSE and NOTICES files in the project root for more information.
 @using EdFi.Ods.AdminApp.Web.Helpers
 @model EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets.ClaimSetFileImportModel
 
-<h3>Import/Export Claim Set</h3>
+<h3>Import Claim Set</h3>
 @using (Html.BeginForm("FileImport", "ClaimSets", FormMethod.Post, new { @id = "import-claim-set-form", enctype = "multipart/form-data"}))
 {
 @Html.AntiForgeryToken()
@@ -22,9 +22,6 @@ See the LICENSE and NOTICES files in the project root for more information.
     </div>
 </div>
 }
-<div class="padding-15 col-lg-offset-6">
-    @Html.Button("Export Claimsets").Attr("href", Url.Action("ExportClaimSetIndex", "ClaimSets")).AddClass("navigational-ajax").Data("state", "edit").Data("page-url", Url.Action("ClaimSets", "GlobalSettings")).Data("action", "exporting Claim Sets")
-</div>
 <div class="padding-top-5">
     @Html.Button("Back").AddClass("back-btn back-ajax claimset-back-btn").Data("back-url", Url.Action("ClaimSets", "GlobalSettings"))
 </div>

--- a/Application/EdFi.Ods.AdminApp.Web/Views/GlobalSettings/ClaimSets.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/GlobalSettings/ClaimSets.cshtml
@@ -23,7 +23,8 @@ See the LICENSE and NOTICES files in the project root for more information.
         </div>
         <div align="right">
             @Html.Button("Add Claim Set").Attr("href", Url.Action("AddClaimSet", "ClaimSets")).AddClass("add-claimset navigational-ajax").Data("state", "add").Data("page-url", Url.Action("ClaimSets", "GlobalSettings")).Data("action", "opening Add Claim Set")
-            @Html.Button("Import/Export Claim Set").Attr("href", Url.Action("ImportExportClaimSet", "ClaimSets")).AddClass("import-export-claimset navigational-ajax").Data("state", "import").Data("page-url", Url.Action("ClaimSets", "GlobalSettings")).Data("action", "opening Import/Export Claim Set")
+            @Html.Button("Import Claim Set").Attr("href", Url.Action("ImportClaimSet", "ClaimSets")).AddClass("import-claimset navigational-ajax").Data("state", "import").Data("page-url", Url.Action("ClaimSets", "GlobalSettings")).Data("action", "opening Import Claim Set")
+            @Html.Button("Export Claim Set").Attr("href", Url.Action("ExportClaimSet", "ClaimSets")).AddClass("navigational-ajax").Data("state", "edit").Data("page-url", Url.Action("ClaimSets", "GlobalSettings")).Data("action", "exporting Claim Sets")
         </div>
         <table class="table">
             <thead>


### PR DESCRIPTION
**Description**
- Renamed ImportExportClaimset to ImportClaimset view. Refactored to remove mentions of export and removed the "Export Claimsets" button on the ImportClaimSet view.
- Added Export Claim Set button to the Claimsets view. Renamed ExportClaimSetIndex to ExportClaimset.