### PR TITLE
Admin App version bump to 2.3.0 after 2.2.1 release

### DIFF
--- a/.teamcity/_Self/Project.kt
+++ b/.teamcity/_Self/Project.kt
@@ -18,7 +18,7 @@ object AdminAppProject : Project({
             +:refs/(pull/*)/merge
         """.trimIndent())
         param("teamcity.ui.settings.readOnly","true")
-        param("adminApp.version", "2.2.1")
+        param("adminApp.version", "2.3.0")
     }
 
     subProject(web.AdminAppWebProject)


### PR DESCRIPTION
**NOTE: This PR should be merged only after the 2.2.1 release artifacts have been accepted. Also, the build-counters and installer version parameters on TeamCity need to be checked for the correct state before merging this PR**

**Description**
Admin App version bump to 2.3.0 after 2.2.1 release