### PR TITLE
[AA-1237] - Removed misleading API warmup exception logged during first time setup flow

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/SetupController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/SetupController.cs
@@ -13,7 +13,6 @@ using EdFi.Ods.AdminApp.Management.Api;
 using EdFi.Ods.AdminApp.Management.Configuration.Application;
 using EdFi.Ods.AdminApp.Management.Helpers;
 using EdFi.Ods.AdminApp.Web.ActionFilters;
-using EdFi.Ods.AdminApp.Web.Helpers;
 using EdFi.Ods.AdminApp.Web.Infrastructure;
 using EdFi.Ods.AdminApp.Web.Infrastructure.HangFire;
 using log4net;
@@ -90,30 +89,12 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
                 await setupAction();
                 _applicationConfigurationService.UpdateFirstTimeSetUpStatus(true);
                 _logger.Info("Setup process completed");
-                if (CloudOdsAdminAppSettings.Instance.Mode.SupportsSingleInstance)
-                {
-                    await WarmupApiServer();
-                }
-                _logger.Info("API warmup complete");
                 return SetupSucess();
             }
             catch (Exception e)
             {
                 _logger.Error("Setup failed", e);
                 return SetupFailure(e);
-            }
-        }
-
-        private async Task WarmupApiServer()
-        {
-            _logger.Info("Setup: Warming up API");
-            try
-            {
-                (await _odsApiFacadeFactory.Create()).WarmUp();
-            }
-            catch (Exception ex)
-            {
-                _logger.Error("Setup: API Warmup Failed", ex);
             }
         }
 

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/SetupController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/SetupController.cs
@@ -9,7 +9,6 @@ using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using EdFi.Ods.AdminApp.Management;
-using EdFi.Ods.AdminApp.Management.Api;
 using EdFi.Ods.AdminApp.Management.Configuration.Application;
 using EdFi.Ods.AdminApp.Management.Helpers;
 using EdFi.Ods.AdminApp.Web.ActionFilters;
@@ -27,19 +26,16 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
       
         private readonly ICompleteOdsFirstTimeSetupCommand _completeOdsFirstTimeSetupCommand;
         private readonly ICompleteOdsPostUpdateSetupCommand _completeOdsPostUpdateSetupCommand;
-        private readonly IOdsApiFacadeFactory _odsApiFacadeFactory;
         private readonly ApplicationConfigurationService _applicationConfigurationService;
         private readonly AppSettings _appSettings;
 
         public SetupController(ICompleteOdsFirstTimeSetupCommand completeOdsFirstTimeSetupCommand
             , ICompleteOdsPostUpdateSetupCommand completeOdsPostUpdateSetupCommand
-            , IOdsApiFacadeFactory odsApiFacadeFactory
             , ApplicationConfigurationService applicationConfigurationService
             , IOptions<AppSettings> appSettingsAccessor)
         {
             _completeOdsFirstTimeSetupCommand = completeOdsFirstTimeSetupCommand;
             _completeOdsPostUpdateSetupCommand = completeOdsPostUpdateSetupCommand;
-            _odsApiFacadeFactory = odsApiFacadeFactory;
             _applicationConfigurationService = applicationConfigurationService;
             _appSettings = appSettingsAccessor.Value;
         }

--- a/Application/EdFi.Ods.AdminApp.Web/Helpers/OdsApiFacadeExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Helpers/OdsApiFacadeExtensions.cs
@@ -20,11 +20,5 @@ namespace EdFi.Ods.AdminApp.Web.Helpers
                     .Union(odsApiFacade.GetAllSchools().Select(mapper.Map<EducationOrganizationModel>))
                     .ToList();
         }
-
-        public static void WarmUp(this IOdsApiFacade odsApiFacade)
-        {
-            odsApiFacade.GetAllLocalEducationAgencies();
-            odsApiFacade.GetAllGradeLevels();
-        }
     }
 }

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -2,11 +2,18 @@
 
 ## Contents
 
-* [Development Pre-Requisites](#development-pre-requisites)
-* [Build Script](#build-script)
-* [TeamCity Automation](#teamcity-automation)
-* [Running on Localhost](#running-on-localhost)
-* [Running in Docker](#running-in-docker)
+- [Admin App Developer Instructions](#admin-app-developer-instructions)
+  - [Contents](#contents)
+  - [Development Pre-Requisites](#development-pre-requisites)
+  - [Build Script](#build-script)
+  - [TeamCity Automation](#teamcity-automation)
+  - [Running on Localhost](#running-on-localhost)
+    - [Shared Instance](#shared-instance)
+    - [Year-Specific Mode](#year-specific-mode)
+    - [District-Specific Mode](#district-specific-mode)
+  - [Running in Docker](#running-in-docker)
+    - [Running Only the API in Docker](#running-only-the-api-in-docker)
+    - [Running a Local Build in Docker](#running-a-local-build-in-docker)
 
 For debugging on Azure, see [CloudODS Debugging](cloudods-debugging.md)
 
@@ -55,6 +62,9 @@ Available commands:
 * `.\build.ps1 package` builds pre-release and release NuGet packages for the
   Admin App web application.
 * `.\build.ps1 push` uploads a NuGet package to the NuGet feed.
+* `.\build.ps1 run` launches the Admin App from the build script. The LaunchProfile
+  parameter is required for running Admin App. Valid values include 'mssql-district'
+  , 'mssql-shared', 'mssql-year', 'pg-district', 'pg-shared' and 'pg-year'
 
 Review the parameters at the top of `build.ps1` for additional command line
 arguments.


### PR DESCRIPTION
**Description**
- Removed WarmupApiServer() method and associated usages/code to avoid misleadingly logging "API stored key and secret have been corrupted" issue. This doesn't really make sense as we already indicate the user to restart the ODS/API anyway
- Updated the dev readme to add build.ps1 Run action documentation.