### PR TITLE
[AA-1288] - Move Production GA property Measurement ID to TeamCity

### DIFF
--- a/.teamcity/Web/templates/BuildAndTestTemplate.kt
+++ b/.teamcity/Web/templates/BuildAndTestTemplate.kt
@@ -32,6 +32,16 @@ object BuildAndTestTemplate : Template({
                 """.trimIndent()
             }
         }
+        powerShell {
+            name = "Populate Google Analytics AppSettings"
+            formatStderrAsError = true
+            executionMode = BuildStep.ExecutionMode.RUN_ON_SUCCESS
+            scriptMode = script {
+                content = """
+                    .\build.ps1 -Command PopulateGoogleAnalyticsAppSettings -GoogleAnalyticsMeasurementId "%adminApp.googleAnalyticsMeasurementId%"
+                """.trimIndent()
+            }
+        }
         // Note: there are no artifact rules on this template, so that the NuGet packages
         // will *not* be kept for pull requests. Artifact rules *are* applied on the
         // BuildBranch build type.

--- a/Application/EdFi.Ods.AdminApp.Web/appsettings.json
+++ b/Application/EdFi.Ods.AdminApp.Web/appsettings.json
@@ -19,7 +19,7 @@
         "IdaSubscriptionId": "",
         "AwsCurrentVersion": "1.0",
         "PathBase": "",
-        "GoogleAnalyticsMeasurementId": "UA-65907370-12",
+        "GoogleAnalyticsMeasurementId": "",
         "EncryptionKey": ""
     },
     "ConnectionStrings": {


### PR DESCRIPTION
**Description**
- Removed the production GA property measurement ID from appsettings.json as the value is now shifted to TeamCity.
- Added PopulateGoogleAnalyticsAppSettings command to the build script to update appsettings.json with the GoogleAnalyticsMeasurementId value provided. Refactored build script to take in a GoogleAnalyticsMeasurementId parameter for this command.
- Added a build step to the BuildAndTest template to populate the GA measurement ID before proceeding to create the nuget package.