### PR TITLE
[AA-1262] Phase out async FluentValidation rules

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Models/AddLocalEducationAgencyModelTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Models/AddLocalEducationAgencyModelTests.cs
@@ -82,8 +82,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
             validator.ShouldValidate(_addLocalEducationAgencyModel);
 
             EducationOrganizationValidationHelper
-                .ProposedEducationOrganizationIdIsNotInUse(_addLocalEducationAgencyModel.LocalEducationAgencyId.Value, _mockOdsApiFacade.Object)
-                .ShouldBeTrue();
+                .ProposedEducationOrganizationIdIsInUse(_addLocalEducationAgencyModel.LocalEducationAgencyId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeFalse();
         }
 
         [Test]
@@ -121,8 +121,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
             });
 
             EducationOrganizationValidationHelper
-                .ProposedEducationOrganizationIdIsNotInUse(_addLocalEducationAgencyModel.LocalEducationAgencyId.Value, _mockOdsApiFacade.Object)
-                .ShouldBeFalse();
+                .ProposedEducationOrganizationIdIsInUse(_addLocalEducationAgencyModel.LocalEducationAgencyId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeTrue();
         }
 
         [Test]
@@ -160,8 +160,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
             });
 
             EducationOrganizationValidationHelper
-                .ProposedEducationOrganizationIdIsNotInUse(_addLocalEducationAgencyModel.LocalEducationAgencyId.Value, _mockOdsApiFacade.Object)
-                .ShouldBeFalse();
+                .ProposedEducationOrganizationIdIsInUse(_addLocalEducationAgencyModel.LocalEducationAgencyId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeTrue();
         }
 
         [Test]
@@ -199,8 +199,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
             });
 
             EducationOrganizationValidationHelper
-                .ProposedEducationOrganizationIdIsNotInUse(_addLocalEducationAgencyModel.LocalEducationAgencyId.Value, _mockOdsApiFacade.Object)
-                .ShouldBeFalse();
+                .ProposedEducationOrganizationIdIsInUse(_addLocalEducationAgencyModel.LocalEducationAgencyId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeTrue();
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Models/AddLocalEducationAgencyModelTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Models/AddLocalEducationAgencyModelTests.cs
@@ -4,12 +4,12 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using EdFi.Ods.AdminApp.Management.Api;
 using EdFi.Ods.AdminApp.Management.Api.Models;
 using EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations;
 using Moq;
 using NUnit.Framework;
+using Shouldly;
 
 namespace EdFi.Ods.AdminApp.Management.Tests.Models
 {
@@ -17,14 +17,12 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
     public class AddLocalEducationAgencyModelTests
     {
         private Mock<IOdsApiFacade> _mockOdsApiFacade;
-        private Mock<IOdsApiFacadeFactory> _mockOdsApiFacadeFactory;
         private AddLocalEducationAgencyModel _addLocalEducationAgencyModel;
         private const int Id = 1;
 
         [SetUp]
         public void Init()
         {
-            _mockOdsApiFacadeFactory = new Mock<IOdsApiFacadeFactory>();
             _mockOdsApiFacade = new Mock<IOdsApiFacade>();
 
             _addLocalEducationAgencyModel = new AddLocalEducationAgencyModel
@@ -42,7 +40,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
         public void ShouldNotValidateAddLocalEducationAgencyModelIfLocalEducationAgencyIdIsEmpty()
         {
             _addLocalEducationAgencyModel.LocalEducationAgencyId = null;
-            var validator = new AddLocalEducationAgencyModelValidator(_mockOdsApiFacadeFactory.Object);
+            var validator = new AddLocalEducationAgencyModelValidator();
             validator.ShouldNotValidate(_addLocalEducationAgencyModel, "'Local Education Organization ID' must not be empty.");
         }
 
@@ -80,11 +78,12 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
                 existingPsiWithDifferentId
             });
 
-            _mockOdsApiFacadeFactory.Setup(x => x.Create())
-                .Returns(Task.FromResult(_mockOdsApiFacade.Object));
-
-            var validator = new AddLocalEducationAgencyModelValidator(_mockOdsApiFacadeFactory.Object);
+            var validator = new AddLocalEducationAgencyModelValidator();
             validator.ShouldValidate(_addLocalEducationAgencyModel);
+
+            EducationOrganizationValidationHelper
+                .ProposedEducationOrganizationIdIsNotInUse(_addLocalEducationAgencyModel.LocalEducationAgencyId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeTrue();
         }
 
         [Test]
@@ -121,11 +120,9 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
                 existingPsiWithDifferentId
             });
 
-            _mockOdsApiFacadeFactory.Setup(x => x.Create())
-                .Returns(Task.FromResult(_mockOdsApiFacade.Object));
-
-            var validator = new AddLocalEducationAgencyModelValidator(_mockOdsApiFacadeFactory.Object);
-            validator.ShouldNotValidate(_addLocalEducationAgencyModel, "This 'Local Education Organization ID' is already associated with another Education Organization. Please provide a unique value.");
+            EducationOrganizationValidationHelper
+                .ProposedEducationOrganizationIdIsNotInUse(_addLocalEducationAgencyModel.LocalEducationAgencyId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeFalse();
         }
 
         [Test]
@@ -162,11 +159,9 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
                 existingPsiWithDifferentId
             });
 
-            _mockOdsApiFacadeFactory.Setup(x => x.Create())
-                .Returns(Task.FromResult(_mockOdsApiFacade.Object));
-
-            var validator = new AddLocalEducationAgencyModelValidator(_mockOdsApiFacadeFactory.Object);
-            validator.ShouldNotValidate(_addLocalEducationAgencyModel, "This 'Local Education Organization ID' is already associated with another Education Organization. Please provide a unique value.");
+            EducationOrganizationValidationHelper
+                .ProposedEducationOrganizationIdIsNotInUse(_addLocalEducationAgencyModel.LocalEducationAgencyId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeFalse();
         }
 
         [Test]
@@ -203,11 +198,9 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
                 existingPsiWithSameId
             });
 
-            _mockOdsApiFacadeFactory.Setup(x => x.Create())
-                .Returns(Task.FromResult(_mockOdsApiFacade.Object));
-
-            var validator = new AddLocalEducationAgencyModelValidator(_mockOdsApiFacadeFactory.Object);
-            validator.ShouldNotValidate(_addLocalEducationAgencyModel, "This 'Local Education Organization ID' is already associated with another Education Organization. Please provide a unique value.");
+            EducationOrganizationValidationHelper
+                .ProposedEducationOrganizationIdIsNotInUse(_addLocalEducationAgencyModel.LocalEducationAgencyId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeFalse();
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Models/AddPostSecondaryInstitutionModelTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Models/AddPostSecondaryInstitutionModelTests.cs
@@ -10,6 +10,7 @@ using EdFi.Ods.AdminApp.Management.Api.Models;
 using EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations;
 using Moq;
 using NUnit.Framework;
+using Shouldly;
 
 namespace EdFi.Ods.AdminApp.Management.Tests.Models
 {
@@ -17,14 +18,12 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
     public class AddPostSecondaryInstitutionModelTests
     {
         private Mock<IOdsApiFacade> _mockOdsApiFacade;
-        private Mock<IOdsApiFacadeFactory> _mockOdsApiFacadeFactory;
         private AddPostSecondaryInstitutionModel _addPostSecondaryInstitutionModel;
         private const int Id = 1;
 
         [SetUp]
         public void Init()
         {
-            _mockOdsApiFacadeFactory = new Mock<IOdsApiFacadeFactory>();
             _mockOdsApiFacade = new Mock<IOdsApiFacade>();
 
             _addPostSecondaryInstitutionModel = new AddPostSecondaryInstitutionModel
@@ -42,7 +41,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
         public void ShouldNotValidateAddPostSecondaryInstitutionModelIfPostSecondaryInstitutionIdIsEmpty()
         {
             _addPostSecondaryInstitutionModel.PostSecondaryInstitutionId = null;
-            var validator = new AddPostSecondaryInstitutionModelValidator(_mockOdsApiFacadeFactory.Object);
+            var validator = new AddPostSecondaryInstitutionModelValidator();
             validator.ShouldNotValidate(_addPostSecondaryInstitutionModel, "'Post-Secondary Institution ID' must not be empty.");
         }
 
@@ -80,11 +79,12 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
                 existingPsiWithDifferentId
             });
 
-            _mockOdsApiFacadeFactory.Setup(x => x.Create())
-                .Returns(Task.FromResult(_mockOdsApiFacade.Object));
-
-            var validator = new AddPostSecondaryInstitutionModelValidator(_mockOdsApiFacadeFactory.Object);
+            var validator = new AddPostSecondaryInstitutionModelValidator();
             validator.ShouldValidate(_addPostSecondaryInstitutionModel);
+
+            EducationOrganizationValidationHelper
+                .ProposedEducationOrganizationIdIsNotInUse(_addPostSecondaryInstitutionModel.PostSecondaryInstitutionId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeTrue();
         }
 
         [Test]
@@ -121,11 +121,9 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
                 existingPsiWithSameId
             });
 
-            _mockOdsApiFacadeFactory.Setup(x => x.Create())
-                .Returns(Task.FromResult(_mockOdsApiFacade.Object));
-
-            var validator = new AddPostSecondaryInstitutionModelValidator(_mockOdsApiFacadeFactory.Object);
-            validator.ShouldNotValidate(_addPostSecondaryInstitutionModel, "This 'Post-Secondary Institution ID' is already associated with another Education Organization. Please provide a unique value.");
+            EducationOrganizationValidationHelper
+                .ProposedEducationOrganizationIdIsNotInUse(_addPostSecondaryInstitutionModel.PostSecondaryInstitutionId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeFalse();
         }
 
         [Test]
@@ -162,11 +160,9 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
                 existingPsiWithDifferentId
             });
 
-            _mockOdsApiFacadeFactory.Setup(x => x.Create())
-                .Returns(Task.FromResult(_mockOdsApiFacade.Object));
-
-            var validator = new AddPostSecondaryInstitutionModelValidator(_mockOdsApiFacadeFactory.Object);
-            validator.ShouldNotValidate(_addPostSecondaryInstitutionModel, "This 'Post-Secondary Institution ID' is already associated with another Education Organization. Please provide a unique value.");
+            EducationOrganizationValidationHelper
+                .ProposedEducationOrganizationIdIsNotInUse(_addPostSecondaryInstitutionModel.PostSecondaryInstitutionId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeFalse();
         }
 
         [Test]
@@ -203,11 +199,9 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
                 existingPsiWithDifferentId
             });
 
-            _mockOdsApiFacadeFactory.Setup(x => x.Create())
-                .Returns(Task.FromResult(_mockOdsApiFacade.Object));
-
-            var validator = new AddPostSecondaryInstitutionModelValidator(_mockOdsApiFacadeFactory.Object);
-            validator.ShouldNotValidate(_addPostSecondaryInstitutionModel, "This 'Post-Secondary Institution ID' is already associated with another Education Organization. Please provide a unique value.");
+            EducationOrganizationValidationHelper
+                .ProposedEducationOrganizationIdIsNotInUse(_addPostSecondaryInstitutionModel.PostSecondaryInstitutionId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeFalse();
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Models/AddPostSecondaryInstitutionModelTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Models/AddPostSecondaryInstitutionModelTests.cs
@@ -83,8 +83,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
             validator.ShouldValidate(_addPostSecondaryInstitutionModel);
 
             EducationOrganizationValidationHelper
-                .ProposedEducationOrganizationIdIsNotInUse(_addPostSecondaryInstitutionModel.PostSecondaryInstitutionId.Value, _mockOdsApiFacade.Object)
-                .ShouldBeTrue();
+                .ProposedEducationOrganizationIdIsInUse(_addPostSecondaryInstitutionModel.PostSecondaryInstitutionId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeFalse();
         }
 
         [Test]
@@ -122,8 +122,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
             });
 
             EducationOrganizationValidationHelper
-                .ProposedEducationOrganizationIdIsNotInUse(_addPostSecondaryInstitutionModel.PostSecondaryInstitutionId.Value, _mockOdsApiFacade.Object)
-                .ShouldBeFalse();
+                .ProposedEducationOrganizationIdIsInUse(_addPostSecondaryInstitutionModel.PostSecondaryInstitutionId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeTrue();
         }
 
         [Test]
@@ -161,8 +161,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
             });
 
             EducationOrganizationValidationHelper
-                .ProposedEducationOrganizationIdIsNotInUse(_addPostSecondaryInstitutionModel.PostSecondaryInstitutionId.Value, _mockOdsApiFacade.Object)
-                .ShouldBeFalse();
+                .ProposedEducationOrganizationIdIsInUse(_addPostSecondaryInstitutionModel.PostSecondaryInstitutionId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeTrue();
         }
 
         [Test]
@@ -200,8 +200,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
             });
 
             EducationOrganizationValidationHelper
-                .ProposedEducationOrganizationIdIsNotInUse(_addPostSecondaryInstitutionModel.PostSecondaryInstitutionId.Value, _mockOdsApiFacade.Object)
-                .ShouldBeFalse();
+                .ProposedEducationOrganizationIdIsInUse(_addPostSecondaryInstitutionModel.PostSecondaryInstitutionId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeTrue();
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Models/AddPsiSchoolModelTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Models/AddPsiSchoolModelTests.cs
@@ -125,8 +125,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
             validator.ShouldValidate(_addPsiSchoolModel);
 
             EducationOrganizationValidationHelper
-                .ProposedEducationOrganizationIdIsNotInUse(_addPsiSchoolModel.SchoolId.Value, _mockOdsApiFacade.Object)
-                .ShouldBeTrue();
+                .ProposedEducationOrganizationIdIsInUse(_addPsiSchoolModel.SchoolId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeFalse();
         }
 
         [Test]
@@ -164,8 +164,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
             });
 
             EducationOrganizationValidationHelper
-                .ProposedEducationOrganizationIdIsNotInUse(_addPsiSchoolModel.SchoolId.Value, _mockOdsApiFacade.Object)
-                .ShouldBeFalse();
+                .ProposedEducationOrganizationIdIsInUse(_addPsiSchoolModel.SchoolId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeTrue();
         }
 
         [Test]
@@ -203,8 +203,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
             });
 
             EducationOrganizationValidationHelper
-                .ProposedEducationOrganizationIdIsNotInUse(_addPsiSchoolModel.SchoolId.Value, _mockOdsApiFacade.Object)
-                .ShouldBeFalse();
+                .ProposedEducationOrganizationIdIsInUse(_addPsiSchoolModel.SchoolId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeTrue();
         }
 
         [Test]
@@ -242,8 +242,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
             });
 
             EducationOrganizationValidationHelper
-                .ProposedEducationOrganizationIdIsNotInUse(_addPsiSchoolModel.SchoolId.Value, _mockOdsApiFacade.Object)
-                .ShouldBeFalse();
+                .ProposedEducationOrganizationIdIsInUse(_addPsiSchoolModel.SchoolId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeTrue();
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Models/AddPsiSchoolModelTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Models/AddPsiSchoolModelTests.cs
@@ -10,6 +10,7 @@ using EdFi.Ods.AdminApp.Management.Api.Models;
 using EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations;
 using Moq;
 using NUnit.Framework;
+using Shouldly;
 
 namespace EdFi.Ods.AdminApp.Management.Tests.Models
 {
@@ -17,14 +18,12 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
     public class AddPsiSchoolModelTests
     {
         private Mock<IOdsApiFacade> _mockOdsApiFacade;
-        private Mock<IOdsApiFacadeFactory> _mockOdsApiFacadeFactory;
         private AddPsiSchoolModel _addPsiSchoolModel;
         private const int Id = 1;
 
         [SetUp]
         public void Init()
         {
-            _mockOdsApiFacadeFactory = new Mock<IOdsApiFacadeFactory>();
             _mockOdsApiFacade = new Mock<IOdsApiFacade>();
            
             _addPsiSchoolModel = new AddPsiSchoolModel
@@ -44,7 +43,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
         public void ShouldNotValidateAddSchoolModelIfSchoolIdIsEmpty()
         {
             _addPsiSchoolModel.SchoolId = null;
-            var validator = new AddPsiSchoolModelValidator(_mockOdsApiFacadeFactory.Object);
+            var validator = new AddPsiSchoolModelValidator();
             validator.ShouldNotValidate(_addPsiSchoolModel, "'School ID' must not be empty.");
         }
 
@@ -84,10 +83,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
                 existingPsiWithDifferentId
             });
 
-            _mockOdsApiFacadeFactory.Setup(x => x.Create())
-                .Returns(Task.FromResult(_mockOdsApiFacade.Object));
-
-            var validator = new AddPsiSchoolModelValidator(_mockOdsApiFacadeFactory.Object);
+            var validator = new AddPsiSchoolModelValidator();
             validator.ShouldNotValidate(_addPsiSchoolModel, "You must choose at least one grade level");
         }
 
@@ -125,11 +121,12 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
                 existingPsiWithDifferentId
             });
 
-            _mockOdsApiFacadeFactory.Setup(x => x.Create())
-                .Returns(Task.FromResult(_mockOdsApiFacade.Object));
-
-            var validator = new AddPsiSchoolModelValidator(_mockOdsApiFacadeFactory.Object);
+            var validator = new AddPsiSchoolModelValidator();
             validator.ShouldValidate(_addPsiSchoolModel);
+
+            EducationOrganizationValidationHelper
+                .ProposedEducationOrganizationIdIsNotInUse(_addPsiSchoolModel.SchoolId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeTrue();
         }
 
         [Test]
@@ -166,11 +163,9 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
                 existingPsiWithDifferentId
             });
 
-            _mockOdsApiFacadeFactory.Setup(x => x.Create())
-                .Returns(Task.FromResult(_mockOdsApiFacade.Object));
-
-            var validator = new AddPsiSchoolModelValidator(_mockOdsApiFacadeFactory.Object);
-            validator.ShouldNotValidate(_addPsiSchoolModel, "This 'School ID' is already associated with another Education Organization. Please provide a unique value.");
+            EducationOrganizationValidationHelper
+                .ProposedEducationOrganizationIdIsNotInUse(_addPsiSchoolModel.SchoolId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeFalse();
         }
 
         [Test]
@@ -207,11 +202,9 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
                 existingPsiWithDifferentId
             });
 
-            _mockOdsApiFacadeFactory.Setup(x => x.Create())
-                .Returns(Task.FromResult(_mockOdsApiFacade.Object));
-
-            var validator = new AddPsiSchoolModelValidator(_mockOdsApiFacadeFactory.Object);
-            validator.ShouldNotValidate(_addPsiSchoolModel, "This 'School ID' is already associated with another Education Organization. Please provide a unique value.");
+            EducationOrganizationValidationHelper
+                .ProposedEducationOrganizationIdIsNotInUse(_addPsiSchoolModel.SchoolId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeFalse();
         }
 
         [Test]
@@ -248,11 +241,9 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
                 existingPsiWithSameId
             });
 
-            _mockOdsApiFacadeFactory.Setup(x => x.Create())
-                .Returns(Task.FromResult(_mockOdsApiFacade.Object));
-
-            var validator = new AddPsiSchoolModelValidator(_mockOdsApiFacadeFactory.Object);
-            validator.ShouldNotValidate(_addPsiSchoolModel, "This 'School ID' is already associated with another Education Organization. Please provide a unique value.");
+            EducationOrganizationValidationHelper
+                .ProposedEducationOrganizationIdIsNotInUse(_addPsiSchoolModel.SchoolId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeFalse();
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Models/AddSchoolModelTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Models/AddSchoolModelTests.cs
@@ -124,8 +124,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
             validator.ShouldValidate(_addSchoolModel);
 
             EducationOrganizationValidationHelper
-                .ProposedEducationOrganizationIdIsNotInUse(_addSchoolModel.SchoolId.Value, _mockOdsApiFacade.Object)
-                .ShouldBeTrue();
+                .ProposedEducationOrganizationIdIsInUse(_addSchoolModel.SchoolId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeFalse();
         }
 
         [Test]
@@ -163,8 +163,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
             });
 
             EducationOrganizationValidationHelper
-                .ProposedEducationOrganizationIdIsNotInUse(_addSchoolModel.SchoolId.Value, _mockOdsApiFacade.Object)
-                .ShouldBeFalse();
+                .ProposedEducationOrganizationIdIsInUse(_addSchoolModel.SchoolId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeTrue();
         }
 
         [Test]
@@ -202,8 +202,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
             });
 
             EducationOrganizationValidationHelper
-                .ProposedEducationOrganizationIdIsNotInUse(_addSchoolModel.SchoolId.Value, _mockOdsApiFacade.Object)
-                .ShouldBeFalse();
+                .ProposedEducationOrganizationIdIsInUse(_addSchoolModel.SchoolId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeTrue();
         }
 
         [Test]
@@ -241,8 +241,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
             });
 
             EducationOrganizationValidationHelper
-                .ProposedEducationOrganizationIdIsNotInUse(_addSchoolModel.SchoolId.Value, _mockOdsApiFacade.Object)
-                .ShouldBeFalse();
+                .ProposedEducationOrganizationIdIsInUse(_addSchoolModel.SchoolId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeTrue();
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Models/AddSchoolModelTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Models/AddSchoolModelTests.cs
@@ -4,12 +4,12 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using EdFi.Ods.AdminApp.Management.Api;
 using EdFi.Ods.AdminApp.Management.Api.Models;
 using EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations;
 using Moq;
 using NUnit.Framework;
+using Shouldly;
 
 namespace EdFi.Ods.AdminApp.Management.Tests.Models
 {
@@ -17,14 +17,12 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
     public class AddSchoolModelTests
     {
         private Mock<IOdsApiFacade> _mockOdsApiFacade;
-        private Mock<IOdsApiFacadeFactory> _mockOdsApiFacadeFactory;
         private AddSchoolModel _addSchoolModel;
         private const int Id = 1;
 
         [SetUp]
         public void Init()
         {
-            _mockOdsApiFacadeFactory = new Mock<IOdsApiFacadeFactory>();
             _mockOdsApiFacade = new Mock<IOdsApiFacade>();
            
             _addSchoolModel = new AddSchoolModel
@@ -44,7 +42,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
         public void ShouldNotValidateAddSchoolModelIfSchoolIdIsEmpty()
         {
             _addSchoolModel.SchoolId = null;
-            var validator = new AddSchoolModelValidator(_mockOdsApiFacadeFactory.Object);
+            var validator = new AddSchoolModelValidator();
             validator.ShouldNotValidate(_addSchoolModel, "'School ID' must not be empty.");
         }
 
@@ -84,10 +82,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
                 existingPsiWithDifferentId
             });
 
-            _mockOdsApiFacadeFactory.Setup(x => x.Create())
-                .Returns(Task.FromResult(_mockOdsApiFacade.Object));
-
-            var validator = new AddSchoolModelValidator(_mockOdsApiFacadeFactory.Object);
+            var validator = new AddSchoolModelValidator();
             validator.ShouldNotValidate(_addSchoolModel, "You must choose at least one grade level");
         }
 
@@ -125,11 +120,12 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
                 existingPsiWithDifferentId
             });
 
-            _mockOdsApiFacadeFactory.Setup(x => x.Create())
-                .Returns(Task.FromResult(_mockOdsApiFacade.Object));
-
-            var validator = new AddSchoolModelValidator(_mockOdsApiFacadeFactory.Object);
+            var validator = new AddSchoolModelValidator();
             validator.ShouldValidate(_addSchoolModel);
+
+            EducationOrganizationValidationHelper
+                .ProposedEducationOrganizationIdIsNotInUse(_addSchoolModel.SchoolId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeTrue();
         }
 
         [Test]
@@ -166,11 +162,9 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
                 existingPsiWithDifferentId
             });
 
-            _mockOdsApiFacadeFactory.Setup(x => x.Create())
-                .Returns(Task.FromResult(_mockOdsApiFacade.Object));
-
-            var validator = new AddSchoolModelValidator(_mockOdsApiFacadeFactory.Object);
-            validator.ShouldNotValidate(_addSchoolModel, "This 'School ID' is already associated with another Education Organization. Please provide a unique value.");
+            EducationOrganizationValidationHelper
+                .ProposedEducationOrganizationIdIsNotInUse(_addSchoolModel.SchoolId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeFalse();
         }
 
         [Test]
@@ -207,11 +201,9 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
                 existingPsiWithDifferentId
             });
 
-            _mockOdsApiFacadeFactory.Setup(x => x.Create())
-                .Returns(Task.FromResult(_mockOdsApiFacade.Object));
-
-            var validator = new AddSchoolModelValidator(_mockOdsApiFacadeFactory.Object);
-            validator.ShouldNotValidate(_addSchoolModel, "This 'School ID' is already associated with another Education Organization. Please provide a unique value.");
+            EducationOrganizationValidationHelper
+                .ProposedEducationOrganizationIdIsNotInUse(_addSchoolModel.SchoolId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeFalse();
         }
 
         [Test]
@@ -248,11 +240,9 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Models
                 existingPsiWithSameId
             });
 
-            _mockOdsApiFacadeFactory.Setup(x => x.Create())
-                .Returns(Task.FromResult(_mockOdsApiFacade.Object));
-
-            var validator = new AddSchoolModelValidator(_mockOdsApiFacadeFactory.Object);
-            validator.ShouldNotValidate(_addSchoolModel, "This 'School ID' is already associated with another Education Organization. Please provide a unique value.");
+            EducationOrganizationValidationHelper
+                .ProposedEducationOrganizationIdIsNotInUse(_addSchoolModel.SchoolId.Value, _mockOdsApiFacade.Object)
+                .ShouldBeFalse();
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/EducationOrganizationsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/EducationOrganizationsController.cs
@@ -77,9 +77,11 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         [AddTelemetry("Add Local Education Agency")]
         public async Task<ActionResult> AddLocalEducationAgency(AddLocalEducationAgencyModel viewModel)
         {
+            var apiFacade = await _odsApiFacadeFactory.Create();
+
             var model = _mapper.Map<LocalEducationAgency>(viewModel);
             model.Id = Guid.Empty.ToString();
-            var addResult = (await _odsApiFacadeFactory.Create()).AddLocalEducationAgency(model);
+            var addResult = apiFacade.AddLocalEducationAgency(model);
             return addResult.Success ? JsonSuccess("Organization Added") : JsonError(addResult.ErrorMessage);
         }
 
@@ -87,9 +89,11 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         [AddTelemetry("Add Post-Secondary Institution")]
         public async Task<ActionResult> AddPostSecondaryInstitution(AddPostSecondaryInstitutionModel viewModel)
         {
+            var apiFacade = await _odsApiFacadeFactory.Create();
+
             var model = _mapper.Map<PostSecondaryInstitution>(viewModel);
             model.Id = Guid.Empty.ToString();
-            var addResult = (await _odsApiFacadeFactory.Create()).AddPostSecondaryInstitution(model);
+            var addResult = apiFacade.AddPostSecondaryInstitution(model);
             return addResult.Success ? JsonSuccess("Post-Secondary Institution Added") : JsonError(addResult.ErrorMessage);
         }
 
@@ -97,9 +101,11 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         [AddTelemetry("Add School")]
         public async Task<ActionResult> AddSchool(AddSchoolModel viewModel)
         {
+            var apiFacade = await _odsApiFacadeFactory.Create();
+
             var model = _mapper.Map<School>(viewModel);
             model.Id = Guid.Empty.ToString();
-            var addResult = (await _odsApiFacadeFactory.Create()).AddSchool(model);
+            var addResult = apiFacade.AddSchool(model);
             return addResult.Success ? JsonSuccess("School Added") : JsonError(addResult.ErrorMessage);
         }
 
@@ -107,9 +113,11 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         [AddTelemetry("Add Post-Secondary Institution School")]
         public async Task<ActionResult> AddPsiSchool(AddPsiSchoolModel viewModel)
         {
+            var apiFacade = await _odsApiFacadeFactory.Create();
+
             var model = _mapper.Map<PsiSchool>(viewModel);
             model.Id = Guid.Empty.ToString();
-            var addResult = (await _odsApiFacadeFactory.Create()).AddPsiSchool(model);
+            var addResult = apiFacade.AddPsiSchool(model);
             return addResult.Success ? JsonSuccess("School Added") : JsonError(addResult.ErrorMessage);
         }
 

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/EducationOrganizationsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/EducationOrganizationsController.cs
@@ -85,7 +85,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
 
             if (leaId != null)
             {
-                if (!ProposedEducationOrganizationIdIsNotInUse(leaId.Value, apiFacade))
+                if (ProposedEducationOrganizationIdIsInUse(leaId.Value, apiFacade))
                     return ValidationFailureResult(
                         "LocalEducationAgencyId",
                         "This 'Local Education Organization ID' is already associated with " +
@@ -108,7 +108,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
 
             if (psiId != null)
             {
-                if (!ProposedEducationOrganizationIdIsNotInUse(psiId.Value, apiFacade))
+                if (ProposedEducationOrganizationIdIsInUse(psiId.Value, apiFacade))
                     return ValidationFailureResult(
                         "PostSecondaryInstitutionId",
                         "This 'Post-Secondary Institution ID' is already associated with " +
@@ -131,7 +131,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
 
             if (schoolId != null)
             {
-                if (!ProposedEducationOrganizationIdIsNotInUse(schoolId.Value, apiFacade))
+                if (ProposedEducationOrganizationIdIsInUse(schoolId.Value, apiFacade))
                     return ValidationFailureResult(
                             "SchoolId",
                             "This 'School ID' is already associated with another " +
@@ -154,7 +154,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
 
             if (schoolId != null)
             {
-                if (!ProposedEducationOrganizationIdIsNotInUse(schoolId.Value, apiFacade))
+                if (ProposedEducationOrganizationIdIsInUse(schoolId.Value, apiFacade))
                     return ValidationFailureResult(
                         "SchoolId",
                         "This 'School ID' is already associated with another " +

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/EducationOrganizationsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/EducationOrganizationsController.cs
@@ -19,6 +19,8 @@ using EdFi.Ods.AdminApp.Web.ActionFilters;
 using EdFi.Ods.AdminApp.Web.Display.Pagination;
 using EdFi.Ods.AdminApp.Web.Display.TabEnumeration;
 using EdFi.Ods.AdminApp.Web.Infrastructure;
+using Newtonsoft.Json;
+using static EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations.EducationOrganizationValidationHelper;
 
 namespace EdFi.Ods.AdminApp.Web.Controllers
 {
@@ -79,6 +81,17 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         {
             var apiFacade = await _odsApiFacadeFactory.Create();
 
+            var leaId = viewModel.LocalEducationAgencyId;
+
+            if (leaId != null)
+            {
+                if (!ProposedEducationOrganizationIdIsNotInUse(leaId.Value, apiFacade))
+                    return ValidationFailureResult(
+                        "LocalEducationAgencyId",
+                        "This 'Local Education Organization ID' is already associated with " +
+                        "another Education Organization. Please provide a unique value.");
+            }
+
             var model = _mapper.Map<LocalEducationAgency>(viewModel);
             model.Id = Guid.Empty.ToString();
             var addResult = apiFacade.AddLocalEducationAgency(model);
@@ -90,6 +103,17 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         public async Task<ActionResult> AddPostSecondaryInstitution(AddPostSecondaryInstitutionModel viewModel)
         {
             var apiFacade = await _odsApiFacadeFactory.Create();
+
+            var psiId = viewModel.PostSecondaryInstitutionId;
+
+            if (psiId != null)
+            {
+                if (!ProposedEducationOrganizationIdIsNotInUse(psiId.Value, apiFacade))
+                    return ValidationFailureResult(
+                        "PostSecondaryInstitutionId",
+                        "This 'Post-Secondary Institution ID' is already associated with " +
+                        "another Education Organization. Please provide a unique value.");
+            }
 
             var model = _mapper.Map<PostSecondaryInstitution>(viewModel);
             model.Id = Guid.Empty.ToString();
@@ -103,6 +127,17 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         {
             var apiFacade = await _odsApiFacadeFactory.Create();
 
+            var schoolId = viewModel.SchoolId;
+
+            if (schoolId != null)
+            {
+                if (!ProposedEducationOrganizationIdIsNotInUse(schoolId.Value, apiFacade))
+                    return ValidationFailureResult(
+                            "SchoolId",
+                            "This 'School ID' is already associated with another " +
+                            "Education Organization. Please provide a unique value.");
+            }
+
             var model = _mapper.Map<School>(viewModel);
             model.Id = Guid.Empty.ToString();
             var addResult = apiFacade.AddSchool(model);
@@ -114,6 +149,17 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         public async Task<ActionResult> AddPsiSchool(AddPsiSchoolModel viewModel)
         {
             var apiFacade = await _odsApiFacadeFactory.Create();
+
+            var schoolId = viewModel.SchoolId;
+
+            if (schoolId != null)
+            {
+                if (!ProposedEducationOrganizationIdIsNotInUse(schoolId.Value, apiFacade))
+                    return ValidationFailureResult(
+                        "SchoolId",
+                        "This 'School ID' is already associated with another " +
+                        "Education Organization. Please provide a unique value.");
+            }
 
             var model = _mapper.Map<PsiSchool>(viewModel);
             model.Id = Guid.Empty.ToString();
@@ -346,6 +392,20 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
             };
             selectOptionList.AddRange(getSelectOptionList.Invoke());
             return selectOptionList;
+        }
+
+        private ActionResult ValidationFailureResult(string modelStateKey, string errorMessage)
+        {
+            ModelState.AddModelError(modelStateKey, errorMessage);
+
+            return new ContentResult
+            {
+                Content = JsonConvert.SerializeObject(
+                    ModelState,
+                    new JsonSerializerSettings {ReferenceLoopHandling = ReferenceLoopHandling.Ignore}),
+                ContentType = "application/json",
+                StatusCode = 400
+            };
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddLocalEducationAgencyModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddLocalEducationAgencyModel.cs
@@ -45,14 +45,13 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
             RuleFor(m => m.City).NotEmpty();
             RuleFor(m => m.ZipCode).NotEmpty();
             RuleFor(m => m.LocalEducationAgencyId)
-                .Must(i => ProposedEducationOrganizationIdIsNotInUse(i, apiFacade)).When(m => m.LocalEducationAgencyId != null)
+                .Must(i => ProposedEducationOrganizationIdIsNotInUse(i.Value, apiFacade)).When(m => m.LocalEducationAgencyId != null)
                 .WithMessage("This 'Local Education Organization ID' is already associated with another Education Organization. Please provide a unique value.");
         }
 
-        public static bool ProposedEducationOrganizationIdIsNotInUse(int? id, IOdsApiFacade apiFacade)
+        public static bool ProposedEducationOrganizationIdIsNotInUse(int id, IOdsApiFacade apiFacade)
         {
-            return id != null
-                   && apiFacade.GetAllPostSecondaryInstitutions().Find(x => x.EducationOrganizationId == id) == null
+            return apiFacade.GetAllPostSecondaryInstitutions().Find(x => x.EducationOrganizationId == id) == null
                    && apiFacade.GetAllLocalEducationAgencies().Find(x => x.EducationOrganizationId == id) == null
                    && apiFacade.GetAllSchools().Find(x => x.EducationOrganizationId == id) == null;
         }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddLocalEducationAgencyModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddLocalEducationAgencyModel.cs
@@ -45,15 +45,8 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
             RuleFor(m => m.City).NotEmpty();
             RuleFor(m => m.ZipCode).NotEmpty();
             RuleFor(m => m.LocalEducationAgencyId)
-                .Must(i => ProposedEducationOrganizationIdIsNotInUse(i.Value, apiFacade)).When(m => m.LocalEducationAgencyId != null)
+                .Must(i => EducationOrganizationValidationHelper.ProposedEducationOrganizationIdIsNotInUse(i.Value, apiFacade)).When(m => m.LocalEducationAgencyId != null)
                 .WithMessage("This 'Local Education Organization ID' is already associated with another Education Organization. Please provide a unique value.");
-        }
-
-        public static bool ProposedEducationOrganizationIdIsNotInUse(int id, IOdsApiFacade apiFacade)
-        {
-            return apiFacade.GetAllPostSecondaryInstitutions().Find(x => x.EducationOrganizationId == id) == null
-                   && apiFacade.GetAllLocalEducationAgencies().Find(x => x.EducationOrganizationId == id) == null
-                   && apiFacade.GetAllSchools().Find(x => x.EducationOrganizationId == id) == null;
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddLocalEducationAgencyModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddLocalEducationAgencyModel.cs
@@ -6,7 +6,6 @@
 using FluentValidation;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using EdFi.Ods.AdminApp.Management.Api;
 using EdFi.Ods.AdminApp.Management.Api.Models;
 
 namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
@@ -35,18 +34,14 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
 
     public class AddLocalEducationAgencyModelValidator : AbstractValidator<AddLocalEducationAgencyModel>
     {
-        public AddLocalEducationAgencyModelValidator(IOdsApiFacadeFactory odsApiFacadeFactory)
+        public AddLocalEducationAgencyModelValidator()
         {
-            var apiFacade = odsApiFacadeFactory.Create().GetAwaiter().GetResult();
             RuleFor(m => m.LocalEducationAgencyId).NotEmpty();
             RuleFor(m => m.Name).NotEmpty();
             RuleFor(m => m.StreetNumberName).NotEmpty();
             RuleFor(m => m.State).NotEmpty();
             RuleFor(m => m.City).NotEmpty();
             RuleFor(m => m.ZipCode).NotEmpty();
-            RuleFor(m => m.LocalEducationAgencyId)
-                .Must(i => EducationOrganizationValidationHelper.ProposedEducationOrganizationIdIsNotInUse(i.Value, apiFacade)).When(m => m.LocalEducationAgencyId != null)
-                .WithMessage("This 'Local Education Organization ID' is already associated with another Education Organization. Please provide a unique value.");
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddLocalEducationAgencyModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddLocalEducationAgencyModel.cs
@@ -45,11 +45,11 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
             RuleFor(m => m.City).NotEmpty();
             RuleFor(m => m.ZipCode).NotEmpty();
             RuleFor(m => m.LocalEducationAgencyId)
-                .Must(i => BeUniqueId(i, apiFacade)).When(m => m.LocalEducationAgencyId != null)
+                .Must(i => ProposedEducationOrganizationIdIsNotInUse(i, apiFacade)).When(m => m.LocalEducationAgencyId != null)
                 .WithMessage("This 'Local Education Organization ID' is already associated with another Education Organization. Please provide a unique value.");
         }
 
-        public static bool BeUniqueId(int? id, IOdsApiFacade apiFacade)
+        public static bool ProposedEducationOrganizationIdIsNotInUse(int? id, IOdsApiFacade apiFacade)
         {
             return id != null
                    && apiFacade.GetAllPostSecondaryInstitutions().Find(x => x.EducationOrganizationId == id) == null

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddLocalEducationAgencyModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddLocalEducationAgencyModel.cs
@@ -35,11 +35,9 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
 
     public class AddLocalEducationAgencyModelValidator : AbstractValidator<AddLocalEducationAgencyModel>
     {
-        private readonly IOdsApiFacade _apiFacade;
-
         public AddLocalEducationAgencyModelValidator(IOdsApiFacadeFactory odsApiFacadeFactory)
         {
-            _apiFacade = odsApiFacadeFactory.Create().GetAwaiter().GetResult();
+            var apiFacade = odsApiFacadeFactory.Create().GetAwaiter().GetResult();
             RuleFor(m => m.LocalEducationAgencyId).NotEmpty();
             RuleFor(m => m.Name).NotEmpty();
             RuleFor(m => m.StreetNumberName).NotEmpty();
@@ -47,16 +45,16 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
             RuleFor(m => m.City).NotEmpty();
             RuleFor(m => m.ZipCode).NotEmpty();
             RuleFor(m => m.LocalEducationAgencyId)
-                .Must(BeUniqueId).When(m => m.LocalEducationAgencyId != null)
+                .Must(i => BeUniqueId(i, apiFacade)).When(m => m.LocalEducationAgencyId != null)
                 .WithMessage("This 'Local Education Organization ID' is already associated with another Education Organization. Please provide a unique value.");
         }
 
-        private bool BeUniqueId(int? id)
+        public static bool BeUniqueId(int? id, IOdsApiFacade apiFacade)
         {
             return id != null
-                   && _apiFacade.GetAllPostSecondaryInstitutions().Find(x => x.EducationOrganizationId == id) == null
-                   && _apiFacade.GetAllLocalEducationAgencies().Find(x => x.EducationOrganizationId == id) == null
-                   && _apiFacade.GetAllSchools().Find(x => x.EducationOrganizationId == id) == null;
+                   && apiFacade.GetAllPostSecondaryInstitutions().Find(x => x.EducationOrganizationId == id) == null
+                   && apiFacade.GetAllLocalEducationAgencies().Find(x => x.EducationOrganizationId == id) == null
+                   && apiFacade.GetAllSchools().Find(x => x.EducationOrganizationId == id) == null;
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddPostSecondaryInstitutionModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddPostSecondaryInstitutionModel.cs
@@ -48,11 +48,11 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
             RuleFor(m => m.City).NotEmpty();
             RuleFor(m => m.ZipCode).NotEmpty();
             RuleFor(m => m.PostSecondaryInstitutionId)
-                .Must(i => BeUniqueId(i, _apiFacade)).When(m => m.PostSecondaryInstitutionId != null)
+                .Must(i => ProposedEducationOrganizationIdIsNotInUse(i, _apiFacade)).When(m => m.PostSecondaryInstitutionId != null)
                 .WithMessage("This 'Post-Secondary Institution ID' is already associated with another Education Organization. Please provide a unique value.");
         }
 
-        public static bool BeUniqueId(int? id, IOdsApiFacade apiFacade)
+        public static bool ProposedEducationOrganizationIdIsNotInUse(int? id, IOdsApiFacade apiFacade)
         {
             return id != null
                    && apiFacade.GetAllPostSecondaryInstitutions().Find(x => x.EducationOrganizationId == id) == null

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddPostSecondaryInstitutionModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddPostSecondaryInstitutionModel.cs
@@ -6,7 +6,6 @@
 using FluentValidation;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using EdFi.Ods.AdminApp.Management.Api;
 using EdFi.Ods.AdminApp.Management.Api.Models;
 
 namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
@@ -36,18 +35,14 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
 
     public class AddPostSecondaryInstitutionModelValidator : AbstractValidator<AddPostSecondaryInstitutionModel>
     {
-        public AddPostSecondaryInstitutionModelValidator(IOdsApiFacadeFactory odsApiFacadeFactory)
+        public AddPostSecondaryInstitutionModelValidator()
         {
-            var apiFacade = odsApiFacadeFactory.Create().GetAwaiter().GetResult();
             RuleFor(m => m.PostSecondaryInstitutionId).NotEmpty();
             RuleFor(m => m.Name).NotEmpty();
             RuleFor(m => m.StreetNumberName).NotEmpty();
             RuleFor(m => m.State).NotEmpty();
             RuleFor(m => m.City).NotEmpty();
             RuleFor(m => m.ZipCode).NotEmpty();
-            RuleFor(m => m.PostSecondaryInstitutionId)
-                .Must(i => EducationOrganizationValidationHelper.ProposedEducationOrganizationIdIsNotInUse(i.Value, apiFacade)).When(m => m.PostSecondaryInstitutionId != null)
-                .WithMessage("This 'Post-Secondary Institution ID' is already associated with another Education Organization. Please provide a unique value.");
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddPostSecondaryInstitutionModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddPostSecondaryInstitutionModel.cs
@@ -48,16 +48,16 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
             RuleFor(m => m.City).NotEmpty();
             RuleFor(m => m.ZipCode).NotEmpty();
             RuleFor(m => m.PostSecondaryInstitutionId)
-                .Must(BeUniqueId).When(m => m.PostSecondaryInstitutionId != null)
+                .Must(i => BeUniqueId(i, _apiFacade)).When(m => m.PostSecondaryInstitutionId != null)
                 .WithMessage("This 'Post-Secondary Institution ID' is already associated with another Education Organization. Please provide a unique value.");
         }
 
-        private bool BeUniqueId(int? id)
+        public static bool BeUniqueId(int? id, IOdsApiFacade apiFacade)
         {
             return id != null
-                   && _apiFacade.GetAllPostSecondaryInstitutions().Find(x => x.EducationOrganizationId == id) == null
-                   && _apiFacade.GetAllLocalEducationAgencies().Find(x => x.EducationOrganizationId == id) == null
-                   && _apiFacade.GetAllSchools().Find(x => x.EducationOrganizationId == id) == null;
+                   && apiFacade.GetAllPostSecondaryInstitutions().Find(x => x.EducationOrganizationId == id) == null
+                   && apiFacade.GetAllLocalEducationAgencies().Find(x => x.EducationOrganizationId == id) == null
+                   && apiFacade.GetAllSchools().Find(x => x.EducationOrganizationId == id) == null;
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddPostSecondaryInstitutionModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddPostSecondaryInstitutionModel.cs
@@ -46,15 +46,8 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
             RuleFor(m => m.City).NotEmpty();
             RuleFor(m => m.ZipCode).NotEmpty();
             RuleFor(m => m.PostSecondaryInstitutionId)
-                .Must(i => ProposedEducationOrganizationIdIsNotInUse(i.Value, apiFacade)).When(m => m.PostSecondaryInstitutionId != null)
+                .Must(i => EducationOrganizationValidationHelper.ProposedEducationOrganizationIdIsNotInUse(i.Value, apiFacade)).When(m => m.PostSecondaryInstitutionId != null)
                 .WithMessage("This 'Post-Secondary Institution ID' is already associated with another Education Organization. Please provide a unique value.");
-        }
-
-        public static bool ProposedEducationOrganizationIdIsNotInUse(int id, IOdsApiFacade apiFacade)
-        {
-            return apiFacade.GetAllPostSecondaryInstitutions().Find(x => x.EducationOrganizationId == id) == null
-                   && apiFacade.GetAllLocalEducationAgencies().Find(x => x.EducationOrganizationId == id) == null
-                   && apiFacade.GetAllSchools().Find(x => x.EducationOrganizationId == id) == null;
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddPostSecondaryInstitutionModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddPostSecondaryInstitutionModel.cs
@@ -48,14 +48,13 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
             RuleFor(m => m.City).NotEmpty();
             RuleFor(m => m.ZipCode).NotEmpty();
             RuleFor(m => m.PostSecondaryInstitutionId)
-                .Must(i => ProposedEducationOrganizationIdIsNotInUse(i, _apiFacade)).When(m => m.PostSecondaryInstitutionId != null)
+                .Must(i => ProposedEducationOrganizationIdIsNotInUse(i.Value, _apiFacade)).When(m => m.PostSecondaryInstitutionId != null)
                 .WithMessage("This 'Post-Secondary Institution ID' is already associated with another Education Organization. Please provide a unique value.");
         }
 
-        public static bool ProposedEducationOrganizationIdIsNotInUse(int? id, IOdsApiFacade apiFacade)
+        public static bool ProposedEducationOrganizationIdIsNotInUse(int id, IOdsApiFacade apiFacade)
         {
-            return id != null
-                   && apiFacade.GetAllPostSecondaryInstitutions().Find(x => x.EducationOrganizationId == id) == null
+            return apiFacade.GetAllPostSecondaryInstitutions().Find(x => x.EducationOrganizationId == id) == null
                    && apiFacade.GetAllLocalEducationAgencies().Find(x => x.EducationOrganizationId == id) == null
                    && apiFacade.GetAllSchools().Find(x => x.EducationOrganizationId == id) == null;
         }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddPostSecondaryInstitutionModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddPostSecondaryInstitutionModel.cs
@@ -36,11 +36,9 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
 
     public class AddPostSecondaryInstitutionModelValidator : AbstractValidator<AddPostSecondaryInstitutionModel>
     {
-        private readonly IOdsApiFacade _apiFacade;
-
         public AddPostSecondaryInstitutionModelValidator(IOdsApiFacadeFactory odsApiFacadeFactory)
         {
-            _apiFacade = odsApiFacadeFactory.Create().GetAwaiter().GetResult();
+            var apiFacade = odsApiFacadeFactory.Create().GetAwaiter().GetResult();
             RuleFor(m => m.PostSecondaryInstitutionId).NotEmpty();
             RuleFor(m => m.Name).NotEmpty();
             RuleFor(m => m.StreetNumberName).NotEmpty();
@@ -48,7 +46,7 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
             RuleFor(m => m.City).NotEmpty();
             RuleFor(m => m.ZipCode).NotEmpty();
             RuleFor(m => m.PostSecondaryInstitutionId)
-                .Must(i => ProposedEducationOrganizationIdIsNotInUse(i.Value, _apiFacade)).When(m => m.PostSecondaryInstitutionId != null)
+                .Must(i => ProposedEducationOrganizationIdIsNotInUse(i.Value, apiFacade)).When(m => m.PostSecondaryInstitutionId != null)
                 .WithMessage("This 'Post-Secondary Institution ID' is already associated with another Education Organization. Please provide a unique value.");
         }
 

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddPsiSchoolModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddPsiSchoolModel.cs
@@ -4,8 +4,6 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Collections.Generic;
-using FluentValidation;
-using EdFi.Ods.AdminApp.Management.Api;
 using EdFi.Ods.AdminApp.Management.Api.Models;
 
 namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
@@ -21,8 +19,5 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
 
     public class AddPsiSchoolModelValidator : AddSchoolModelValidatorBase<AddPsiSchoolModel>
     {
-        public AddPsiSchoolModelValidator(IOdsApiFacadeFactory odsApiFacadeFactory)
-            : base(odsApiFacadeFactory) {
-        }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddSchoolModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddSchoolModel.cs
@@ -56,11 +56,11 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
             RuleFor(x => x.ZipCode).NotEmpty();
             RuleFor(x => x.GradeLevels).Must(x => x != null && x.Count > 0).WithMessage("You must choose at least one grade level");
             RuleFor(x => x.SchoolId)
-                .Must(i => BeUniqueId(i, _apiFacade)).When(x => x.SchoolId != null)
+                .Must(i => ProposedEducationOrganizationIdIsNotInUse(i, _apiFacade)).When(x => x.SchoolId != null)
                 .WithMessage("This 'School ID' is already associated with another Education Organization. Please provide a unique value.");
         }
 
-        public static bool BeUniqueId(int? id, IOdsApiFacade apiFacade)
+        public static bool ProposedEducationOrganizationIdIsNotInUse(int? id, IOdsApiFacade apiFacade)
         {
             return id != null
                    && apiFacade.GetAllPostSecondaryInstitutions().Find(x => x.EducationOrganizationId == id) == null

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddSchoolModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddSchoolModel.cs
@@ -56,16 +56,16 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
             RuleFor(x => x.ZipCode).NotEmpty();
             RuleFor(x => x.GradeLevels).Must(x => x != null && x.Count > 0).WithMessage("You must choose at least one grade level");
             RuleFor(x => x.SchoolId)
-                .Must(BeUniqueId).When(x => x.SchoolId != null)
+                .Must(i => BeUniqueId(i, _apiFacade)).When(x => x.SchoolId != null)
                 .WithMessage("This 'School ID' is already associated with another Education Organization. Please provide a unique value.");
         }
 
-        private bool BeUniqueId(int? id)
+        public static bool BeUniqueId(int? id, IOdsApiFacade apiFacade)
         {
             return id != null
-                   && _apiFacade.GetAllPostSecondaryInstitutions().Find(x => x.EducationOrganizationId == id) == null
-                   && _apiFacade.GetAllLocalEducationAgencies().Find(x => x.EducationOrganizationId == id) == null
-                   && _apiFacade.GetAllSchools().Find(x => x.EducationOrganizationId == id) == null;
+                   && apiFacade.GetAllPostSecondaryInstitutions().Find(x => x.EducationOrganizationId == id) == null
+                   && apiFacade.GetAllLocalEducationAgencies().Find(x => x.EducationOrganizationId == id) == null
+                   && apiFacade.GetAllSchools().Find(x => x.EducationOrganizationId == id) == null;
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddSchoolModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddSchoolModel.cs
@@ -6,7 +6,6 @@
 using FluentValidation;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using EdFi.Ods.AdminApp.Management.Api;
 using EdFi.Ods.AdminApp.Management.Api.Models;
 
 namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
@@ -34,17 +33,12 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
 
     public class AddSchoolModelValidator : AddSchoolModelValidatorBase<AddSchoolModel>
     {
-        public AddSchoolModelValidator(IOdsApiFacadeFactory odsApiFacadeFactory)
-            : base(odsApiFacadeFactory)
-        {
-        }
     }
 
     public abstract class AddSchoolModelValidatorBase<T> : AbstractValidator<T> where T : AddSchoolModel   
     {
-        protected AddSchoolModelValidatorBase(IOdsApiFacadeFactory odsApiFacadeFactory)
+        protected AddSchoolModelValidatorBase()
         {
-            var apiFacade = odsApiFacadeFactory.Create().GetAwaiter().GetResult();
             RuleFor(x => x.SchoolId).NotEmpty();
             RuleFor(x => x.Name).NotEmpty();
             RuleFor(x => x.StreetNumberName).NotEmpty();
@@ -52,9 +46,6 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
             RuleFor(x => x.State).NotEmpty();
             RuleFor(x => x.ZipCode).NotEmpty();
             RuleFor(x => x.GradeLevels).Must(x => x != null && x.Count > 0).WithMessage("You must choose at least one grade level");
-            RuleFor(x => x.SchoolId)
-                .Must(i => EducationOrganizationValidationHelper.ProposedEducationOrganizationIdIsNotInUse(i.Value, apiFacade)).When(x => x.SchoolId != null)
-                .WithMessage("This 'School ID' is already associated with another Education Organization. Please provide a unique value.");
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddSchoolModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddSchoolModel.cs
@@ -53,15 +53,8 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
             RuleFor(x => x.ZipCode).NotEmpty();
             RuleFor(x => x.GradeLevels).Must(x => x != null && x.Count > 0).WithMessage("You must choose at least one grade level");
             RuleFor(x => x.SchoolId)
-                .Must(i => ProposedEducationOrganizationIdIsNotInUse(i.Value, apiFacade)).When(x => x.SchoolId != null)
+                .Must(i => EducationOrganizationValidationHelper.ProposedEducationOrganizationIdIsNotInUse(i.Value, apiFacade)).When(x => x.SchoolId != null)
                 .WithMessage("This 'School ID' is already associated with another Education Organization. Please provide a unique value.");
-        }
-
-        public static bool ProposedEducationOrganizationIdIsNotInUse(int id, IOdsApiFacade apiFacade)
-        {
-            return apiFacade.GetAllPostSecondaryInstitutions().Find(x => x.EducationOrganizationId == id) == null
-                   && apiFacade.GetAllLocalEducationAgencies().Find(x => x.EducationOrganizationId == id) == null
-                   && apiFacade.GetAllSchools().Find(x => x.EducationOrganizationId == id) == null;
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddSchoolModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddSchoolModel.cs
@@ -56,14 +56,13 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
             RuleFor(x => x.ZipCode).NotEmpty();
             RuleFor(x => x.GradeLevels).Must(x => x != null && x.Count > 0).WithMessage("You must choose at least one grade level");
             RuleFor(x => x.SchoolId)
-                .Must(i => ProposedEducationOrganizationIdIsNotInUse(i, _apiFacade)).When(x => x.SchoolId != null)
+                .Must(i => ProposedEducationOrganizationIdIsNotInUse(i.Value, _apiFacade)).When(x => x.SchoolId != null)
                 .WithMessage("This 'School ID' is already associated with another Education Organization. Please provide a unique value.");
         }
 
-        public static bool ProposedEducationOrganizationIdIsNotInUse(int? id, IOdsApiFacade apiFacade)
+        public static bool ProposedEducationOrganizationIdIsNotInUse(int id, IOdsApiFacade apiFacade)
         {
-            return id != null
-                   && apiFacade.GetAllPostSecondaryInstitutions().Find(x => x.EducationOrganizationId == id) == null
+            return apiFacade.GetAllPostSecondaryInstitutions().Find(x => x.EducationOrganizationId == id) == null
                    && apiFacade.GetAllLocalEducationAgencies().Find(x => x.EducationOrganizationId == id) == null
                    && apiFacade.GetAllSchools().Find(x => x.EducationOrganizationId == id) == null;
         }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddSchoolModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/AddSchoolModel.cs
@@ -42,12 +42,9 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
 
     public abstract class AddSchoolModelValidatorBase<T> : AbstractValidator<T> where T : AddSchoolModel   
     {
-        private readonly IOdsApiFacade _apiFacade;
-
         protected AddSchoolModelValidatorBase(IOdsApiFacadeFactory odsApiFacadeFactory)
         {
-           
-            _apiFacade =  odsApiFacadeFactory.Create().GetAwaiter().GetResult();
+            var apiFacade = odsApiFacadeFactory.Create().GetAwaiter().GetResult();
             RuleFor(x => x.SchoolId).NotEmpty();
             RuleFor(x => x.Name).NotEmpty();
             RuleFor(x => x.StreetNumberName).NotEmpty();
@@ -56,7 +53,7 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
             RuleFor(x => x.ZipCode).NotEmpty();
             RuleFor(x => x.GradeLevels).Must(x => x != null && x.Count > 0).WithMessage("You must choose at least one grade level");
             RuleFor(x => x.SchoolId)
-                .Must(i => ProposedEducationOrganizationIdIsNotInUse(i.Value, _apiFacade)).When(x => x.SchoolId != null)
+                .Must(i => ProposedEducationOrganizationIdIsNotInUse(i.Value, apiFacade)).When(x => x.SchoolId != null)
                 .WithMessage("This 'School ID' is already associated with another Education Organization. Please provide a unique value.");
         }
 

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/EducationOrganizationValidationHelper.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/EducationOrganizationValidationHelper.cs
@@ -9,11 +9,11 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
 {
     public class EducationOrganizationValidationHelper
     {
-        public static bool ProposedEducationOrganizationIdIsNotInUse(int id, IOdsApiFacade apiFacade)
+        public static bool ProposedEducationOrganizationIdIsInUse(int id, IOdsApiFacade apiFacade)
         {
-            return apiFacade.GetAllPostSecondaryInstitutions().Find(x => x.EducationOrganizationId == id) == null &&
-                   apiFacade.GetAllLocalEducationAgencies().Find(x => x.EducationOrganizationId == id) == null &&
-                   apiFacade.GetAllSchools().Find(x => x.EducationOrganizationId == id) == null;
+            return apiFacade.GetAllPostSecondaryInstitutions().Find(x => x.EducationOrganizationId == id) != null ||
+                   apiFacade.GetAllLocalEducationAgencies().Find(x => x.EducationOrganizationId == id) != null ||
+                   apiFacade.GetAllSchools().Find(x => x.EducationOrganizationId == id) != null;
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/EducationOrganizationValidationHelper.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/EducationOrganizations/EducationOrganizationValidationHelper.cs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Ods.AdminApp.Management.Api;
+
+namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations
+{
+    public class EducationOrganizationValidationHelper
+    {
+        public static bool ProposedEducationOrganizationIdIsNotInUse(int id, IOdsApiFacade apiFacade)
+        {
+            return apiFacade.GetAllPostSecondaryInstitutions().Find(x => x.EducationOrganizationId == id) == null &&
+                   apiFacade.GetAllLocalEducationAgencies().Find(x => x.EducationOrganizationId == id) == null &&
+                   apiFacade.GetAllSchools().Find(x => x.EducationOrganizationId == id) == null;
+        }
+    }
+}


### PR DESCRIPTION
Although they appear to be supported and have behaved in practice, async operations within FluentValidation rules are considered a deadlock risk according to FluentValidation's maintainer.

Fortunately, only a small number of our rules ever performed work with async Task objects, all related to Education Organization ID uniqueness checks.

This PR complies with the guidance of having no async work within FluentValidation rules by moving that rule check into the related controller actions where async is naturally intended/supported. By crafting the same ModelState-based 400 response as would have been returned by JsonValidationFilter, the preexisting javascript which displays validation errors picks up on it unaware of the code change on the server side, giving the user a consistent experience while satisfying the no-async-validations rule.