### PR TITLE
Upgrade RestSharp to latest version

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.4" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Npgsql" Version="4.1.5" />
-    <PackageReference Include="RestSharp" Version="106.11.5" />
+    <PackageReference Include="RestSharp" Version="106.12.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**Description**
Bump RestSharp from 106.11.5 to 106.12.0 in EdFi.Ods.AdminApp.Management.