### PR TITLE
[ODS-4811] - Refactoring admin app installer to consume the new app common package changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,9 +62,9 @@ libs.codegen/
 
 #EdFi.Installer.AdminApp Files
 EdFi.Suite3.Installer.AdminApp/downloads
-EdFi.Suite3.Installer.AdminApp/Ed-Fi-Common
-EdFi.Suite3.Installer.AdminApp/Ed-Fi-ODS
-EdFi.Suite3.Installer.AdminApp/Ed-Fi-ODS-Implementation
+EdFi.Suite3.Installer.AdminApp/AppCommon
+EdFi.Suite3.Installer.AdminApp/key-management.psm1
+
 
 #EdFi.Ods.AdminApp.Web minified css and script files
 /Application/EdFi.Ods.AdminApp.Web/wwwroot/bundles/

--- a/EdFi.Suite3.Installer.AdminApp/EdFi.Suite3.Installer.AdminApp.nuspec
+++ b/EdFi.Suite3.Installer.AdminApp/EdFi.Suite3.Installer.AdminApp.nuspec
@@ -15,8 +15,7 @@
     <file src="install.ps1" />
     <file src="global.json" />
     <file src="Install-EdFiOdsAdminApp.psm1" />
-    <file src="Ed-Fi-ODS/**" />
-    <file src="Ed-Fi-ODS-Implementation/**" />
+    <file src="AppCommon/**" />
     <file src="../LICENSE" />
     <file src="../NOTICES.md" />
     <file src="../eng/key-management.psm1" />

--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -18,22 +18,21 @@ function Set-TlsVersion {
 }
 
 Import-Module "$PSScriptRoot/key-management.psm1"
-$env:PathResolverRepositoryOverride = "Ed-Fi-Ods;Ed-Fi-ODS-Implementation;"
-Import-Module -Force -Scope Global "$PSScriptRoot/Ed-Fi-ODS-Implementation/logistics/scripts/modules/path-resolver.psm1"
 
-Import-Module -Force $folders.modules.invoke("Environment/Prerequisites.psm1") -Scope Global
+$appCommonDirectory = "$PSScriptRoot/AppCommon"
+Import-Module -Force "$appCommonDirectory/Environment/Prerequisites.psm1" -Scope Global
 Set-TlsVersion
 Install-DotNetCore "C:\temp\tools"
 
-Import-Module -Force -Scope Global $folders.modules.invoke("utility/hashtable.psm1")
-Import-Module -Force $folders.modules.invoke("packaging/nuget-helper.psm1")
-Import-Module -Force $folders.modules.invoke("tasks/TaskHelper.psm1")
-Import-Module -Force $folders.modules.invoke("tools/ToolsHelper.psm1")
+Import-Module -Force "$appCommonDirectory/Utility/hashtable.psm1" -Scope Global
+Import-Module -Force "$appCommonDirectory/Utility/nuget-helper.psm1"
+Import-Module -Force "$appCommonDirectory/Utility/TaskHelper.psm1"
+Import-Module -Force "$appCommonDirectory/Utility/ToolsHelper.psm1"
 
 # Import the following with global scope so that they are available inside of script blocks
-Import-Module -Force $folders.modules.invoke("Application/Install.psm1") -Scope Global
-Import-Module -Force $folders.modules.invoke("Application/Uninstall.psm1") -Scope Global
-Import-Module -Force $folders.modules.invoke("Application/Configuration.psm1") -Scope Global
+Import-Module -Force "$appCommonDirectory/Application/Install.psm1" -Scope Global
+Import-Module -Force "$appCommonDirectory/Application/Uninstall.psm1" -Scope Global
+Import-Module -Force "$appCommonDirectory/Application/Configuration.psm1" -Scope Global
 
 $DbDeployVersion = "2.1.0"
 

--- a/EdFi.Suite3.Installer.AdminApp/build-package.ps1
+++ b/EdFi.Suite3.Installer.AdminApp/build-package.ps1
@@ -32,7 +32,9 @@ Invoke-Expression "$PSScriptRoot/prep-installer-package.ps1 $PSScriptRoot"
 
 $verbose = $PSCmdlet.MyInvocation.BoundParameters["Verbose"]
 
-Import-Module "$PSScriptRoot/../../Ed-Fi-ODS-Implementation/logistics/scripts/modules/packaging/create-package.psm1" -Force
+$appCommonUtilityDirectory = "$PSScriptRoot/AppCommon/Utility"
+
+Import-Module "$appCommonUtilityDirectory/create-package.psm1" -Force
 
 $parameters = @{
     PackageDefinitionFile = Resolve-Path "$PSScriptRoot/EdFi.Suite3.Installer.AdminApp.nuspec"

--- a/EdFi.Suite3.Installer.AdminApp/nuget-helper.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/nuget-helper.psm1
@@ -1,0 +1,125 @@
+﻿# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+function Install-NuGetCli {
+    <#
+    .SYNOPSIS
+        Installs the latest version of the NuGet command line executable
+
+    .DESCRIPTION
+        Installs the latest version of the NuGet command line executable
+
+    .PARAMETER toolsPath
+        The path to store nuget.exe to
+
+    .PARAMETER sourceNuGetExe
+        Web location to the nuget file. Defaulted to the version 5.3.1.0 of nuget.exe.
+    #>
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $true)]
+        [string] $ToolsPath,
+
+        [string] $sourceNuGetExe = "https://dist.nuget.org/win-x86-commandline/v5.3.1/nuget.exe"
+    )
+
+    if (-not $(Test-Path $ToolsPath)) {
+        mkdir $ToolsPath | Out-Null
+    }
+
+    $nuget = (Join-Path $ToolsPath "nuget.exe")
+
+    if (-not $(Test-Path $nuget)) {
+        Write-Host "Downloading nuget.exe official distribution from " $sourceNuGetExe
+        Invoke-WebRequest $sourceNuGetExe -OutFile $nuget
+    }
+    else {
+        $info = Get-Command $nuget
+
+        if ("5.3.1.0" -ne $info.Version.ToString()) {
+            Write-Host "Updating nuget.exe official distribution from " $sourceNuGetExe
+            Invoke-WebRequest $sourceNuGetExe -OutFile $nuget
+        }
+    }
+
+    # Add the tools directory to the path if not already there
+    if (-not ($env:PATH.Contains($ToolsPath))) {
+        $env:PATH = "$ToolsPath;$env:PATH"
+    }
+
+    return $nuget
+}
+
+function Get-NuGetPackage {
+    <#
+    .SYNOPSIS
+        Download and unzip a NuGet package for the purpose of bundling into another package.
+    .DESCRIPTION
+        Uses nuget command line to download a NuGet package and unzip it into an output
+        directory. Uses the Ed-Fi Azure Artifacts package feed by default. Default output directory
+        is .\downloads.
+    .PARAMETER packageName
+        Alias "applicationId". Name of the package to download.
+    .PARAMETER packageVersion
+        Package version number. Can include pre-release information. Optional. If not
+        specified, installs the most recent full release version.
+    .PARAMETER toolsPath
+        The path in which to find the NuGet command line client.
+    .PARAMETER outputDirectory
+        The path into which the package is unzipped. Defaults to ".\downloads".
+    .PARAMETER packageSource
+        The NuGet package source. Defaults to "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json".
+    .EXAMPLE
+        $parameters = @{
+            packageName = "EdFi.Suite3.Ods.WebApi"
+            packageVersion = "5.0.0-b11661"
+            toolsPath = ".\tools"
+        }
+        Get-NuGetPackage @parameters
+    #>
+    [CmdletBinding()]
+    param (
+        [string]
+        [Parameter(Mandatory = $true)]
+        [Alias("applicationId")]
+        $PackageName,
+
+        [string]
+        $PackageVersion,
+
+        [string]
+        [Parameter(Mandatory = $true)]
+        $ToolsPath,
+
+        [string]
+        $OutputDirectory = '.\downloads',
+
+        [string]
+        $PackageSource = "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
+    )
+
+    $nuget = Install-NuGetCli $ToolsPath
+    $parameters = @(
+        "install", $PackageName,
+        "-source", $PackageSource,
+        "-outputDirectory", $OutputDirectory
+    )
+    if ($PackageVersion) {
+        $parameters += "-version"
+        $parameters += $PackageVersion
+    }
+    
+    Write-Host -ForegroundColor Magenta "$ToolsPath\nuget $parameters"
+    & "$ToolsPath\nuget" $parameters | Out-Null
+
+    return Resolve-Path $outputDirectory/$PackageName.$PackageVersion* | Select-Object -Last 1
+}
+
+$exports = @(
+    "Install-NuGetCli"
+    "Get-NuGetPackage"
+)
+
+Export-ModuleMember -Function $exports

--- a/EdFi.Suite3.Installer.AdminApp/prep-installer-package.ps1
+++ b/EdFi.Suite3.Installer.AdminApp/prep-installer-package.ps1
@@ -10,7 +10,7 @@ param (
     $PackageDirectory,
 
     [string]
-    $AppCommonVersion = "1.4.0-pre1183",
+    $AppCommonVersion = "2.0.0",
 
     [string]
     $PackageSource = "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"

--- a/EdFi.Suite3.Installer.AdminApp/test.ps1
+++ b/EdFi.Suite3.Installer.AdminApp/test.ps1
@@ -9,9 +9,10 @@ Param(
     $Scenario
 )
 
+Copy-Item -Path "$PSScriptRoot/../eng/key-management.psm1" -Destination "$PSScriptRoot/key-management.psm1"
 import-module -force "$PSScriptRoot/Install-EdFiOdsAdminApp.psm1"
 
-$PackageVersion = '2.1.0'
+$PackageVersion = '2.2.1'
 
 function Invoke-InstallSqlServer {
 


### PR DESCRIPTION
**Description**
**NOTE: This PR should be merged only after the release of the AppCommon package from the [*ODS-4811 Ed-Fi-ODS-Deploy repo PR*](https://github.com/Ed-Fi-Alliance/Ed-Fi-ODS-Deploy/pull/215) and the AppCommon package version has been updated with the release version in this repo**
- Refactored prep-installer-package.ps1 to use the latest AppCommon package and made changes to the folder structure for the new package. Removed references to the Ed-Fi repos and use the added nuget-helper module to get the AppCommon nuget package.
- Refactored the Import-Module statements to use the scripts under AppCommon folder. Removed references to the path-resolver scripts as they are no longer needed.
- Updated the nuspec and gitignore files based on the AppCommon changes.
- Refactored test.ps1 to update the AdminApp package to the latest version and copy the key-management module from "eng" folder to run the AdminApp installer module locally.