### PR TITLE
[AA-1315] - Edit and Delete PostSecondaryInstitution School implementation

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Controllers/EducationOrganizationsControllerTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Controllers/EducationOrganizationsControllerTests.cs
@@ -577,6 +577,10 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             const string postSecondaryInstitutionLevelValue = "Namespace#Four or more years";
             const string administrativeFundingControl = "Private School";
             const string administrativeFundingControlValue = "Namespace#Private School";
+            const string accreditationStatus = "Test Accreditation Status";
+            const string accreditationStatusValue = "Namespace#Test Accreditation Status";
+            const string federalLocaleCode = "Test Federal Locale Code";
+            const string federalLocaleCodeValue = "Namespace#Test Federal Locale Code";
 
             _mockOdsApiFacade.Setup(x => x.GetAllPsiSchools()).Returns(schools);
             _mockOdsApiFacade.Setup(x => x.GetLocalEducationAgenciesByPage(0, Page<LocalEducationAgency>.DefaultPageSize + 1)).Returns(leas);
@@ -591,6 +595,12 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             _mockOdsApiFacade.Setup(x => x.GetAdministrativeFundingControls())
                 .Returns(new List<SelectOptionModel>
                     {new SelectOptionModel {DisplayText = administrativeFundingControl, Value = administrativeFundingControlValue}});
+            _mockOdsApiFacade.Setup(x => x.GetAccreditationStatusOptions())
+                .Returns(new List<SelectOptionModel>
+                    {new SelectOptionModel {DisplayText = accreditationStatus, Value = accreditationStatusValue}});
+            _mockOdsApiFacade.Setup(x => x.GetFederalLocaleCodes())
+                .Returns(new List<SelectOptionModel>
+                    {new SelectOptionModel {DisplayText = federalLocaleCode, Value = federalLocaleCodeValue}});
             _controller =
                 new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
 
@@ -612,8 +622,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
 
             var addPostSecondaryInstitutionModel = model.AddPostSecondaryInstitutionModel;
             addPostSecondaryInstitutionModel.ShouldNotBeNull();
-            addPostSecondaryInstitutionModel.PostSecondaryInstitutionLevelOptions.Count.ShouldBe(2);
-            addPostSecondaryInstitutionModel.AdministrativeFundingControlOptions.Count.ShouldBe(2);
+            addPostSecondaryInstitutionModel.PostSecondaryInstitutionLevelOptions.Count.ShouldBeGreaterThan(0);
+            addPostSecondaryInstitutionModel.AdministrativeFundingControlOptions.Count.ShouldBeGreaterThan(0);
             var postSecondaryInstitutionLevelOption = addPostSecondaryInstitutionModel.PostSecondaryInstitutionLevelOptions.Single(x => x.Value != null);
             postSecondaryInstitutionLevelOption.DisplayText.ShouldBe(postSecondaryInstitutionLevel);
             postSecondaryInstitutionLevelOption.Value.ShouldBe(postSecondaryInstitutionLevelValue);

--- a/Application/EdFi.Ods.AdminApp.Management/Api/IOdsApiFacade.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/IOdsApiFacade.cs
@@ -28,7 +28,9 @@ namespace EdFi.Ods.AdminApp.Management.Api
         LocalEducationAgency GetLocalEducationAgencyById(string id);
         OdsApiResult EditLocalEducationAgency(LocalEducationAgency editedLocalEducationAgency);
         School GetSchoolById(string id);
+        PsiSchool GetPsiSchoolById(string id);
         OdsApiResult EditSchool(School editedSchool);
+        OdsApiResult EditPsiSchool(PsiSchool model);
         List<SelectOptionModel> GetAllStateAbbreviations();
         List<SelectOptionModel> GetPostSecondaryInstitutionLevels();
         List<SelectOptionModel> GetAdministrativeFundingControls();

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiFacade.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiFacade.cs
@@ -199,7 +199,19 @@ namespace EdFi.Ods.AdminApp.Management.Api
             return _mapper.Map<Models.School>(school);
         }
 
+        public Models.PsiSchool GetPsiSchoolById(string id)
+        {
+            var school = _restClient.GetById<School>(ResourcePaths.SchoolById, id);
+            return _mapper.Map<Models.PsiSchool>(school);
+        }
+
         public OdsApiResult EditSchool(Models.School model)
+        {
+            var request = _mapper.Map<School>(model);
+            return _restClient.PutResource(request, ResourcePaths.Schools, request.Id);
+        }
+
+        public OdsApiResult EditPsiSchool(Models.PsiSchool model)
         {
             var request = _mapper.Map<School>(model);
             return _restClient.PutResource(request, ResourcePaths.Schools, request.Id);

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/EducationOrganizationsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/EducationOrganizationsController.cs
@@ -181,6 +181,32 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
             return editResult.Success ? JsonSuccess("School Updated") : JsonError(editResult.ErrorMessage);
         }
 
+        public async Task<ActionResult> EditPsiSchoolModal(string id)
+        {
+            var api = await _odsApiFacadeFactory.Create();
+            var psiSchool = api.GetPsiSchoolById(id);
+            var gradeLevelOptions = api.GetAllGradeLevels();
+            var stateOptions = api.GetAllStateAbbreviations();
+            var federalLocaleCodeOptions = api.GetFederalLocaleCodes();
+            var accreditationStatusOptions = api.GetAccreditationStatusOptions();
+
+            var model = _mapper.Map<EditPsiSchoolModel>(psiSchool);
+            model.GradeLevelOptions = gradeLevelOptions;
+            model.StateOptions = stateOptions;
+            model.FederalLocaleCodeOptions = federalLocaleCodeOptions;
+            model.AccreditationStatusOptions = accreditationStatusOptions;
+
+            return PartialView("_EditPsiSchoolModal", model);
+        }
+
+        [HttpPost]
+        [AddTelemetry("Edit Post Secondary Institution School")]
+        public async Task<ActionResult> EditPsiSchool(EditPsiSchoolModel model)
+        {
+            var editResult = (await _odsApiFacadeFactory.Create()).EditPsiSchool(_mapper.Map<PsiSchool>(model));
+            return editResult.Success ? JsonSuccess("School Updated") : JsonError(editResult.ErrorMessage);
+        }
+
         public async Task<ActionResult> LocalEducationAgencyList(int pageNumber)
         {
             var api = await _odsApiFacadeFactory.Create();

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/EducationOrganizationsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/EducationOrganizationsController.cs
@@ -187,8 +187,8 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
             var psiSchool = api.GetPsiSchoolById(id);
             var gradeLevelOptions = api.GetAllGradeLevels();
             var stateOptions = api.GetAllStateAbbreviations();
-            var federalLocaleCodeOptions = api.GetFederalLocaleCodes();
-            var accreditationStatusOptions = api.GetAccreditationStatusOptions();
+            var federalLocaleCodeOptions = BuildListWithEmptyOption(api.GetFederalLocaleCodes);
+            var accreditationStatusOptions = BuildListWithEmptyOption(api.GetAccreditationStatusOptions);
 
             var model = _mapper.Map<EditPsiSchoolModel>(psiSchool);
             model.GradeLevelOptions = gradeLevelOptions;
@@ -263,8 +263,8 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
                 {
                     GradeLevelOptions = api.GetAllGradeLevels(),
                     StateOptions = api.GetAllStateAbbreviations(),
-                    FederalLocaleCodeOptions = api.GetFederalLocaleCodes(),
-                    AccreditationStatusOptions = api.GetAccreditationStatusOptions(),
+                    FederalLocaleCodeOptions = BuildListWithEmptyOption(api.GetFederalLocaleCodes),
+                    AccreditationStatusOptions = BuildListWithEmptyOption(api.GetAccreditationStatusOptions),
                     RequiredApiDataExist = requiredApiDataExist
                 },
                 AddPostSecondaryInstitutionModel = new AddPostSecondaryInstitutionModel

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/AutoMapper/AdminWebMappingProfile.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/AutoMapper/AdminWebMappingProfile.cs
@@ -116,7 +116,8 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure.AutoMapper
             CreateMap<EditPsiSchoolModel, PsiSchool>()
                 .ForMember(dst => dst.EducationOrganizationId, opt => opt.MapFrom(src => src.SchoolId))
                 .ForMember(dst => dst.EducationOrganizationCategory, opt => opt.MapFrom(src => EducationOrganizationTypes.Instance.SchoolType))
-                .ForMember(dst => dst.ImprovingSchool, opt => opt.Ignore());
+                .ForMember(dst => dst.ImprovingSchool, opt => opt.Ignore())
+                .ForMember(dst => dst.LocalEducationAgencyId, opt => opt.Ignore());
 
             CreateMap<Descriptor, DescriptorModel>();
 

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/AutoMapper/AdminWebMappingProfile.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/AutoMapper/AdminWebMappingProfile.cs
@@ -105,7 +105,19 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure.AutoMapper
             CreateMap<EditSchoolModel, School>()
                 .ForMember(dst => dst.EducationOrganizationId, opt => opt.MapFrom(src => src.SchoolId))
                 .ForMember(dst => dst.EducationOrganizationCategory, opt => opt.MapFrom(src => EducationOrganizationTypes.Instance.SchoolType));
-                
+
+            CreateMap<PsiSchool, EditPsiSchoolModel>()
+                .ForMember(dst => dst.SchoolId, opt => opt.MapFrom(src => src.EducationOrganizationId))
+                .ForMember(dst => dst.GradeLevelOptions, opt => opt.Ignore())
+                .ForMember(dst => dst.StateOptions, opt => opt.Ignore())
+                .ForMember(dst => dst.AccreditationStatusOptions, opt => opt.Ignore())
+                .ForMember(dst => dst.FederalLocaleCodeOptions, opt => opt.Ignore());
+
+            CreateMap<EditPsiSchoolModel, PsiSchool>()
+                .ForMember(dst => dst.EducationOrganizationId, opt => opt.MapFrom(src => src.SchoolId))
+                .ForMember(dst => dst.EducationOrganizationCategory, opt => opt.MapFrom(src => EducationOrganizationTypes.Instance.SchoolType))
+                .ForMember(dst => dst.ImprovingSchool, opt => opt.Ignore());
+
             CreateMap<Descriptor, DescriptorModel>();
 
             CreateMap<AuthorizationStrategy, Management.ClaimSetEditor.AuthorizationStrategy>()

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/EditPsiSchoolModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/EditPsiSchoolModel.cs
@@ -17,6 +17,6 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
         public List<SelectOptionModel> FederalLocaleCodeOptions { get; set; }
     }
 
-    public class EditPsiSchoolModelValidator : EditSchoolModelValidator<EditPsiSchoolModel>
+    public class EditPsiSchoolModelValidator : EditSchoolModelValidatorBase<EditPsiSchoolModel>
     { }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/EditPsiSchoolModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/EditPsiSchoolModel.cs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Generic;
+using EdFi.Ods.AdminApp.Management.Api.Models;
+
+namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
+{
+    public class EditPsiSchoolModel: EditSchoolModel
+    {
+        public int? PostSecondaryInstitutionId { get; set; }
+        public string AccreditationStatus { get; set; }
+        public List<SelectOptionModel> AccreditationStatusOptions { get; set; }
+        public string FederalLocaleCode { get; set; }
+        public List<SelectOptionModel> FederalLocaleCodeOptions { get; set; }
+    }
+
+    public class EditPsiSchoolModelValidator : EditSchoolModelValidator<EditPsiSchoolModel>
+    { }
+}

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/EditSchoolModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/EditSchoolModel.cs
@@ -30,7 +30,7 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
         public List<SelectOptionModel> StateOptions { get; set; }
     }
 
-    public class EditSchoolModelValidator : AbstractValidator<EditSchoolModel>
+    public class EditSchoolModelValidator<T> : AbstractValidator<T> where T : EditSchoolModel
     {
         public EditSchoolModelValidator()
         {

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/EditSchoolModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/EditSchoolModel.cs
@@ -30,9 +30,12 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
         public List<SelectOptionModel> StateOptions { get; set; }
     }
 
-    public class EditSchoolModelValidator<T> : AbstractValidator<T> where T : EditSchoolModel
+    public class EditSchoolModelValidator : EditSchoolModelValidatorBase<EditSchoolModel>
+    { }
+
+    public abstract class EditSchoolModelValidatorBase<T> : AbstractValidator<T> where T : EditSchoolModel
     {
-        public EditSchoolModelValidator()
+        protected EditSchoolModelValidatorBase()
         {
             RuleFor(x => x.Name).NotEmpty();
             RuleFor(x => x.StreetNumberName).NotEmpty();

--- a/Application/EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_AddPsiSchoolModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_AddPsiSchoolModal.cshtml
@@ -30,11 +30,11 @@ See the LICENSE and NOTICES files in the project root for more information.
                 @Html.InputBlock(m => m.City).AddClass("reset-included")
                 @Html.SelectListBlock(m => m.State, Model.StateOptions, x => new SelectListItem { Text = x.DisplayText, Value = x.Value })
                 @Html.InputBlock(m => m.ZipCode).AddClass("reset-included")
-                if (Model.AccreditationStatusOptions.Any())
+                if (Model.AccreditationStatusOptions.Count > 1)
                 {
                     @Html.SelectListBlock(m => m.AccreditationStatus, Model.AccreditationStatusOptions, x => new SelectListItem { Text = x.DisplayText, Value = x.Value })
                 }
-                if (Model.FederalLocaleCodeOptions.Any())
+                if (Model.FederalLocaleCodeOptions.Count > 1)
                 {
                     @Html.SelectListBlock(m => m.FederalLocaleCode, Model.FederalLocaleCodeOptions, x => new SelectListItem { Text = x.DisplayText, Value = x.Value })
                 }

--- a/Application/EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_EditPsiSchoolModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_EditPsiSchoolModal.cshtml
@@ -1,0 +1,48 @@
+@*
+SPDX-License-Identifier: Apache-2.0
+Licensed to the Ed-Fi Alliance under one or more agreements.
+The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+See the LICENSE and NOTICES files in the project root for more information.
+*@
+
+@using EdFi.Ods.AdminApp.Web.Helpers
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations.EditPsiSchoolModel
+
+<div id="edit-psi-school-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="editPsiSchoolModal" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Edit School</h4>
+            </div>
+            <div class="modal-body center-block text-center">
+                @using (Html.BeginForm("EditPsiSchool", "EducationOrganizations"))
+                {
+                    @Html.Input(m => m.Id).Hide()
+                    @Html.Input(m => m.SchoolId).Hide()
+                    @Html.Input(m => m.PostSecondaryInstitutionId).Hide()
+                    @Html.ValidationBlock()
+                    @Html.MultiSelectListBlock(m => m.GradeLevels, Model.GradeLevelOptions, x => new SelectListItem { Text = x.DisplayText, Value = x.Value, Selected = (Model.GradeLevels != null && Model.GradeLevels.Contains(x.Value)) })
+                    @Html.InputBlock(m => m.Name)
+                    @Html.InputBlock(m => m.StreetNumberName)
+                    @Html.InputBlock(m => m.ApartmentRoomSuiteNumber)
+                    @Html.InputBlock(m => m.City)
+                    @Html.SelectListBlock(m => m.State, Model.StateOptions, x => new SelectListItem { Text = x.DisplayText, Value = x.Value, Selected = Model.State == x.Value })
+                    @Html.InputBlock(m => m.ZipCode)
+                    if (Model.AccreditationStatusOptions.Any())
+                    {
+                        @Html.SelectListBlock(m => m.AccreditationStatus, Model.AccreditationStatusOptions, x => new SelectListItem { Text = x.DisplayText, Value = x.Value, Selected = Model.AccreditationStatus == x.Value})
+                    }
+                    if (Model.FederalLocaleCodeOptions.Any())
+                    {
+                        @Html.SelectListBlock(m => m.FederalLocaleCode, Model.FederalLocaleCodeOptions, x => new SelectListItem { Text = x.DisplayText, Value = x.Value, Selected = Model.FederalLocaleCode == x.Value})
+                    }
+                }
+            </div>
+            <div class="modal-footer">
+                @Html.CancelModalButton()
+                @Html.SaveButton("Save Changes").AppendSpinner("edit-psi-school-spinner")
+            </div>
+        </div>
+    </div>
+</div>

--- a/Application/EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_EditPsiSchoolModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_EditPsiSchoolModal.cshtml
@@ -29,11 +29,11 @@ See the LICENSE and NOTICES files in the project root for more information.
                     @Html.InputBlock(m => m.City)
                     @Html.SelectListBlock(m => m.State, Model.StateOptions, x => new SelectListItem { Text = x.DisplayText, Value = x.Value, Selected = Model.State == x.Value })
                     @Html.InputBlock(m => m.ZipCode)
-                    if (Model.AccreditationStatusOptions.Any())
+                    if (Model.AccreditationStatusOptions.Count > 1)
                     {
                         @Html.SelectListBlock(m => m.AccreditationStatus, Model.AccreditationStatusOptions, x => new SelectListItem { Text = x.DisplayText, Value = x.Value, Selected = Model.AccreditationStatus == x.Value})
                     }
-                    if (Model.FederalLocaleCodeOptions.Any())
+                    if (Model.FederalLocaleCodeOptions.Count > 1)
                     {
                         @Html.SelectListBlock(m => m.FederalLocaleCode, Model.FederalLocaleCodeOptions, x => new SelectListItem { Text = x.DisplayText, Value = x.Value, Selected = Model.FederalLocaleCode == x.Value})
                     }

--- a/Application/EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_PostSecondaryInstitutions.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_PostSecondaryInstitutions.cshtml
@@ -61,7 +61,7 @@ See the LICENSE and NOTICES files in the project root for more information.
                     <h7>@school.Name</h7>
                 </div>
                 <div class="col-lg-4 text-right">
-                    <a href="javascript:void(0)" class="loads-ajax-modal" data-url="@Url.Action("EditSchoolModal", "EducationOrganizations", new {id = school.Id})"> <span class="fa fa-pencil action-icons"></span></a>
+                    <a href="javascript:void(0)" class="loads-ajax-modal" data-url="@Url.Action("EditPsiSchoolModal", "EducationOrganizations", new {id = school.Id})"> <span class="fa fa-pencil action-icons"></span></a>
                     <a href="javascript:void(0)" class="delete-school-link" data-id="@school.Id" data-name="@school.Name"> <span class="fa fa-trash-o action-icons"></span></a>
                 </div>
             }

--- a/Application/EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_PostSecondaryInstitutions.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_PostSecondaryInstitutions.cshtml
@@ -62,7 +62,7 @@ See the LICENSE and NOTICES files in the project root for more information.
                 </div>
                 <div class="col-lg-4 text-right">
                     <a href="javascript:void(0)" class="loads-ajax-modal" data-url="@Url.Action("EditSchoolModal", "EducationOrganizations", new {id = school.Id})"> <span class="fa fa-pencil action-icons"></span></a>
-                    <a href="javascript:void(0)" class="delete-psi-school-link" data-id="@school.Id" data-name="@school.Name"> <span class="fa fa-trash-o action-icons"></span></a>
+                    <a href="javascript:void(0)" class="delete-school-link" data-id="@school.Id" data-name="@school.Name"> <span class="fa fa-trash-o action-icons"></span></a>
                 </div>
             }
             <div class="col-lg-12 text-right padding-bottom-5">

--- a/Application/EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_PostSecondaryInstitutions.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_PostSecondaryInstitutions.cshtml
@@ -75,7 +75,7 @@ See the LICENSE and NOTICES files in the project root for more information.
 }
 
 
-@Html.PagingControl(Url.Action("PostSecondaryInstitutions", "EducationOrganizations"), Model.PostSecondaryInstitutions)
+@Html.PagingControl(Url.Action("PostSecondaryInstitutionsList", "EducationOrganizations"), Model.PostSecondaryInstitutions)
 
 @{ await Html.RenderPartialAsync("_DeleteOrganizationModal", new DeleteEducationOrganizationModel()); }
 @{ await Html.RenderPartialAsync("_AddPostSecondaryInstitutionModal", Model.AddPostSecondaryInstitutionModel); }


### PR DESCRIPTION
**NOTE: This should be merged in after [*182 PR*](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-AdminApp/pull/182) has been merged to AA-1315**
**Description**
- Refactored EditSchoolModel to use the existing school properties via inheritance. 
Added EditPsiSchoolModel. Added mappings for EditPsiSchoolModel. PsiSchools.
- Added GetPsiSchoolById and EditPsiSchool api actions to OdsApiFacade.Added actions for editing Psi Schools in EducationOrganizationController. Added unit tests for EducationOrganizationController EditPsiSchool flow.Added_EditPsiSchoolModal view for the edit psi school flow.
- Refactored to use the existing class for Delete PSI School flow avoiding duplication of the existing Delete School flow.