### PR TITLE
[AA-1280] - Issue opening the School Year Edit modal with no current instance known

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/SchoolYearsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/SchoolYearsController.cs
@@ -6,12 +6,14 @@
 using System.Linq;
 using EdFi.Ods.AdminApp.Management.Database.Ods.SchoolYears;
 using EdFi.Ods.AdminApp.Management.Instances;
+using EdFi.Ods.AdminApp.Web.ActionFilters;
 using EdFi.Ods.AdminApp.Web.Infrastructure;
 using EdFi.Ods.AdminApp.Web.Models.ViewModels.SchoolYears;
 using Microsoft.AspNetCore.Mvc;
 
 namespace EdFi.Ods.AdminApp.Web.Controllers
 {
+    [BypassInstanceContextFilter]
     public class SchoolYearsController : ControllerBase
     {
         private readonly GetSchoolYearsQuery _getSchoolYears;

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/SchoolYearsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/SchoolYearsController.cs
@@ -56,6 +56,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
                 new EditSchoolYearModel
                 {
                     Warning = warning,
+                    InstanceName = instanceName,
                     SchoolYear = currentSchoolYear,
                     SchoolYears = schoolYears
                         .ToSelectListItems(


### PR DESCRIPTION
**Description**

Added the [BypassInstanceContextFilter] attribute to the SchoolYearsController to avoid the check for instance context as it is not needed to edit the school year. The modal is informed about the instance using the instance listing.