### PR TITLE
[AA-1315] - Edit and Delete PostSecondaryInstitution implementation

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Controllers/EducationOrganizationsControllerTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Controllers/EducationOrganizationsControllerTests.cs
@@ -514,6 +514,56 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
         }
 
         [Test]
+        public void When_Perform_Post_Request_To_DeletePostSecondaryInstitution_Return_Success_Response()
+        {
+            // Arrange
+            var deletePostSecondaryInstitutionModel = new DeleteEducationOrganizationModel
+            {
+                Id = "id"
+            };
+        
+            _mockOdsApiFacade.Setup(x => x.DeletePostSecondaryInstitution(It.IsAny<string>()))
+                .Returns(new OdsApiResult());
+            _mockOdsApiFacadeFactory.Setup(x => x.Create())
+                .Returns(Task.FromResult(_mockOdsApiFacade.Object));
+            _controller =
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
+
+            // Act
+            var result = _controller.DeletePostSecondaryInstitution(deletePostSecondaryInstitutionModel).Result as ContentResult;
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.Content.ShouldContain("Post Secondary Institution Removed");
+        }
+
+        [Test]
+        public void When_Perform_Post_Request_To_DeletePostSecondaryInstitution_Return_Error_Response()
+        {
+            // Arrange
+            var error = "error";
+            var deletePostSecondaryInstitutionModel = new DeleteEducationOrganizationModel
+            {
+                Id = "id"
+            };
+            var apiResult = new OdsApiResult { ErrorMessage = error };
+         
+            _mockOdsApiFacade.Setup(x => x.DeletePostSecondaryInstitution(It.IsAny<string>()))
+                .Returns(apiResult);
+            _mockOdsApiFacadeFactory.Setup(x => x.Create())
+                .Returns(Task.FromResult(_mockOdsApiFacade.Object));
+            _controller =
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
+
+            // Act
+            var result = _controller.DeletePostSecondaryInstitution(deletePostSecondaryInstitutionModel).Result as ContentResult;
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.Content.ShouldContain(error);
+        }
+
+        [Test]
         public void When_Perform_Post_Request_To_DeleteLocalEducationAgency_Return_Success_Response()
         {
             // Arrange

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Controllers/EducationOrganizationsControllerTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Controllers/EducationOrganizationsControllerTests.cs
@@ -241,6 +241,61 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
         }
 
         [Test]
+        public void When_Perform_Post_Request_To_EditPostSecondaryInstitution_Return_Success_Response()
+        {
+            // Arrange
+            var editPostSecondaryInstitutionModel = new EditPostSecondaryInstitutionModel
+            {
+                City = "city"
+            };
+
+            _mockMapper.Setup(x => x.Map<PostSecondaryInstitution>(It.IsAny<EditPostSecondaryInstitutionModel>()))
+                .Returns(new PostSecondaryInstitution());
+            _mockOdsApiFacade.Setup(x => x.EditPostSecondaryInstitution(It.IsAny<PostSecondaryInstitution>()))
+                .Returns(new OdsApiResult());
+            _mockOdsApiFacadeFactory.Setup(x => x.Create())
+                .Returns(Task.FromResult(_mockOdsApiFacade.Object));
+            _controller =
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
+
+            // Act
+            var result = _controller.EditPostSecondaryInstitution(editPostSecondaryInstitutionModel).Result as ContentResult;
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.Content.ShouldContain("Post Secondary Institution Updated");
+        }
+
+        [Test]
+        public void When_Perform_Post_Request_To_EditPostSecondaryInstitution_Return_Error_Response()
+        {
+            // Arrange
+            const string error = "error";
+            var editPostSecondaryInstitutionModel = new EditPostSecondaryInstitutionModel
+            {
+                City = "city"
+            };
+
+            var apiResult = new OdsApiResult { ErrorMessage = error };
+
+            _mockMapper.Setup(x => x.Map<PostSecondaryInstitution>(It.IsAny<EditPostSecondaryInstitutionModel>()))
+                .Returns(new PostSecondaryInstitution());
+            _mockOdsApiFacade.Setup(x => x.EditPostSecondaryInstitution(It.IsAny<PostSecondaryInstitution>()))
+                .Returns(apiResult);
+            _mockOdsApiFacadeFactory.Setup(x => x.Create())
+                .Returns(Task.FromResult(_mockOdsApiFacade.Object));
+            _controller =
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
+
+            // Act
+            var result = _controller.EditPostSecondaryInstitution(editPostSecondaryInstitutionModel).Result as ContentResult;
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.Content.ShouldContain(error);
+        }
+
+        [Test]
         public void When_Perform_Get_Request_To_EditSchoolModal_Return_PartialView_With_Expected_Model()
         {
             // Arrange

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/EducationOrganizationsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/EducationOrganizationsController.cs
@@ -276,6 +276,14 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         }
 
         [HttpPost]
+        [AddTelemetry("Delete Post Secondary Institution")]
+        public async Task<ActionResult> DeletePostSecondaryInstitution(DeleteEducationOrganizationModel model)
+        {
+            var deletionResult = (await _odsApiFacadeFactory.Create()).DeletePostSecondaryInstitution(model.Id);
+            return deletionResult.Success ? JsonSuccess("Post Secondary Institution Removed") : JsonError(deletionResult.ErrorMessage);
+        }
+
+        [HttpPost]
         [AddTelemetry("Delete School")]
         public async Task<ActionResult> DeleteSchool(DeleteEducationOrganizationModel model)
         {

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/EducationOrganizationsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/EducationOrganizationsController.cs
@@ -135,6 +135,30 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
             return editResult.Success ? JsonSuccess("Organization Updated") : JsonError(editResult.ErrorMessage);
         }
 
+        public async Task<ActionResult> EditPostSecondaryInstitutionModal(string id)
+        {
+            var api = await _odsApiFacadeFactory.Create();
+            var postSecondaryInstitution = api.GetPostSecondaryInstitutionById(id);
+            var postSecondaryInstitutionLevelOptions = BuildListWithEmptyOption(api.GetPostSecondaryInstitutionLevels);
+            var administrativeFundingControlOptions = BuildListWithEmptyOption(api.GetAdministrativeFundingControls);
+            var stateOptions = api.GetAllStateAbbreviations();
+
+            var model = _mapper.Map<EditPostSecondaryInstitutionModel>(postSecondaryInstitution);
+            model.PostSecondaryInstitutionLevelOptions = postSecondaryInstitutionLevelOptions;
+            model.AdministrativeFundingControlOptions = administrativeFundingControlOptions;
+            model.StateOptions = stateOptions;
+
+            return PartialView("_EditPostSecondaryInstitutionModal", model);
+        }
+
+        [HttpPost]
+        [AddTelemetry("Edit Post Secondary Institution")]
+        public async Task<ActionResult> EditPostSecondaryInstitution(EditPostSecondaryInstitutionModel model)
+        {
+            var editResult = (await _odsApiFacadeFactory.Create()).EditPostSecondaryInstitution(_mapper.Map<PostSecondaryInstitution>(model));
+            return editResult.Success ? JsonSuccess("Post Secondary Institution Updated") : JsonError(editResult.ErrorMessage);
+        }
+
         public async Task<ActionResult> EditSchoolModal(string id)
         {
             var api = await _odsApiFacadeFactory.Create();

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/AutoMapper/AdminWebMappingProfile.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/AutoMapper/AdminWebMappingProfile.cs
@@ -87,6 +87,16 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure.AutoMapper
                 .ForMember(dst => dst.EducationOrganizationId, opt => opt.MapFrom(src => src.LocalEducationAgencyId))
                 .ForMember(dst => dst.EducationOrganizationCategory, opt => opt.MapFrom(src => EducationOrganizationTypes.Instance.LocalEducationAgency));
 
+            CreateMap<PostSecondaryInstitution, EditPostSecondaryInstitutionModel>()
+                .ForMember(dst => dst.PostSecondaryInstitutionLevelOptions, opt => opt.Ignore())
+                .ForMember(dst => dst.AdministrativeFundingControlOptions, opt => opt.Ignore())
+                .ForMember(dst => dst.StateOptions, opt => opt.Ignore());
+
+            CreateMap<EditPostSecondaryInstitutionModel, PostSecondaryInstitution>()
+                .ForMember(dst => dst.EducationOrganizationId, opt => opt.MapFrom(src => src.PostSecondaryInstitutionId))
+                .ForMember(dst => dst.EducationOrganizationCategory, opt => opt.MapFrom(src => EducationOrganizationTypes.Instance.PostSecondaryInstitution))
+                .ForMember(dst => dst.LocalEducationAgencyId, opt => opt.Ignore());
+
             CreateMap<School, EditSchoolModel>()
                 .ForMember(dst => dst.SchoolId, opt => opt.MapFrom(src => src.EducationOrganizationId))
                 .ForMember(dst => dst.GradeLevelOptions, opt => opt.Ignore())

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/EditPostSecondaryInstitutionModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/EditPostSecondaryInstitutionModel.cs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using FluentValidation;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using EdFi.Ods.AdminApp.Management.Api.Models;
+
+namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
+{
+    public class EditPostSecondaryInstitutionModel
+    {
+        public string Id { get; set; }
+        [Display(Name = "Post Secondary Institution ID")]
+        public int? PostSecondaryInstitutionId { get; set; }
+        [Display(Name = "Name of Institution")]
+        public string Name { get; set; }
+        [Display(Name = "Address")]
+        public string StreetNumberName { get; set; }
+        [Display(Name = "Suite")]
+        public string ApartmentRoomSuiteNumber { get; set; }
+        public string City { get; set; }
+        public string State { get; set; }
+        public string ZipCode { get; set; }
+
+        public string PostSecondaryInstitutionLevel { get; set; }
+        public string AdministrativeFundingControl { get; set; }
+        public List<SelectOptionModel> PostSecondaryInstitutionLevelOptions { get; set; }
+        public List<SelectOptionModel> AdministrativeFundingControlOptions { get; set; }
+        public List<SelectOptionModel> StateOptions { get; set; }
+    }
+
+    public class EditPostSecondaryInstitutionModelValidator : AbstractValidator<EditPostSecondaryInstitutionModel>
+    {
+        public EditPostSecondaryInstitutionModelValidator()
+        {
+            RuleFor(m => m.Name).NotEmpty();
+            RuleFor(m => m.StreetNumberName).NotEmpty();
+            RuleFor(m => m.State).NotEmpty();
+            RuleFor(m => m.City).NotEmpty();
+            RuleFor(m => m.ZipCode).NotEmpty();
+        }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_DeleteOrganizationModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_DeleteOrganizationModal.cshtml
@@ -44,25 +44,37 @@ See the LICENSE and NOTICES files in the project root for more information.
         $(".delete-lea-link").click(function () {
             var name = $(this).attr("data-name");
             var id = $(this).attr("data-id");
-            ShowDeleteEdOrgModal(name, id, "@(Html.Raw(Url.Action("DeleteLocalEducationAgency", "EducationOrganizations")))", false);
+            ShowDeleteEdOrgModal(name, id, "@(Html.Raw(Url.Action("DeleteLocalEducationAgency", "EducationOrganizations")))", 'LEA');
+        });
+
+        $(".delete-psi-link").click(function () {
+            var name = $(this).attr("data-name");
+            var id = $(this).attr("data-id");
+            ShowDeleteEdOrgModal(name, id, "@(Html.Raw(Url.Action("DeletePostSecondaryInstitution", "EducationOrganizations")))", 'PSI');
         });
 
         $(".delete-school-link").click(function () {
             var name = $(this).attr("data-name");
             var id = $(this).attr("data-id");
-            ShowDeleteEdOrgModal(name, id, "@(Html.Raw(Url.Action("DeleteSchool", "EducationOrganizations")))", true);
+            ShowDeleteEdOrgModal(name, id, "@(Html.Raw(Url.Action("DeleteSchool", "EducationOrganizations")))", 'School');
         });
     });
 
-    function ShowDeleteEdOrgModal(organizationName, organizationId, url, isSchool) {
+    function ShowDeleteEdOrgModal(organizationName, organizationId, url, organizationType) {
         var $deleteEdOrgModal = $("#delete-edorg-modal");
         $deleteEdOrgModal.find("form").attr("action", url);
         $deleteEdOrgModal.find("#delete-edorg-name").text(organizationName);
         $deleteEdOrgModal.find("#delete-edorg-id").val(organizationId);
-        if (isSchool) {
-            $deleteEdOrgModal.find("#delete-modal-title").text("Delete School");
-        } else {
-            $deleteEdOrgModal.find("#delete-modal-title").text("Delete Local Education Agency");
+        switch (organizationType) {
+            case 'LEA':
+                $deleteEdOrgModal.find("#delete-modal-title").text("Delete Local Education Agency");
+                break;
+            case 'PSI':
+                $deleteEdOrgModal.find("#delete-modal-title").text("Delete Post Secondary Institution");
+                break;
+            case 'School':
+                $deleteEdOrgModal.find("#delete-modal-title").text("Delete School");
+                break;
         }
         $deleteEdOrgModal.modal("show");
     }

--- a/Application/EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_EditPostSecondaryInstitutionModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_EditPostSecondaryInstitutionModal.cshtml
@@ -1,0 +1,40 @@
+@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations.EditPostSecondaryInstitutionModel
+
+<div id="add-psi-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="editPSIModal" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Edit Post Secondary Institution</h4>
+            </div>
+            <div class="modal-body center-block text-center">
+                @using (Html.BeginForm("EditPostSecondaryInstitution", "EducationOrganizations", new { id = "editPostSecondaryFormModal" }))
+                {
+                    @Html.Input(m => m.Id).Hide()
+                    @Html.Input(m => m.PostSecondaryInstitutionId).Hide()
+                    @Html.ValidationBlock()
+                    @Html.SelectListBlock(m => m.PostSecondaryInstitutionLevel, Model.PostSecondaryInstitutionLevelOptions, x => new SelectListItem { Text = x.DisplayText, Value = x.Value, Selected = Model.PostSecondaryInstitutionLevel == x.Value})
+                    @Html.SelectListBlock(m => m.AdministrativeFundingControl, Model.AdministrativeFundingControlOptions, x => new SelectListItem { Text = x.DisplayText, Value = x.Value, Selected = Model.AdministrativeFundingControl == x.Value })
+                    @Html.InputBlock(m => m.Name)
+                    @Html.InputBlock(m => m.StreetNumberName)
+                    @Html.InputBlock(m => m.ApartmentRoomSuiteNumber)
+                    @Html.InputBlock(m => m.City)
+                    @Html.SelectListBlock(m => m.State, Model.StateOptions, x => new SelectListItem { Text = x.DisplayText, Value = x.Value, Selected = Model.State == x.Value })
+                    @Html.InputBlock(m => m.ZipCode)
+                }
+            </div>
+            <div class="modal-footer">
+                @Html.CancelModalButton()
+                @Html.SaveButton("Save Changes").AppendSpinner("edit-psi-spinner")
+            </div>
+        </div>
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_EditPostSecondaryInstitutionModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_EditPostSecondaryInstitutionModal.cshtml
@@ -16,7 +16,7 @@ See the LICENSE and NOTICES files in the project root for more information.
                 <h4 class="modal-title">Edit Post Secondary Institution</h4>
             </div>
             <div class="modal-body center-block text-center">
-                @using (Html.BeginForm("EditPostSecondaryInstitution", "EducationOrganizations", new { id = "editPostSecondaryFormModal" }))
+                @using (Html.BeginForm("EditPostSecondaryInstitution", "EducationOrganizations"))
                 {
                     @Html.Input(m => m.Id).Hide()
                     @Html.Input(m => m.PostSecondaryInstitutionId).Hide()

--- a/Application/EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_PostSecondaryInstitutions.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_PostSecondaryInstitutions.cshtml
@@ -35,7 +35,7 @@ See the LICENSE and NOTICES files in the project root for more information.
             </div>
 
             <div class="col-lg-6 text-right">
-                <a href="javascript:void(0)" class="loads-ajax-modal" data-url="@Url.Action("EditLocalEducationAgencyModal", "EducationOrganizations", new {id = postSecondaryInstitution.Id})"> <span class="fa fa-pencil action-icons"></span></a>
+                <a href="javascript:void(0)" class="loads-ajax-modal" data-url="@Url.Action("EditPostSecondaryInstitutionModal", "EducationOrganizations", new {id = postSecondaryInstitution.Id})"> <span class="fa fa-pencil action-icons"></span></a>
                 @if (!schools.Any())
                 {
                     <a href="javascript:void(0)" class="delete-psi-link" data-id="@postSecondaryInstitution.Id" data-name="@postSecondaryInstitution.Name"> <span class="fa fa-trash-o action-icons"></span></a>


### PR DESCRIPTION
**NOTE - This should be merged in after [*181 PR*](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-AdminApp/pull/181) has been merged to AA-1315**  
**Description**
- Added EditPostSecondaryInstitutionModel. Added mappings for EditPostSecondaryInstitutionModel.Added EditPostSecondaryInstitution actions. Added unit tests for EditPostSecondaryInstitution.Added EditPostSecondaryInstitutionModal view. Refactored to use EditPostSecondaryInstitution action in PostSecondaryInstitutions.
- Added DeletePostSecondaryInstitution action. Added unit tests for DeletePostSecondaryInstitution.Refactored _DeleteOrganizationModal view to take PostSecondaryInstitution into account.