### PR TITLE
[AA-1342] send product registration analytics

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Infrastructure/ProductRegistrationModelTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Infrastructure/ProductRegistrationModelTests.cs
@@ -31,6 +31,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Infrastructure
                     {
                         OdsApiVersion = "5.2",
                         OdsApiMode = "YearSpecific",
+                        InstanceCount = 5
                     }
                 },
                 
@@ -49,7 +50,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Infrastructure
                     .AppendLine(@"  ""OdsApiConnections"": [")
                     .AppendLine(@"    {")
                     .AppendLine(@"      ""OdsApiVersion"": ""5.2"",")
-                    .AppendLine(@"      ""OdsApiMode"": ""YearSpecific""")
+                    .AppendLine(@"      ""OdsApiMode"": ""YearSpecific"",")
+                    .AppendLine(@"      ""InstanceCount"": 5")
                     .AppendLine(@"    }")
                     .AppendLine(@"  ],")
                     .AppendLine(@"  ""ProductType"": ""Admin App"",")

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Infrastructure/ProductRegistrationModelTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Infrastructure/ProductRegistrationModelTests.cs
@@ -1,0 +1,52 @@
+using System;
+using EdFi.Ods.AdminApp.Web.Infrastructure;
+using NUnit.Framework;
+using Shouldly;
+
+namespace EdFi.Ods.AdminApp.Management.Tests.Infrastructure
+{
+    public class ProductRegistrationModelTests
+    {
+        [Test]
+        public void ShouldRenderConsistentJson()
+        {
+            // Since this model's JSON representation must be handled by a single
+            // production endpoint, we must be sure that there are no breaking
+            // changes in the JSON structure from one Admin App release to the
+            // next.
+            //
+            // Any test failure here should be taken with great care. Rather than
+            // blindly changing the assertion to start passing, consider whether
+            // that would break messages submitted by older Admin App versions
+            // still being used in production environments.
+
+            var model = new ProductRegistrationModel
+            {
+                ProductRegistrationId = "0031cc17-0fe7-4a98-92d8-179065ff35ea",
+                OdsApiVersion = "5.2",
+                OdsApiMode = "YearSpecific",
+                ProductVersion = "2.2.1",
+                OsVersion = "Windows 95",
+                DatabaseVersion = "Microsoft SQL Server 2019 (RTM-GDR) (KB4583458) - 15.0.2080.9 (X64)   Nov  6 2020 16:50:01   Copyright (C) 2019 Microsoft Corporation  Developer Edition (64-bit) on Windows 10 Pro 10.0 <X64> (Build 19042: ) ",
+                HostName = "the-installed-admin-app-hostname.example.com",
+                UserId = "347f41d2-2e4b-45c3-b757-44d9545dba4b",
+                UserName = "the-logged-in-user@example.com",
+                UtcTimeStamp = new DateTime(2021, 8, 23, 21, 33,59, 268, DateTimeKind.Utc)
+            };
+
+            model.Serialize().ShouldBe(@"{
+  ""ProductRegistrationId"": ""0031cc17-0fe7-4a98-92d8-179065ff35ea"",
+  ""OdsApiVersion"": ""5.2"",
+  ""OdsApiMode"": ""YearSpecific"",
+  ""ProductType"": ""Admin App"",
+  ""ProductVersion"": ""2.2.1"",
+  ""OSVersion"": ""Windows 95"",
+  ""DatabaseVersion"": ""Microsoft SQL Server 2019 (RTM-GDR) (KB4583458) - 15.0.2080.9 (X64)   Nov  6 2020 16:50:01   Copyright (C) 2019 Microsoft Corporation  Developer Edition (64-bit) on Windows 10 Pro 10.0 <X64> (Build 19042: ) "",
+  ""HostName"": ""the-installed-admin-app-hostname.example.com"",
+  ""UserId"": ""347f41d2-2e4b-45c3-b757-44d9545dba4b"",
+  ""UserName"": ""the-logged-in-user@example.com"",
+  ""UtcTimeStamp"": ""2021-08-23T21:33:59.268Z""
+}");
+        }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Infrastructure/ProductRegistrationModelTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Infrastructure/ProductRegistrationModelTests.cs
@@ -23,8 +23,16 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Infrastructure
             var model = new ProductRegistrationModel
             {
                 ProductRegistrationId = "0031cc17-0fe7-4a98-92d8-179065ff35ea",
-                OdsApiVersion = "5.2",
-                OdsApiMode = "YearSpecific",
+
+                OdsApiConnections = new[]
+                {
+                    new ProductRegistrationModel.OdsApiConnection()
+                    {
+                        OdsApiVersion = "5.2",
+                        OdsApiMode = "YearSpecific",
+                    }
+                },
+                
                 ProductVersion = "2.2.1",
                 OsVersion = "Windows 95",
                 DatabaseVersion = "Microsoft SQL Server 2019 (RTM-GDR) (KB4583458) - 15.0.2080.9 (X64)   Nov  6 2020 16:50:01   Copyright (C) 2019 Microsoft Corporation  Developer Edition (64-bit) on Windows 10 Pro 10.0 <X64> (Build 19042: ) ",
@@ -36,8 +44,12 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Infrastructure
 
             model.Serialize().ShouldBe(@"{
   ""ProductRegistrationId"": ""0031cc17-0fe7-4a98-92d8-179065ff35ea"",
-  ""OdsApiVersion"": ""5.2"",
-  ""OdsApiMode"": ""YearSpecific"",
+  ""OdsApiConnections"": [
+    {
+      ""OdsApiVersion"": ""5.2"",
+      ""OdsApiMode"": ""YearSpecific""
+    }
+  ],
   ""ProductType"": ""Admin App"",
   ""ProductVersion"": ""2.2.1"",
   ""OSVersion"": ""Windows 95"",

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Infrastructure/ProductRegistrationModelTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Infrastructure/ProductRegistrationModelTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 using EdFi.Ods.AdminApp.Web.Infrastructure;
 using NUnit.Framework;
 using Shouldly;
@@ -42,23 +43,27 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Infrastructure
                 UtcTimeStamp = new DateTime(2021, 8, 23, 21, 33,59, 268, DateTimeKind.Utc)
             };
 
-            model.Serialize().ShouldBe(@"{
-  ""ProductRegistrationId"": ""0031cc17-0fe7-4a98-92d8-179065ff35ea"",
-  ""OdsApiConnections"": [
-    {
-      ""OdsApiVersion"": ""5.2"",
-      ""OdsApiMode"": ""YearSpecific""
-    }
-  ],
-  ""ProductType"": ""Admin App"",
-  ""ProductVersion"": ""2.2.1"",
-  ""OSVersion"": ""Windows 95"",
-  ""DatabaseVersion"": ""Microsoft SQL Server 2019 (RTM-GDR) (KB4583458) - 15.0.2080.9 (X64)   Nov  6 2020 16:50:01   Copyright (C) 2019 Microsoft Corporation  Developer Edition (64-bit) on Windows 10 Pro 10.0 <X64> (Build 19042: ) "",
-  ""HostName"": ""the-installed-admin-app-hostname.example.com"",
-  ""UserId"": ""347f41d2-2e4b-45c3-b757-44d9545dba4b"",
-  ""UserName"": ""the-logged-in-user@example.com"",
-  ""UtcTimeStamp"": ""2021-08-23T21:33:59.268Z""
-}");
+            var expected = new StringBuilder()
+                    .AppendLine(@"{")
+                    .AppendLine(@"  ""ProductRegistrationId"": ""0031cc17-0fe7-4a98-92d8-179065ff35ea"",")
+                    .AppendLine(@"  ""OdsApiConnections"": [")
+                    .AppendLine(@"    {")
+                    .AppendLine(@"      ""OdsApiVersion"": ""5.2"",")
+                    .AppendLine(@"      ""OdsApiMode"": ""YearSpecific""")
+                    .AppendLine(@"    }")
+                    .AppendLine(@"  ],")
+                    .AppendLine(@"  ""ProductType"": ""Admin App"",")
+                    .AppendLine(@"  ""ProductVersion"": ""2.2.1"",")
+                    .AppendLine(@"  ""OSVersion"": ""Windows 95"",")
+                    .AppendLine(@"  ""DatabaseVersion"": ""Microsoft SQL Server 2019 (RTM-GDR) (KB4583458) - 15.0.2080.9 (X64)   Nov  6 2020 16:50:01   Copyright (C) 2019 Microsoft Corporation  Developer Edition (64-bit) on Windows 10 Pro 10.0 <X64> (Build 19042: ) "",")
+                    .AppendLine(@"  ""HostName"": ""the-installed-admin-app-hostname.example.com"",")
+                    .AppendLine(@"  ""UserId"": ""347f41d2-2e4b-45c3-b757-44d9545dba4b"",")
+                    .AppendLine(@"  ""UserName"": ""the-logged-in-user@example.com"",")
+                    .AppendLine(@"  ""UtcTimeStamp"": ""2021-08-23T21:33:59.268Z""")
+                    .Append(@"}")
+                    .ToString();
+
+             model.Serialize().ShouldBe(expected);
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Instance/GetOdsInstanceRegistrationsQueryTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Instance/GetOdsInstanceRegistrationsQueryTests.cs
@@ -33,6 +33,24 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Instance
             results.Select(x => x.Name).ShouldBe(testInstances.Select(x => x.Name));
         }
 
+        [TestCase(1)]
+        [TestCase(5)]
+        public void ShouldGetAdminAppOdsInstanceCount(int instanceCount)
+        {
+            ResetOdsInstanceRegistrations();
+
+            SetupOdsInstanceRegistrations(instanceCount).OrderBy(x => x.Name).ToList();
+
+            var result = Transaction(database =>
+            {
+                var command = new GetOdsInstanceRegistrationsQuery(database);
+
+                return command.ExecuteCount();
+            });
+
+            result.ShouldBe(instanceCount);
+        }
+
         [Test]
         public void ShouldGetAdminAppOdsInstanceById()
         {

--- a/Application/EdFi.Ods.AdminApp.Management/Helpers/AppSettings.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Helpers/AppSettings.cs
@@ -30,5 +30,6 @@ namespace EdFi.Ods.AdminApp.Management.Helpers
         public string EncryptionKey { get; set; }
 
         public string GoogleAnalyticsMeasurementId { get; set; }
+        public string ProductRegistrationUrl { get; set; }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management/Instances/GetOdsInstanceRegistrationsQuery.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Instances/GetOdsInstanceRegistrationsQuery.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -26,6 +26,11 @@ namespace EdFi.Ods.AdminApp.Management.Instances
             return instances;
         }
 
+        public int ExecuteCount()
+        {
+            return _database.OdsInstanceRegistrations.Count();
+        }
+
         public OdsInstanceRegistration Execute(string odsInstanceRegistrationName)
         {
             return _database.OdsInstanceRegistrations.SingleOrDefault(x => x.Name == odsInstanceRegistrationName);
@@ -40,6 +45,7 @@ namespace EdFi.Ods.AdminApp.Management.Instances
     public interface IGetOdsInstanceRegistrationsQuery
     {
         IEnumerable<OdsInstanceRegistration> Execute();
+        int ExecuteCount();
         OdsInstanceRegistration Execute(string odsInstanceRegistrationName);
         OdsInstanceRegistration Execute(int odsInstanceId);
     }

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/IdentityController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/IdentityController.cs
@@ -31,10 +31,12 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         private readonly RegisterCommand _registerCommand;
         private readonly EditUserRoleCommand _editUserRoleCommand;
         private readonly IGetOdsInstanceRegistrationsQuery _getOdsInstanceRegistrationsQuery;
+        private readonly IProductRegistration _productRegistration;
 
         public IdentityController(ApplicationConfigurationService applicationConfiguration, RegisterCommand registerCommand, EditUserRoleCommand editUserRoleCommand, IGetOdsInstanceRegistrationsQuery getOdsInstanceRegistrationsQuery,
             SignInManager<AdminAppUser> signInManager,
-            UserManager<AdminAppUser> userManager)
+            UserManager<AdminAppUser> userManager,
+            IProductRegistration productRegistration)
         {
             _applicationConfiguration = applicationConfiguration;
             _registerCommand = registerCommand;
@@ -42,6 +44,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
             _getOdsInstanceRegistrationsQuery = getOdsInstanceRegistrationsQuery;
             _signInManager = signInManager;
             _userManager = userManager;
+            _productRegistration = productRegistration;
         }
 
         [AllowAnonymous]
@@ -73,6 +76,8 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
 
             if (result.Succeeded)
             {
+                await _productRegistration.NotifyWhenEnabled();
+
                 return RedirectToLocal(returnUrl);
             }
             if (result.RequiresTwoFactor)

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ProductImprovementController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ProductImprovementController.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Threading.Tasks;
+using EdFi.Ods.AdminApp.Management;
 using Microsoft.AspNetCore.Mvc;
 using EdFi.Ods.AdminApp.Management.Configuration.Application;
 using EdFi.Ods.AdminApp.Web.ActionFilters;
@@ -17,14 +18,16 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
     {
         private readonly ApplicationConfigurationService _applicationConfigurationService;
         private readonly IProductRegistration _productRegistration;
-
+        private readonly AdminAppUserContext _userContext;
+        
         public ProductImprovementController(
             ApplicationConfigurationService applicationConfigurationService,
-            IProductRegistration productRegistration
-            )
+            IProductRegistration productRegistration,
+            AdminAppUserContext userContext)
         {
             _applicationConfigurationService = applicationConfigurationService;
             _productRegistration = productRegistration;
+            _userContext = userContext;
         }
 
         public ActionResult EditConfiguration()
@@ -36,7 +39,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         public async Task<ActionResult> EditConfiguration(ProductImprovementModel model)
         {
             SaveProductImprovementModel(model);
-            await _productRegistration.NotifyWhenEnabled();
+            await _productRegistration.NotifyWhenEnabled(_userContext.User);
             return RedirectToAction("Index", "Home");
         }
 
@@ -49,7 +52,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         public async Task<ActionResult> EnableProductImprovementFirstTimeSetup(ProductImprovementModel model)
         {
             SaveProductImprovementModel(model);
-            await _productRegistration.NotifyWhenEnabled();
+            await _productRegistration.NotifyWhenEnabled(_userContext.User);
             return RedirectToAction("PostSetup", "Home", new {setupCompleted = true});
         }
 

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ProductImprovementController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ProductImprovementController.cs
@@ -3,9 +3,11 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using EdFi.Ods.AdminApp.Management.Configuration.Application;
 using EdFi.Ods.AdminApp.Web.ActionFilters;
+using EdFi.Ods.AdminApp.Web.Infrastructure;
 using EdFi.Ods.AdminApp.Web.Models.ViewModels;
 
 namespace EdFi.Ods.AdminApp.Web.Controllers
@@ -14,10 +16,15 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
     public class ProductImprovementController : ControllerBase
     {
         private readonly ApplicationConfigurationService _applicationConfigurationService;
+        private readonly IProductRegistration _productRegistration;
 
-        public ProductImprovementController(ApplicationConfigurationService applicationConfigurationService)
+        public ProductImprovementController(
+            ApplicationConfigurationService applicationConfigurationService,
+            IProductRegistration productRegistration
+            )
         {
             _applicationConfigurationService = applicationConfigurationService;
+            _productRegistration = productRegistration;
         }
 
         public ActionResult EditConfiguration()
@@ -26,9 +33,10 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         }
 
         [HttpPost]
-        public ActionResult EditConfiguration(ProductImprovementModel model)
+        public async Task<ActionResult> EditConfiguration(ProductImprovementModel model)
         {
             SaveProductImprovementModel(model);
+            await _productRegistration.NotifyWhenEnabled();
             return RedirectToAction("Index", "Home");
         }
 
@@ -38,9 +46,10 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         }
 
         [HttpPost]
-        public ActionResult EnableProductImprovementFirstTimeSetup(ProductImprovementModel model)
+        public async Task<ActionResult> EnableProductImprovementFirstTimeSetup(ProductImprovementModel model)
         {
             SaveProductImprovementModel(model);
+            await _productRegistration.NotifyWhenEnabled();
             return RedirectToAction("PostSetup", "Home", new {setupCompleted = true});
         }
 

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/ProductRegistration.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/ProductRegistration.cs
@@ -101,7 +101,7 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure
                     "The product registration POST failed. This may happen if the product registration service " +
                     "is temporarily unavailable or blocked on your network. This notice is merely informational " +
                     "and does not limit Admin App functionality. The attempted POST returned with status code " +
-                    $"{response.StatusCode} ({response.StatusDescription})");
+                    $"{(int)response.StatusCode} ({response.StatusDescription}).");
             }
         }
 

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/ProductRegistration.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/ProductRegistration.cs
@@ -139,7 +139,14 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure
 
         private string HostName()
         {
-            return Try(() => _httpContextAccessor.HttpContext.Request.Host.Value);
+            return Try(() =>
+            {
+                var requestHost = _httpContextAccessor.HttpContext.Request.Host;
+
+                return requestHost.HasValue
+                    ? requestHost.Host
+                    : null;
+            });
         }
 
         private static string ProductVersion()

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/ProductRegistration.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/ProductRegistration.cs
@@ -110,11 +110,21 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure
 
         private ProductRegistrationModel BuildProductRegistrationModel(string productRegistrationId)
         {
+            var singleOdsApiConnection = new ProductRegistrationModel.OdsApiConnection
+            {
+                OdsApiVersion = OdsApiVersion(),
+                OdsApiMode = _odsApiMode
+            };
+
             return new ProductRegistrationModel
             {
                 ProductRegistrationId = productRegistrationId,
-                OdsApiVersion = OdsApiVersion(),
-                OdsApiMode = _odsApiMode,
+
+                // Naturally Admin App always has 1 connection. This property supports an array
+                // in case other Ed-Fi applications need to report multiple connections using the
+                // same JSON model.
+                OdsApiConnections = new[] { singleOdsApiConnection },
+
                 ProductVersion = ProductVersion(),
                 OsVersion = OsVersion(),
                 DatabaseVersion = DatabaseVersion(),

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/ProductRegistration.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/ProductRegistration.cs
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using EdFi.Ods.AdminApp.Management;
+using EdFi.Ods.AdminApp.Management.Api;
+using EdFi.Ods.AdminApp.Management.Configuration.Application;
+using EdFi.Ods.AdminApp.Management.Database;
+using EdFi.Ods.AdminApp.Management.Helpers;
+using log4net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using RestSharp;
+using static System.Environment;
+
+namespace EdFi.Ods.AdminApp.Web.Infrastructure
+{
+    public interface IProductRegistration
+    {
+        Task NotifyWhenEnabled();
+    }
+
+    public class ProductRegistration : IProductRegistration
+    {
+        private static readonly ILog _logger = LogManager.GetLogger(typeof(ProductRegistration));
+
+        private readonly AdminAppUserContext _userContext;
+        private readonly AdminAppDbContext _database;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly ApplicationConfigurationService _applicationConfigurationService;
+
+        private readonly string _odsApiMode;
+        private readonly string _productRegistrationUrl;
+
+        public ProductRegistration(
+            IOptions<AppSettings> appSettingsAccessor,
+            AdminAppUserContext userContext,
+            AdminAppDbContext database,
+            IHttpContextAccessor httpContextAccessor,
+            ApplicationConfigurationService applicationConfigurationService)
+        {
+            _userContext = userContext;
+            _database = database;
+            _httpContextAccessor = httpContextAccessor;
+            _applicationConfigurationService = applicationConfigurationService;
+
+            var appSettings = appSettingsAccessor.Value;
+            _odsApiMode = appSettings.ApiStartupType;
+            _productRegistrationUrl = appSettings.ProductRegistrationUrl;
+        }
+
+        public async Task NotifyWhenEnabled()
+        {
+            try
+            {
+                var productImprovementEnabled = _applicationConfigurationService.IsProductImprovementEnabled(out var productRegistrationId);
+                var productRegistrationUrlAvailable = !string.IsNullOrEmpty(_productRegistrationUrl);
+                var productRegistrationIdAvailable = !string.IsNullOrEmpty(productRegistrationId);
+
+                if (productImprovementEnabled && productRegistrationUrlAvailable && productRegistrationIdAvailable)
+                {
+                    await Notify(BuildProductRegistrationModel(productRegistrationId));
+                }
+            }
+            catch (Exception exception)
+            {
+                _logger.Warn("Could not submit product registration. This notice is merely diagnostic " +
+                             "and does not limit Admin App functionality.", exception);
+            }
+        }
+
+        private async Task Notify(ProductRegistrationModel model)
+        {
+            var client = new RestClient(_productRegistrationUrl);
+
+            var request = new RestRequest
+            {
+                Method = Method.POST,
+
+                //For absolute control of this externally-facing JSON format,
+                //we serialize ourselves below rather than relying on RestSharp's
+                //internal serializer.
+                RequestFormat = DataFormat.None
+            };
+
+            request.AddHeader("Accept", "application/json");
+            request.AddParameter("", model.Serialize(), "application/json", ParameterType.RequestBody);
+
+            var response = await client.ExecuteAsync(request);
+
+            if (response.IsSuccessful)
+            {
+                _logger.Info("Product registration submitted.");
+            }
+            else
+            {
+                _logger.Info(
+                    "The product registration POST failed. This may happen if the product registration service " +
+                    "is temporarily unavailable or blocked on your network. This notice is merely informational " +
+                    "and does not limit Admin App functionality. The attempted POST returned with status code " +
+                    $"{response.StatusCode} ({response.StatusDescription})");
+            }
+        }
+
+        private ProductRegistrationModel BuildProductRegistrationModel(string productRegistrationId)
+        {
+            return new ProductRegistrationModel
+            {
+                ProductRegistrationId = productRegistrationId,
+                OdsApiVersion = OdsApiVersion(),
+                OdsApiMode = _odsApiMode,
+                ProductVersion = ProductVersion(),
+                OsVersion = OsVersion(),
+                DatabaseVersion = DatabaseVersion(),
+                HostName = HostName(),
+                UserId = _userContext?.User?.Id ?? "",
+                UserName = _userContext?.User?.UserName ?? "",
+                UtcTimeStamp = DateTime.UtcNow
+            };
+        }
+
+        private string HostName()
+        {
+            return Try(() => _httpContextAccessor.HttpContext.Request.Host.Value);
+        }
+
+        private static string ProductVersion()
+        {
+            return Try(() => Version.InformationalVersion);
+        }
+
+        private static string OdsApiVersion()
+        {
+            return Try(
+                () => InMemoryCache.Instance.GetOrSet(
+                    "OdsApiVersion",
+                    () => new InferOdsApiVersion().Version(
+                        CloudOdsAdminAppSettings.Instance.ProductionApiUrl)));
+        }
+
+        private static string OsVersion()
+        {
+            return Try(() => OSVersion.VersionString);
+        }
+
+        private string DatabaseVersion()
+        {
+            return Try(() => InMemoryCache.Instance.GetOrSet("DatabaseVersion", SelectVersionString));
+
+            string SelectVersionString()
+            {
+                return "SqlServer".Equals(CloudOdsAdminAppSettings.Instance.DatabaseEngine, StringComparison.InvariantCultureIgnoreCase)
+                    ? _database.DatabaseVersionView.FromSqlRaw("SELECT @@VERSION as VersionString").First().VersionString
+                    : _database.DatabaseVersionView.FromSqlRaw("SELECT version() as VersionString").First().VersionString;
+            }
+        }
+
+        private static string Try(Func<string> getValue, [CallerMemberName] string caller = null)
+        {
+            string value = null;
+
+            try
+            {
+                value = getValue();
+            }
+            catch (Exception exception)
+            {
+                _logger.Error($"Could not determine '{caller}' when submitting product registration. " +
+                              "This notice is merely diagnostic and does not limit Admin App functionality.", exception);
+            }
+
+            return value ?? "";
+        }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/ProductRegistrationModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/ProductRegistrationModel.cs
@@ -10,11 +10,16 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure
 {
     public class ProductRegistrationModel
     {
+        /*
+         * IMPORTANT: Because this model corresponds with the external product registration
+         *            endpoint, changes here could easily break data collection. This model
+         *            may also be used by other Ed-Fi applications, so apply model changes
+         *            with great care.
+         */
+
         public string ProductRegistrationId { get; set; }
 
-        public string OdsApiVersion { get; set; }
-
-        public string OdsApiMode { get; set; }
+        public OdsApiConnection[] OdsApiConnections { get; set; }
 
         public string ProductType => "Admin App";
 
@@ -34,5 +39,12 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure
         public DateTime UtcTimeStamp { get; set; }
 
         public string Serialize() => JsonConvert.SerializeObject(this, Formatting.Indented);
+
+        public class OdsApiConnection
+        {
+            public string OdsApiVersion { get; set; }
+
+            public string OdsApiMode { get; set; }
+        }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/ProductRegistrationModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/ProductRegistrationModel.cs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using Newtonsoft.Json;
+
+namespace EdFi.Ods.AdminApp.Web.Infrastructure
+{
+    public class ProductRegistrationModel
+    {
+        public string ProductRegistrationId { get; set; }
+
+        public string OdsApiVersion { get; set; }
+
+        public string OdsApiMode { get; set; }
+
+        public string ProductType => "Admin App";
+
+        public string ProductVersion { get; set; }
+
+        [JsonProperty(PropertyName= "OSVersion")]
+        public string OsVersion { get; set; }
+
+        public string DatabaseVersion { get; set; }
+
+        public string HostName { get; set; }
+
+        public string UserId { get; set; }
+
+        public string UserName { get; set; }
+
+        public DateTime UtcTimeStamp { get; set; }
+
+        public string Serialize() => JsonConvert.SerializeObject(this, Formatting.Indented);
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/ProductRegistrationModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/ProductRegistrationModel.cs
@@ -45,6 +45,8 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure
             public string OdsApiVersion { get; set; }
 
             public string OdsApiMode { get; set; }
+
+            public int? InstanceCount { get; set; }
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Properties/launchSettings.json
+++ b/Application/EdFi.Ods.AdminApp.Web/Properties/launchSettings.json
@@ -14,7 +14,8 @@
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "SqlServer-DistrictSpecific",
                 "AppSettings:GoogleAnalyticsMeasurementId": "UA-65907370-11",
-                "AppSettings:EncryptionKey": "bEnFYNociET2R1Wua3DHzwfU5u/Fa47N5fw0PXD0OSI="
+                "AppSettings:EncryptionKey": "bEnFYNociET2R1Wua3DHzwfU5u/Fa47N5fw0PXD0OSI=",
+                "AppSettings:ProductRegistrationUrl": "https://localhost:44374/development-product-registration-sink"
             }
         },
         "Shared Instance (SQL Server)": {
@@ -23,7 +24,8 @@
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "SqlServer-SharedInstance",
                 "AppSettings:GoogleAnalyticsMeasurementId": "UA-65907370-11",
-                "AppSettings:EncryptionKey": "bEnFYNociET2R1Wua3DHzwfU5u/Fa47N5fw0PXD0OSI="
+                "AppSettings:EncryptionKey": "bEnFYNociET2R1Wua3DHzwfU5u/Fa47N5fw0PXD0OSI=",
+                "AppSettings:ProductRegistrationUrl": "https://localhost:44374/development-product-registration-sink"
             }
         },
         "Year Specific (SQL Server)": {
@@ -32,7 +34,8 @@
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "SqlServer-YearSpecific",
                 "AppSettings:GoogleAnalyticsMeasurementId": "UA-65907370-11",
-                "AppSettings:EncryptionKey": "bEnFYNociET2R1Wua3DHzwfU5u/Fa47N5fw0PXD0OSI="
+                "AppSettings:EncryptionKey": "bEnFYNociET2R1Wua3DHzwfU5u/Fa47N5fw0PXD0OSI=",
+                "AppSettings:ProductRegistrationUrl": "https://localhost:44374/development-product-registration-sink"
             }
         },
         "District Specific (Postgres)": {
@@ -41,7 +44,8 @@
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "PostgreSql-DistrictSpecific",
                 "AppSettings:GoogleAnalyticsMeasurementId": "UA-65907370-11",
-                "AppSettings:EncryptionKey": "bEnFYNociET2R1Wua3DHzwfU5u/Fa47N5fw0PXD0OSI="
+                "AppSettings:EncryptionKey": "bEnFYNociET2R1Wua3DHzwfU5u/Fa47N5fw0PXD0OSI=",
+                "AppSettings:ProductRegistrationUrl": "https://localhost:44374/development-product-registration-sink"
             }
         },
         "Shared Instance (Postgres)": {
@@ -50,7 +54,8 @@
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "PostgreSql-SharedInstance",
                 "AppSettings:GoogleAnalyticsMeasurementId": "UA-65907370-11",
-                "AppSettings:EncryptionKey": "bEnFYNociET2R1Wua3DHzwfU5u/Fa47N5fw0PXD0OSI="
+                "AppSettings:EncryptionKey": "bEnFYNociET2R1Wua3DHzwfU5u/Fa47N5fw0PXD0OSI=",
+                "AppSettings:ProductRegistrationUrl": "https://localhost:44374/development-product-registration-sink"
             }
         },
         "Year Specific (Postgres)": {
@@ -59,7 +64,8 @@
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "PostgreSql-YearSpecific",
                 "AppSettings:GoogleAnalyticsMeasurementId": "UA-65907370-11",
-                "AppSettings:EncryptionKey": "bEnFYNociET2R1Wua3DHzwfU5u/Fa47N5fw0PXD0OSI="
+                "AppSettings:EncryptionKey": "bEnFYNociET2R1Wua3DHzwfU5u/Fa47N5fw0PXD0OSI=",
+                "AppSettings:ProductRegistrationUrl": "https://localhost:44374/development-product-registration-sink"
             }
         },
         "Shared Instance (Docker-Postgres)": {
@@ -68,7 +74,8 @@
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "Docker-SharedInstance",
                 "AppSettings:GoogleAnalyticsMeasurementId": "UA-65907370-11",
-                "AppSettings:EncryptionKey": "bEnFYNociET2R1Wua3DHzwfU5u/Fa47N5fw0PXD0OSI="
+                "AppSettings:EncryptionKey": "bEnFYNociET2R1Wua3DHzwfU5u/Fa47N5fw0PXD0OSI=",
+                "AppSettings:ProductRegistrationUrl": "https://localhost:44374/development-product-registration-sink"
             }
         },
         "mssql-district": {
@@ -78,7 +85,8 @@
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "SqlServer-DistrictSpecific",
                 "AppSettings:GoogleAnalyticsMeasurementId": "UA-65907370-11",
-                "AppSettings:EncryptionKey": "bEnFYNociET2R1Wua3DHzwfU5u/Fa47N5fw0PXD0OSI="
+                "AppSettings:EncryptionKey": "bEnFYNociET2R1Wua3DHzwfU5u/Fa47N5fw0PXD0OSI=",
+                "AppSettings:ProductRegistrationUrl": "https://localhost:5123/development-product-registration-sink"
             }
         },
         "mssql-shared": {
@@ -88,7 +96,8 @@
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "SqlServer-SharedInstance",
                 "AppSettings:GoogleAnalyticsMeasurementId": "UA-65907370-11",
-                "AppSettings:EncryptionKey": "bEnFYNociET2R1Wua3DHzwfU5u/Fa47N5fw0PXD0OSI="
+                "AppSettings:EncryptionKey": "bEnFYNociET2R1Wua3DHzwfU5u/Fa47N5fw0PXD0OSI=",
+                "AppSettings:ProductRegistrationUrl": "https://localhost:5123/development-product-registration-sink"
             }
         },
         "mssql-year": {
@@ -98,7 +107,8 @@
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "SqlServer-YearSpecific",
                 "AppSettings:GoogleAnalyticsMeasurementId": "UA-65907370-11",
-                "AppSettings:EncryptionKey": "bEnFYNociET2R1Wua3DHzwfU5u/Fa47N5fw0PXD0OSI="
+                "AppSettings:EncryptionKey": "bEnFYNociET2R1Wua3DHzwfU5u/Fa47N5fw0PXD0OSI=",
+                "AppSettings:ProductRegistrationUrl": "https://localhost:5123/development-product-registration-sink"
             }
         },
         "pg-district": {
@@ -108,7 +118,8 @@
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "PostgreSql-DistrictSpecific",
                 "AppSettings:GoogleAnalyticsMeasurementId": "UA-65907370-11",
-                "AppSettings:EncryptionKey": "bEnFYNociET2R1Wua3DHzwfU5u/Fa47N5fw0PXD0OSI="
+                "AppSettings:EncryptionKey": "bEnFYNociET2R1Wua3DHzwfU5u/Fa47N5fw0PXD0OSI=",
+                "AppSettings:ProductRegistrationUrl": "https://localhost:5123/development-product-registration-sink"
             }
         },
         "pg-shared": {
@@ -118,7 +129,8 @@
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "PostgreSql-SharedInstance",
                 "AppSettings:GoogleAnalyticsMeasurementId": "UA-65907370-11",
-                "AppSettings:EncryptionKey": "bEnFYNociET2R1Wua3DHzwfU5u/Fa47N5fw0PXD0OSI="
+                "AppSettings:EncryptionKey": "bEnFYNociET2R1Wua3DHzwfU5u/Fa47N5fw0PXD0OSI=",
+                "AppSettings:ProductRegistrationUrl": "https://localhost:5123/development-product-registration-sink"
             }
         },
         "pg-year": {
@@ -128,7 +140,8 @@
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "PostgreSql-YearSpecific",
                 "AppSettings:GoogleAnalyticsMeasurementId": "UA-65907370-11",
-                "AppSettings:EncryptionKey": "bEnFYNociET2R1Wua3DHzwfU5u/Fa47N5fw0PXD0OSI="
+                "AppSettings:EncryptionKey": "bEnFYNociET2R1Wua3DHzwfU5u/Fa47N5fw0PXD0OSI=",
+                "AppSettings:ProductRegistrationUrl": "https://localhost:5123/development-product-registration-sink"
             }
         },
     }

--- a/Application/EdFi.Ods.AdminApp.Web/Startup.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Startup.cs
@@ -26,6 +26,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using FluentValidation.AspNetCore;
 using Hangfire;
+using log4net;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
@@ -200,6 +201,9 @@ namespace EdFi.Ods.AdminApp.Web
 
                             var body = await reader.ReadToEndAsync();
 
+                            var logger = LogManager.GetLogger(typeof(Startup));
+                            logger.Debug($"Development Product Registration Sink Received Message: {Environment.NewLine}{body}");
+                            
                             var model = JsonConvert.DeserializeObject<ProductRegistrationModel>(body);
 
                             context.Response.StatusCode = (int)HttpStatusCode.OK;

--- a/Application/EdFi.Ods.AdminApp.Web/_Installers/CommonConfigurationInstaller.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/_Installers/CommonConfigurationInstaller.cs
@@ -96,6 +96,7 @@ namespace EdFi.Ods.AdminApp.Web._Installers
             services.AddScoped<InstanceContext>();
 
             services.AddTransient<ITelemetry, Telemetry>();
+            services.AddTransient<IProductRegistration, ProductRegistration>();
 
             services.AddTransient<ApplicationConfigurationService>();
 

--- a/Application/EdFi.Ods.AdminApp.Web/appsettings.json
+++ b/Application/EdFi.Ods.AdminApp.Web/appsettings.json
@@ -21,7 +21,8 @@
         "AwsCurrentVersion": "1.0",
         "PathBase": "",
         "GoogleAnalyticsMeasurementId": "",
-        "EncryptionKey": ""
+        "EncryptionKey": "",
+        "ProductRegistrationUrl": ""
     },
     "ConnectionStrings": {
         "Admin": "Data Source=.\\;Initial Catalog=EdFi_Admin;Integrated Security=True",


### PR DESCRIPTION
1. The ProductRegistrationModel presents a reliably-serializable set of telemetry fields.
2. New AppSetting ProductRegistrationUrl, initially blank for now while that service is being developed.
3. In local development environments, product registration notifications are configured to hit a diagnostic endpoint hosted within Admin App instead of the external public production endpoint. The diagnostic endpoint does not exist during production runs.
4. The ProductRegistration class POSTs a ProductRegistrationModel to the configured ProductRegistrationUrl, if and only if the admin has opted into Product Improvement with a Product Registration Id and the configured ProductRegistrationUrl is populated in AppSettings.
5. We attempt product registration upon every successful login, except for the implicit login of the first user registration. We do not do it during registration as this takes place shortly *before* the user can first opt-in. A few seconds later, we'll get our first registration POST if they do opt in.
6. We attempt product registration upon fully enabling Product Improvement, both during first time setup and subsequently on the Configuration page.
7. The ProductRegistrationModel supports reporting zero-or-more ODS / API connections, though Admin App in particular always reports exactly one.
8. The diagnostic endpoint for product registration logs the received message, for QA purposes. This endpoint does not exist in production.