### PR TITLE
[AA-1235] - Fixed error message when importing non JSON file while importing ClaimSets

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ClaimSetFileImportCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ClaimSetFileImportCommandTests.cs
@@ -230,7 +230,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
                 var validator = new ClaimSetFileImportModelValidator(securityContext);
                 var validationResults = validator.Validate(importModel);
                 validationResults.IsValid.ShouldBe(false);
-                validationResults.Errors.Select(x => x.ErrorMessage).ShouldContain("Invalid file extension. Only json files are allowed.");
+                validationResults.Errors.Select(x => x.ErrorMessage).ShouldContain("Invalid file extension. Only '*.json' files are allowed.");
             });
         }
 

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ClaimSetFileImportCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/ClaimSetFileImportCommandTests.cs
@@ -215,6 +215,25 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             });
         }
 
+        [Test]
+        public void ShouldNotImportIfImportFileHasAnInvalidExtension()
+        {
+            var importModel = new ClaimSetFileImportModel();
+
+            var importFile = new Mock<IFormFile>();
+
+            importFile.Setup(f => f.FileName).Returns("testfile.xml");
+            importModel.ImportFile = importFile.Object;
+
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var validator = new ClaimSetFileImportModelValidator(securityContext);
+                var validationResults = validator.Validate(importModel);
+                validationResults.IsValid.ShouldBe(false);
+                validationResults.Errors.Select(x => x.ErrorMessage).ShouldContain("Invalid file extension. Only json files are allowed.");
+            });
+        }
+
         private static ClaimSetFileImportModel GetImportModel(string testJson)
         {
             var byteArray = Encoding.UTF8.GetBytes(testJson);

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/ClaimSetFileImportModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/ClaimSetFileImportModel.cs
@@ -44,9 +44,9 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
                         {
                             var validator = new SharingModelValidator(securityContext, context.PropertyName);
 
-                            if (Path.GetExtension(model.ImportFile.FileName)?.Substring(1) != "json")
+                            if (Path.GetExtension(model.ImportFile.FileName)?.ToLower() != ".json")
                             {
-                                context.AddFailure("Invalid file extension. Only json files are allowed.");
+                                context.AddFailure("Invalid file extension. Only '*.json' files are allowed.");
                             }
                             else
                             {

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/ClaimSetFileImportModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/ClaimSetFileImportModel.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using Microsoft.AspNetCore.Http;
 using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
@@ -42,7 +43,15 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
                         .SafeCustom((model, context) =>
                         {
                             var validator = new SharingModelValidator(securityContext, context.PropertyName);
-                            context.AddFailures(validator.Validate(model.AsSharingModel()));
+
+                            if (Path.GetExtension(model.ImportFile.FileName)?.Substring(1) != "json")
+                            {
+                                context.AddFailure("Invalid file extension. Only json files are allowed.");
+                            }
+                            else
+                            {
+                                context.AddFailures(validator.Validate(model.AsSharingModel()));
+                            }
                         });
                 });
             }

--- a/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_ImportClaimSet.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_ImportClaimSet.cshtml
@@ -39,9 +39,11 @@ See the LICENSE and NOTICES files in the project root for more information.
             if (sessionStorage.getItem("LatestDatabaseChangeTimestamp") != null) {
                 $("#claim-set-warning-message").show();
             }
+            form[0].reset();
         };
         var errorAdditionalBehavior = function () {
             ClaimSetToastrMessage("There was an error while importing the Claimset");
+            form[0].reset();
         };
         var ajaxRequestData = {
             form: $(this),


### PR DESCRIPTION
**Description**
Added file extension check for the ImportFile property in ClaimSetFileImportModel. Added corresponding unit test for the new check.