### PR TITLE
[AA-1281] - Improve Ed Orgs paging performance by fetching minimal Schools

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Controllers/EducationOrganizationsControllerTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Controllers/EducationOrganizationsControllerTests.cs
@@ -498,6 +498,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
         public void When_Perform_Get_Request_To_LocalEducationAgencyList_Return_Education_Organization_List()
         {
             // Arrange
+            var lea = new LocalEducationAgency();
+
             var schools = new List<School>
             {
                 new School()
@@ -505,7 +507,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
 
             var leas = new List<LocalEducationAgency>
             {
-                new LocalEducationAgency()
+                lea
             };
 
             var psis = new List<PostSecondaryInstitution>
@@ -517,7 +519,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             const string localEducationAgencyCategory = "School";
             const string localEducationAgencyCategoryValue = "Namespace#School";
 
-            _mockOdsApiFacade.Setup(x => x.GetAllSchools()).Returns(schools);
+            _mockOdsApiFacade.Setup(x => x.GetSchoolsByLeaIds(new List<int>(){lea.EducationOrganizationId})).Returns(schools);
             _mockOdsApiFacade.Setup(x => x.GetLocalEducationAgenciesByPage(0, Page<LocalEducationAgency>.DefaultPageSize + 1)).Returns(leas);
             _mockOdsApiFacade.Setup(x => x.GetPostSecondaryInstitutionsByPage(0, Page<PostSecondaryInstitution>.DefaultPageSize + 1)).Returns(psis);
             _mockOdsApiFacadeFactory.Setup(x => x.Create())

--- a/Application/EdFi.Ods.AdminApp.Management.UnitTests/Api/OdsApiFacadeTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.UnitTests/Api/OdsApiFacadeTests.cs
@@ -114,7 +114,11 @@ namespace EdFi.Ods.AdminApp.Management.UnitTests.Api
                 new EdFiLocalEducationAgencyReference(LocalEducationAgencyId));
 
             var mockOdsRestClient = new Mock<IOdsRestClient>();
-            mockOdsRestClient.Setup(x => x.GetSchoolsByParentEdOrgId<EdFiSchool>(ResourcePaths.Schools, LocalEducationAgencyId)).Returns(new List<EdFiSchool>
+            var filters = new Dictionary<string, object>
+            {
+                {"localEducationAgencyId", LocalEducationAgencyId}
+            };
+            mockOdsRestClient.Setup(x => x.GetAll<EdFiSchool>(ResourcePaths.Schools, filters)).Returns(new List<EdFiSchool>
             {
                 edfiSchool
             });

--- a/Application/EdFi.Ods.AdminApp.Management.UnitTests/Api/OdsApiFacadeTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.UnitTests/Api/OdsApiFacadeTests.cs
@@ -32,6 +32,7 @@ namespace EdFi.Ods.AdminApp.Management.UnitTests.Api
         private School _school;
         private const string SchoolId = "id";
         private const string SchoolName = "TestSchool";
+        private const int LocalEducationAgencyId = 123;
 
         [SetUp]
         public void Init()
@@ -99,6 +100,57 @@ namespace EdFi.Ods.AdminApp.Management.UnitTests.Api
 
             //Act
             var ex = Assert.Throws<Exception>(() => _facade.GetAllSchools());
+
+            // Assert
+            Assert.AreEqual(errorMessage, ex.Message);
+        }
+
+        [Test]
+        public void Should_GetSchoolsByParentEdOrgId_returns_expected_schools_list()
+        {
+            // Arrange
+            var edfiSchool = new EdFiSchool("id", "TestSchool", 1234, new List<EdFiEducationOrganizationAddress>(),
+                new List<EdFiEducationOrganizationCategory>(), new List<EdFiSchoolGradeLevel>(),
+                new EdFiLocalEducationAgencyReference(LocalEducationAgencyId));
+
+            var mockOdsRestClient = new Mock<IOdsRestClient>();
+            mockOdsRestClient.Setup(x => x.GetSchoolsByParentEdOrgId<EdFiSchool>(ResourcePaths.Schools, LocalEducationAgencyId)).Returns(new List<EdFiSchool>
+            {
+                edfiSchool
+            });
+
+            _facade = new OdsApiFacade(_mapper, mockOdsRestClient.Object);
+
+            //Act
+            var result = _facade.GetSchoolsByLeaIds(new List<int> { LocalEducationAgencyId });
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.Count.ShouldBeGreaterThan(0);
+            result.First().Name.ShouldBe("TestSchool");
+        }
+
+        [Test]
+        public void Should_GetSchoolsByParentEdOrgId_returns_exception_when_api_returns_not_ok_response()
+        {
+            // Arrange
+            const string errorMessage = "not found error";
+
+            var mockRestClient = new Mock<IRestClient>();
+            mockRestClient.Setup(x => x.BaseUrl).Returns(new Uri(_connectionInformation.ApiBaseUrl));
+            mockRestClient.Setup(x => x.Execute(It.IsAny<RestRequest>())).Returns(new RestResponse
+            { StatusCode = HttpStatusCode.NotFound, ErrorMessage = errorMessage });
+
+            var mockTokenRetriever = new Mock<ITokenRetriever>();
+            mockTokenRetriever.Setup(x => x.ObtainNewBearerToken()).Returns("Token");
+
+            var mockOdsRestClient =
+                new OdsRestClient(_connectionInformation, mockRestClient.Object, mockTokenRetriever.Object);
+
+            _facade = new OdsApiFacade(_mapper, mockOdsRestClient);
+
+            //Act
+            var ex = Assert.Throws<Exception>(() => _facade.GetSchoolsByLeaIds(new List<int> { LocalEducationAgencyId }));
 
             // Assert
             Assert.AreEqual(errorMessage, ex.Message);

--- a/Application/EdFi.Ods.AdminApp.Management/Api/IOdsApiFacade.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/IOdsApiFacade.cs
@@ -12,6 +12,7 @@ namespace EdFi.Ods.AdminApp.Management.Api
     {
         List<School> GetAllSchools();
         List<PsiSchool> GetAllPsiSchools();
+        List<School> GetSchoolsByLeaIds(IEnumerable<int> leaIds);
         List<LocalEducationAgency> GetAllLocalEducationAgencies();
         List<LocalEducationAgency> GetLocalEducationAgenciesByPage(int offset = 0, int limit = 50);
         OdsApiResult DeleteLocalEducationAgency(string id);

--- a/Application/EdFi.Ods.AdminApp.Management/Api/IOdsRestClient.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/IOdsRestClient.cs
@@ -16,5 +16,6 @@ namespace EdFi.Ods.AdminApp.Management.Api
         OdsApiResult PutResource<T>(T resource, string elementPath, string id, bool refreshToken = false);
         IReadOnlyList<string> GetAllDescriptors();
         OdsApiResult DeleteResource(string elementPath, string id, bool refreshToken = false);
+        IReadOnlyList<T> GetSchoolsByParentEdOrgId<T>(string elementPath, int edOrgId) where T : class;
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management/Api/IOdsRestClient.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/IOdsRestClient.cs
@@ -11,11 +11,11 @@ namespace EdFi.Ods.AdminApp.Management.Api
     {
         IReadOnlyList<T> GetAll<T>(string elementPath) where T : class;
         IReadOnlyList<T> GetAll<T>(string elementPath, int offset, int limit) where T : class;
+        IReadOnlyList<T> GetAll<T>(string elementPath, Dictionary<string, object> filters) where T : class;
         T GetById<T>(string elementPath, string id) where T : class;
         OdsApiResult PostResource<T>(T resource, string elementPath, bool refreshToken = false);
         OdsApiResult PutResource<T>(T resource, string elementPath, string id, bool refreshToken = false);
         IReadOnlyList<string> GetAllDescriptors();
         OdsApiResult DeleteResource(string elementPath, string id, bool refreshToken = false);
-        IReadOnlyList<T> GetSchoolsByParentEdOrgId<T>(string elementPath, int edOrgId) where T : class;
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiFacade.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiFacade.cs
@@ -44,7 +44,12 @@ namespace EdFi.Ods.AdminApp.Management.Api
 
             foreach (var leaId in leaIds)
             {
-                response.AddRange(_restClient.GetSchoolsByParentEdOrgId<School>(ResourcePaths.Schools, leaId));
+                var filters = new Dictionary<string, object>
+                {
+                    {"localEducationAgencyId", leaId}
+                };
+
+                response.AddRange(_restClient.GetAll<School>(ResourcePaths.Schools, filters));
             }
 
             return _mapper.Map<List<Models.School>>(response);

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiFacade.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiFacade.cs
@@ -38,6 +38,18 @@ namespace EdFi.Ods.AdminApp.Management.Api
             return _mapper.Map<List<Models.PsiSchool>>(response);
         }
 
+        public List<Models.School> GetSchoolsByLeaIds(IEnumerable<int> leaIds)
+        {
+            var response = new List<School>();
+
+            foreach (var leaId in leaIds)
+            {
+                response.AddRange(_restClient.GetSchoolsByParentEdOrgId<School>(ResourcePaths.Schools, leaId));
+            }
+
+            return _mapper.Map<List<Models.School>>(response);
+        }
+
         public List<SelectOptionModel> GetLocalEducationAgencyCategories()
         {
             var response = _restClient.GetAll<DomainModels.EdFiDescriptor>(ResourcePaths.LocalEducationAgencyCategoryDescriptors);

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
@@ -111,6 +111,35 @@ namespace EdFi.Ods.AdminApp.Management.Api
             return responseList; 
         }
 
+        public IReadOnlyList<T> GetSchoolsByParentEdOrgId<T>(string elementPath, int edOrgId) where T : class
+        {
+            var offset = 0;
+            const int limit = 50;
+
+            var request = OdsRequest(elementPath);
+            request.AddParameter("offset", offset);
+            request.AddParameter("limit", limit);
+            request.AddParameter("localEducationAgencyId", edOrgId);
+
+            var responseList = new List<T>();
+            List<T> pageItems;
+
+            do
+            {
+                var restResponse = _restClient.Execute(request);
+                HandleErrorResponse(restResponse);
+
+                pageItems = JsonConvert.DeserializeObject<List<T>>(restResponse.Content);
+                responseList.AddRange(pageItems);
+
+                offset += limit;
+                request.Parameters.Single(x => x.Name == "offset").Value = offset;
+            }
+            while (pageItems.Count >= limit);
+
+            return responseList;
+        }
+
         public T GetById<T>(string elementPath, string id) where T : class
         {
             var request = OdsRequest(elementPath);

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
@@ -111,7 +111,7 @@ namespace EdFi.Ods.AdminApp.Management.Api
             return responseList; 
         }
 
-        public IReadOnlyList<T> GetSchoolsByParentEdOrgId<T>(string elementPath, int edOrgId) where T : class
+        public IReadOnlyList<T> GetAll<T>(string elementPath, Dictionary<string, object> filters) where T : class
         {
             var offset = 0;
             const int limit = 50;
@@ -119,7 +119,11 @@ namespace EdFi.Ods.AdminApp.Management.Api
             var request = OdsRequest(elementPath);
             request.AddParameter("offset", offset);
             request.AddParameter("limit", limit);
-            request.AddParameter("localEducationAgencyId", edOrgId);
+
+            foreach (var (key, value) in filters)
+            {
+                request.AddParameter(key, value);
+            }
 
             var responseList = new List<T>();
             List<T> pageItems;

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/EducationOrganizationsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/EducationOrganizationsController.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
 using EdFi.Ods.AdminApp.Management.Api;
@@ -264,10 +265,12 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         public async Task<ActionResult> LocalEducationAgencyList(int pageNumber)
         {
             var api = await _odsApiFacadeFactory.Create();
-            var schools = api.GetAllSchools();
-
+            
             var localEducationAgencies =
                 await Page<LocalEducationAgency>.FetchAsync(GetLocalEducationAgencies, pageNumber);
+
+            var schools = api.GetSchoolsByLeaIds(
+                localEducationAgencies.Items.Select(x => x.EducationOrganizationId));
 
             var requiredApiDataExist = (await _odsApiFacadeFactory.Create()).DoesApiDataExist();
 


### PR DESCRIPTION
**Description**

- Added GetSchoolsByParentedOrgId to OdsRestClient to fetch schools using the leaId filter
- Added GetSchoolsByLeaIds to OdsApiFacade to fetch schools based on the list of leaIds provided.
- Refactored LocalEducationAgencyList to fetch schools based on the Leas on the page.
- Refactored and added unit tests corresponding to the GetSchoolsByLeaIds flow.