### PR TITLE
Update build script to use appropriate 5.2 era database during integration testing.

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -137,7 +137,7 @@ $supportedApiVersions = @(
     },
     @{
         OdsPackageName = "EdFi.Suite3.RestApi.Databases"
-        OdsVersion = "5.0.0"
+        OdsVersion = "5.2.14406"
         Prerelease = $false
     }
 )


### PR DESCRIPTION
Updates the build script to use the latest 5.2.* Release package hosted in Azure Artifacts. Version 5.0.0 is not available in that feed and this 5.2 era database package is a more useful integration testing target.