### PR TITLE
[AA-1327] - Show ODS restart screen based on Claimset check

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ClaimSetCheckServiceTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ClaimSetCheckServiceTests.cs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
+using NUnit.Framework;
+using Shouldly;
+using static EdFi.Ods.AdminApp.Management.Tests.Testing;
+using Application = EdFi.Security.DataAccess.Models.Application;
+using ClaimSet = EdFi.Security.DataAccess.Models.ClaimSet;
+
+namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
+{
+    public class ClaimSetCheckServiceTests : SecurityDataTestBase
+    {
+        [Test]
+        public void ShouldNotRestartIfRequiredClaimSetsExist()
+        {
+            var testApplication = new Application
+            {
+                ApplicationName = $"Test Application {DateTime.Now:O}"
+            };
+            Save(testApplication);
+
+            var testAbConnectClaimSet = new ClaimSet { ClaimSetName = "AB Connect", Application = testApplication };
+            Save(testAbConnectClaimSet);
+
+            var testAdminAppClaimSet = new ClaimSet { ClaimSetName = "Ed-Fi ODS Admin App", Application = testApplication };
+            Save(testAdminAppClaimSet);
+
+            Scoped<ClaimSetCheckService>(service =>
+            {
+                var result = service.IsRestartRequired();
+                result.ShouldBeFalse();
+            });
+        }
+
+        [Test]
+        public void ShouldRestartIfRequiredClaimSetsDoNotExist()
+        {
+            var testApplication = new Application
+            {
+                ApplicationName = $"Test Application {DateTime.Now:O}"
+            };
+            Save(testApplication);
+
+            Scoped<ClaimSetCheckService>(service =>
+            {
+                var result = service.IsRestartRequired();
+                result.ShouldBeTrue();
+            });
+        }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ClaimSetCheckServiceTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ClaimSetCheckServiceTests.cs
@@ -16,7 +16,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
     public class ClaimSetCheckServiceTests : SecurityDataTestBase
     {
         [Test]
-        public void ShouldNotRestartIfRequiredClaimSetsExist()
+        public void ShouldReturnTrueIfRequiredClaimSetsExist()
         {
             var testApplication = new Application
             {
@@ -24,21 +24,21 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             };
             Save(testApplication);
 
-            var testAbConnectClaimSet = new ClaimSet { ClaimSetName = "AB Connect", Application = testApplication };
+            var testAbConnectClaimSet = new ClaimSet { ClaimSetName = CloudsOdsAcademicBenchmarksConnectApp.DefaultClaimSet, Application = testApplication };
             Save(testAbConnectClaimSet);
 
-            var testAdminAppClaimSet = new ClaimSet { ClaimSetName = "Ed-Fi ODS Admin App", Application = testApplication };
+            var testAdminAppClaimSet = new ClaimSet { ClaimSetName = CloudOdsAdminApp.InternalAdminAppClaimSet, Application = testApplication };
             Save(testAdminAppClaimSet);
 
-            Scoped<ClaimSetCheckService>(service =>
+            Scoped<IClaimSetCheckService>(service =>
             {
-                var result = service.IsRestartRequired();
-                result.ShouldBeFalse();
+                var result = service.RequiredClaimSetsExist();
+                result.ShouldBeTrue();
             });
         }
 
         [Test]
-        public void ShouldRestartIfRequiredClaimSetsDoNotExist()
+        public void ShouldReturnFalseIfRequiredClaimSetsDoNotExist()
         {
             var testApplication = new Application
             {
@@ -46,10 +46,10 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             };
             Save(testApplication);
 
-            Scoped<ClaimSetCheckService>(service =>
+            Scoped<IClaimSetCheckService>(service =>
             {
-                var result = service.IsRestartRequired();
-                result.ShouldBeTrue();
+                var result = service.RequiredClaimSetsExist();
+                result.ShouldBeFalse();
             });
         }
     }

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Setup/CompleteOdsFirstTimeSetupCommandTester.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Setup/CompleteOdsFirstTimeSetupCommandTester.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using EdFi.Admin.DataAccess.Contexts;
 using EdFi.Admin.DataAccess.Models;
 using EdFi.Ods.AdminApp.Management.Azure;
+using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
 using EdFi.Ods.AdminApp.Management.Configuration.Claims;
 using EdFi.Ods.AdminApp.Management.Database.Setup;
 using EdFi.Ods.AdminApp.Management.Instances;
@@ -16,6 +17,7 @@ using EdFi.Ods.AdminApp.Management.OdsInstanceServices;
 using EdFi.Security.DataAccess.Contexts;
 using Moq;
 using NUnit.Framework;
+using Application = EdFi.Admin.DataAccess.Models.Application;
 
 namespace EdFi.Ods.AdminApp.Management.Tests.Database.Setup
 {
@@ -72,6 +74,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Database.Setup
 
             var mockLearningStandardsSetup = new Mock<ILearningStandardsSetup>();
         
+            var mockClaimSetCheckService = new Mock<IClaimSetCheckService>();
 
             var command = new CompleteAzureFirstTimeSetupCommand(
                 mockUsersContext.Object,
@@ -85,7 +88,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Database.Setup
                 mockFirstTimeSetupService.Object,
                 mockRestartAppServicesCommand.Object,
                 mockAssessmentVendorAdjustment.Object,
-                mockLearningStandardsSetup.Object);
+                mockLearningStandardsSetup.Object,
+                mockClaimSetCheckService.Object);
 
             await command.Execute(GetOdsName(), GetClaimSet(), ApiMode.SharedInstance);
 
@@ -145,6 +149,9 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Database.Setup
 
             var mockLearningStandardsSetup = new Mock<ILearningStandardsSetup>();
 
+            var mockClaimSetCheckService = new Mock<IClaimSetCheckService>();
+            mockClaimSetCheckService.Setup(a => a.RequiredClaimSetsExist()).Returns(false);
+
             var command = new CompleteAzureFirstTimeSetupCommand(
                 mockUsersContext.Object,
                 mockSqlConfigurator.Object,
@@ -157,7 +164,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Database.Setup
                 mockFirstTimeSetupService.Object,
                 mockRestartAppServicesCommand.Object,
                 mockAssessmentVendorAdjustment.Object,
-                mockLearningStandardsSetup.Object);
+                mockLearningStandardsSetup.Object,
+                mockClaimSetCheckService.Object);
 
             await command.Execute(GetOdsName(), GetClaimSet(), ApiMode.SharedInstance);
 

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/ClaimSetCheckService.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/ClaimSetCheckService.cs
@@ -8,7 +8,12 @@ using EdFi.Security.DataAccess.Contexts;
 
 namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
 {
-    public class ClaimSetCheckService
+    public interface IClaimSetCheckService
+    {
+        bool RequiredClaimSetsExist();
+    }
+
+    public class ClaimSetCheckService : IClaimSetCheckService
     {
         private readonly ISecurityContext _securityContext;
 
@@ -17,9 +22,9 @@ namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
             _securityContext = securityContext;
         }
 
-        public bool IsRestartRequired()
+        public bool RequiredClaimSetsExist()
         {
-            return !ClaimSetExists("AB Connect") || !ClaimSetExists("Ed-Fi ODS Admin App");
+            return ClaimSetExists(CloudsOdsAcademicBenchmarksConnectApp.DefaultClaimSet) && ClaimSetExists(CloudOdsAdminApp.InternalAdminAppClaimSet);
 
             bool ClaimSetExists(string claimSetName)
             {

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/ClaimSetCheckService.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/ClaimSetCheckService.cs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Linq;
+using EdFi.Security.DataAccess.Contexts;
+
+namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
+{
+    public class ClaimSetCheckService
+    {
+        private readonly ISecurityContext _securityContext;
+
+        public ClaimSetCheckService(ISecurityContext securityContext)
+        {
+            _securityContext = securityContext;
+        }
+
+        public bool IsRestartRequired()
+        {
+            return !ClaimSetExists("AB Connect") || !ClaimSetExists("Ed-Fi ODS Admin App");
+
+            bool ClaimSetExists(string claimSetName)
+            {
+                return _securityContext.ClaimSets.Any(x => x.ClaimSetName == claimSetName);
+            }
+        }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Management/ICompleteOdsFirstTimeSetupCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ICompleteOdsFirstTimeSetupCommand.cs
@@ -14,6 +14,6 @@ namespace EdFi.Ods.AdminApp.Management
     {
         Action ExtraDatabaseInitializationAction { get; set; }
 
-        Task Execute(string odsInstanceName, CloudOdsClaimSet claimSet, ApiMode mode);
+        Task<bool> Execute(string odsInstanceName, CloudOdsClaimSet claimSet, ApiMode mode);
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/HomeController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/HomeController.cs
@@ -45,9 +45,9 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         }
 
         [AddTelemetry("Post Setup", TelemetryType.View)]
-        public ActionResult PostSetup(bool setupCompleted = false)
+        public ActionResult PostSetup(bool setupCompleted = false, bool isRestartRequired = false)
         {
-            if (setupCompleted)
+            if (setupCompleted && isRestartRequired)
             {
                 return View();
             }

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/HomeController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/HomeController.cs
@@ -3,9 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-using System;
 using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
 using EdFi.Ods.AdminApp.Management.Instances;
@@ -45,8 +43,11 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         }
 
         [AddTelemetry("Post Setup", TelemetryType.View)]
-        public ActionResult PostSetup(bool setupCompleted = false, bool isRestartRequired = false)
+        public ActionResult PostSetup(bool setupCompleted = false)
         {
+            bool.TryParse(Request.Cookies["RestartRequired"], out var isRestartRequired);
+            Response.Cookies.Delete("RestartRequired");
+
             if (setupCompleted && isRestartRequired)
             {
                 return View();

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ProductImprovementController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ProductImprovementController.cs
@@ -15,12 +15,10 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
     public class ProductImprovementController : ControllerBase
     {
         private readonly ApplicationConfigurationService _applicationConfigurationService;
-        private readonly ClaimSetCheckService _claimSetCheckService;
 
-        public ProductImprovementController(ApplicationConfigurationService applicationConfigurationService, ClaimSetCheckService claimSetCheckService)
+        public ProductImprovementController(ApplicationConfigurationService applicationConfigurationService)
         {
             _applicationConfigurationService = applicationConfigurationService;
-            _claimSetCheckService = claimSetCheckService;
         }
 
         public ActionResult EditConfiguration()
@@ -52,8 +50,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         public ActionResult EnableProductImprovementFirstTimeSetup(ProductImprovementModel model)
         {
             _applicationConfigurationService.EnableProductImprovement(model.EnableProductImprovement);
-            var isRestartRequired = _claimSetCheckService.IsRestartRequired();
-            return RedirectToAction("PostSetup", "Home", new {setupCompleted = true, isRestartRequired});
+            return RedirectToAction("PostSetup", "Home", new {setupCompleted = true});
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ProductImprovementController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ProductImprovementController.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
 using Microsoft.AspNetCore.Mvc;
 using EdFi.Ods.AdminApp.Management.Configuration.Application;
 using EdFi.Ods.AdminApp.Web.ActionFilters;
@@ -14,10 +15,12 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
     public class ProductImprovementController : ControllerBase
     {
         private readonly ApplicationConfigurationService _applicationConfigurationService;
+        private readonly ClaimSetCheckService _claimSetCheckService;
 
-        public ProductImprovementController(ApplicationConfigurationService applicationConfigurationService)
+        public ProductImprovementController(ApplicationConfigurationService applicationConfigurationService, ClaimSetCheckService claimSetCheckService)
         {
             _applicationConfigurationService = applicationConfigurationService;
+            _claimSetCheckService = claimSetCheckService;
         }
 
         public ActionResult EditConfiguration()
@@ -49,7 +52,8 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         public ActionResult EnableProductImprovementFirstTimeSetup(ProductImprovementModel model)
         {
             _applicationConfigurationService.EnableProductImprovement(model.EnableProductImprovement);
-            return RedirectToAction("PostSetup", "Home", new {setupCompleted = true});
+            var isRestartRequired = _claimSetCheckService.IsRestartRequired();
+            return RedirectToAction("PostSetup", "Home", new {setupCompleted = true, isRestartRequired});
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/SetupController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/SetupController.cs
@@ -61,7 +61,9 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
                 //setup command gives us the access to run the schema init here.
                 _completeOdsFirstTimeSetupCommand.ExtraDatabaseInitializationAction = HangFireInstance.RemoveAllScheduledJobs;
 
-                await _completeOdsFirstTimeSetupCommand.Execute(_appSettings.DefaultOdsInstance, CloudOdsAdminAppClaimSetConfiguration.Default, CloudOdsAdminAppSettings.Instance.Mode);
+                var restartRequired = await _completeOdsFirstTimeSetupCommand.Execute(_appSettings.DefaultOdsInstance, CloudOdsAdminAppClaimSetConfiguration.Default, CloudOdsAdminAppSettings.Instance.Mode);
+
+                Response.Cookies.Append("RestartRequired", restartRequired.ToString());
             });
         }
         

--- a/Application/EdFi.Ods.AdminApp.Web/_Installers/CommonConfigurationInstaller.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/_Installers/CommonConfigurationInstaller.cs
@@ -99,7 +99,7 @@ namespace EdFi.Ods.AdminApp.Web._Installers
 
             services.AddTransient<ApplicationConfigurationService>();
 
-            services.AddTransient<ClaimSetCheckService>();
+            services.AddTransient<IClaimSetCheckService, ClaimSetCheckService>();
 
             foreach (var type in typeof(IMarkerForEdFiOdsAdminAppManagement).Assembly.GetTypes())
             {

--- a/Application/EdFi.Ods.AdminApp.Web/_Installers/CommonConfigurationInstaller.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/_Installers/CommonConfigurationInstaller.cs
@@ -20,6 +20,7 @@ using EdFi.Ods.AdminApp.Web.Infrastructure;
 using EdFi.Ods.AdminApp.Web.Infrastructure.IO;
 using EdFi.Ods.AdminApp.Web.Infrastructure.Jobs;
 using EdFi.Common.Security;
+using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
 using EdFi.Ods.AdminApp.Management.Services;
 using EdFi.Ods.AdminApp.Web.Display.HomeScreen;
 using EdFi.Security.DataAccess.Contexts;
@@ -97,6 +98,8 @@ namespace EdFi.Ods.AdminApp.Web._Installers
             services.AddTransient<ITelemetry, Telemetry>();
 
             services.AddTransient<ApplicationConfigurationService>();
+
+            services.AddTransient<ClaimSetCheckService>();
 
             foreach (var type in typeof(IMarkerForEdFiOdsAdminAppManagement).Assembly.GetTypes())
             {


### PR DESCRIPTION
**Description**

- Added ClaimSetCheckService with the isRestartRequired method to check if the required claimsets exist in the database. Registered the ClaimSetCheckService.
- Refactored the controllers to add the check for required claimsets and display the Restart ODS screen based on the check.
- Added ClaimSetCheckService unit tests for the ClaimSetCheckService.