### PR TITLE
[DO NOT MERGE] Remove "Ed-Fi Alliance Legacy Feed"

### DIFF
--- a/Application/NuGet.Config
+++ b/Application/NuGet.Config
@@ -5,6 +5,5 @@
   </solution>
   <packageSources>
     <add key="Ed-Fi Alliance NuGet Feed" value="https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json" />
-    <add key="Ed-Fi Alliance Legacy Feed" value="https://www.myget.org/F/ed-fi/" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Since all usages of MyGet should be replaced with Azure DevOps, this removes the last occurrence of "myget" from the Admin App repo.

DO NOT MERGE while @plioi reviews build logs.