### PR TITLE
[AA-1351] Improve error message when unable to reach the ODS API

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management/Api/TokenRetriever.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/TokenRetriever.cs
@@ -83,7 +83,7 @@ namespace EdFi.Ods.AdminApp.Management.Api
             return bearerTokenResponse.Data.AccessToken;
         }
 
-        private class TokenRetrieverException : AuthenticationException
+        internal class TokenRetrieverException : AuthenticationException
         {
             public TokenRetrieverException() { }
 

--- a/Application/EdFi.Ods.AdminApp.Management/Api/TokenRetriever.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/TokenRetriever.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Net;
 using System.Security.Authentication;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EdFi.Ods.AdminApp.Management.Api
@@ -30,7 +31,17 @@ namespace EdFi.Ods.AdminApp.Management.Api
         public string ObtainNewBearerToken()
         {
             var oauthClient = new RestClient(_connectionInformation.OAuthUrl);
-            return GetBearerToken(oauthClient);
+
+            try
+            {
+                return GetBearerToken(oauthClient);
+            }
+            catch (JsonException exception)
+            {
+                throw FormatException(
+                    "Unexpected response format from API. Please verify the address ({0}) is configured correctly.",
+                    exception.Message, exception, _connectionInformation.OAuthUrl);
+            }
         }
 
         private string GetBearerToken(IRestClient oauthClient)

--- a/Application/EdFi.Ods.AdminApp.Management/Api/TokenRetriever.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/TokenRetriever.cs
@@ -88,7 +88,7 @@ namespace EdFi.Ods.AdminApp.Management.Api
             public TokenRetrieverException() { }
 
             public TokenRetrieverException(string helpText, string error, Exception innerException, params object[] formatArgs)
-            : base(string.Format("Unable to retrieve an access token. " + helpText + " Error message: " + error, formatArgs)
+            : base(string.Format("Unable to retrieve an access token. " + helpText + (string.IsNullOrWhiteSpace(error) ? "" : " Error message: " + error), formatArgs)
             , innerException)
             { }
         }

--- a/Application/EdFi.Ods.AdminApp.Management/Api/TokenRetriever.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/TokenRetriever.cs
@@ -42,6 +42,10 @@ namespace EdFi.Ods.AdminApp.Management.Api
                     "Unexpected response format from API. Please verify the address ({0}) is configured correctly.",
                     exception.Message, exception, _connectionInformation.OAuthUrl);
             }
+            catch (Exception exception)
+            {
+                throw FormatException("Unexpected error while connecting to API.", exception.Message, exception);
+            }
         }
 
         private string GetBearerToken(IRestClient oauthClient)

--- a/Application/EdFi.Ods.AdminApp.Management/Api/TokenRetriever.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/TokenRetriever.cs
@@ -45,6 +45,8 @@ namespace EdFi.Ods.AdminApp.Management.Api
             {
                 case HttpStatusCode.OK:
                     break;
+                case 0:
+                    throw new AuthenticationException($"Unable to retrieve an access token: Unable to connect to API. Please verify the ODS API ({_connectionInformation.ApiServerUrl}) is running.");
                 case HttpStatusCode.NotFound:
                     throw new AuthenticationException($"Unable to retrieve an access token: API not found. Please verify the address ({_connectionInformation.OAuthUrl}) is configured correctly.");
                 default:

--- a/Application/EdFi.Ods.AdminApp.Management/Api/TokenRetriever.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/TokenRetriever.cs
@@ -40,10 +40,13 @@ namespace EdFi.Ods.AdminApp.Management.Api
             bearerTokenRequest.AddParameter("Grant_type", "client_credentials");
 
             var bearerTokenResponse = oauthClient.Execute<BearerTokenResponse>(bearerTokenRequest);
-            if (bearerTokenResponse.StatusCode != HttpStatusCode.OK)
+
+            switch (bearerTokenResponse.StatusCode)
             {
-                throw new AuthenticationException("Unable to retrieve an access token. Error message: " +
-                                                  bearerTokenResponse.ErrorMessage);
+                case HttpStatusCode.OK:
+                    break;
+                default:
+                    throw new AuthenticationException("Unable to retrieve an access token. Error message: " + bearerTokenResponse.ErrorMessage);
             }
 
             if (bearerTokenResponse.Data.Error != null || bearerTokenResponse.Data.TokenType != "bearer")

--- a/Application/EdFi.Ods.AdminApp.Management/Api/TokenRetriever.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/TokenRetriever.cs
@@ -68,7 +68,7 @@ namespace EdFi.Ods.AdminApp.Management.Api
                 case 0:
                     throw new TokenRetrieverException("Unable to connect to API. Please verify the API ({0}) is running.", bearerTokenResponse.ErrorMessage, null, _connectionInformation.ApiServerUrl);
                 case HttpStatusCode.NotFound:
-                    throw new TokenRetrieverException("Unable to connect to API: API not found. Please verify the address ({0}) is configured correctly.", bearerTokenResponse.ErrorMessage, null, _connectionInformation.ApiServerUrl);
+                    throw new TokenRetrieverException("API not found. Please verify the address ({0}) is configured correctly.", bearerTokenResponse.ErrorMessage, null, _connectionInformation.ApiServerUrl);
                 case HttpStatusCode.ServiceUnavailable:
                     throw new TokenRetrieverException("API Service is unavailable. Please verify the API ({0}) hosting configuration is correct.", bearerTokenResponse.ErrorMessage, null, _connectionInformation.ApiServerUrl);
                 default:

--- a/Application/EdFi.Ods.AdminApp.Management/Api/TokenRetriever.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/TokenRetriever.cs
@@ -36,6 +36,10 @@ namespace EdFi.Ods.AdminApp.Management.Api
             {
                 return GetBearerToken(oauthClient);
             }
+            catch (AuthenticationException)
+            {
+                throw;
+            }
             catch (JsonException exception)
             {
                 throw FormatException(

--- a/Application/EdFi.Ods.AdminApp.Management/Api/TokenRetriever.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/TokenRetriever.cs
@@ -50,6 +50,8 @@ namespace EdFi.Ods.AdminApp.Management.Api
                     throw FormatException("Unable to connect to API. Please verify the API ({0}) is running.", bearerTokenResponse.ErrorMessage, null, _connectionInformation.ApiServerUrl);
                 case HttpStatusCode.NotFound:
                     throw FormatException("Unable to connect to API: API not found. Please verify the address ({0}) is configured correctly.", bearerTokenResponse.ErrorMessage, null, _connectionInformation.ApiServerUrl);
+                case HttpStatusCode.ServiceUnavailable:
+                    throw FormatException("API Service is unavailable. Please verify the API ({0}) hosting configuration is correct.", bearerTokenResponse.ErrorMessage, null, _connectionInformation.ApiServerUrl);
                 default:
                     throw FormatException("Unexpected response from API.", bearerTokenResponse.ErrorMessage, null);
             }

--- a/Application/EdFi.Ods.AdminApp.Management/Api/TokenRetriever.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/TokenRetriever.cs
@@ -45,6 +45,8 @@ namespace EdFi.Ods.AdminApp.Management.Api
             {
                 case HttpStatusCode.OK:
                     break;
+                case HttpStatusCode.NotFound:
+                    throw new AuthenticationException($"Unable to retrieve an access token: API not found. Please verify the address ({_connectionInformation.OAuthUrl}) is configured correctly.");
                 default:
                     throw new AuthenticationException("Unable to retrieve an access token. Error message: " + bearerTokenResponse.ErrorMessage);
             }

--- a/Application/EdFi.Ods.AdminApp.Web/Helpers/HtmlHelperExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Helpers/HtmlHelperExtensions.cs
@@ -500,7 +500,8 @@ namespace EdFi.Ods.AdminApp.Web.Helpers
             var spinnerTag = new DivTag();
             spinnerTag.Append(new HtmlTag("i").AddClasses("fa", "fa-spinner", "fa-pulse", "fa-fw"));
 
-            var errorMessage = "If the error persists, you can find more information and context in the application logs. If you are unable to identify the issue or resolve it, please schedule a ticket via <a href='https://tracker.ed-fi.org/projects/EDFI/issues'>Ed-Fi Tracker</a>" +
+            var errorMessage = "Please verify the configuration and try restarting the ODS / API. Then, reload this to see if this same error occurs." +
+                               " If the error persists, you can find more information and context in the application logs. If you are unable to identify the issue or resolve it, please schedule a ticket via <a href='https://tracker.ed-fi.org/projects/EDFI/issues'>Ed-Fi Tracker</a>" +
                                " or visit <a href='https://techdocs.ed-fi.org/display/ADMIN'>Admin App documentation</a> for more information.";
 
             var contentLoadingArea = new DivTag().Data("source-url", url).Data("error-message", errorMessage).AddClass("load-action-async");

--- a/Application/EdFi.Ods.AdminApp.Web/Helpers/HtmlHelperExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Helpers/HtmlHelperExtensions.cs
@@ -501,7 +501,7 @@ namespace EdFi.Ods.AdminApp.Web.Helpers
             spinnerTag.Append(new HtmlTag("i").AddClasses("fa", "fa-spinner", "fa-pulse", "fa-fw"));
 
             var errorMessage = "Restarting the ODS / API is known to solve issues with first time setup or previously cached information, and may help resolve this issue on its own." +
-                               " Please try restarting the ODS / API now and reload this to see if this same error occurs." +
+                               " Please verify the configuration and try restarting the ODS / API. Then, reload this to see if this same error occurs." +
                                " If the error persists, please check the application logs and then feel to schedule a ticket via <a href='https://tracker.ed-fi.org/projects/EDFI/issues'>Ed-Fi Tracker</a>" +
                                " or visit <a href='https://techdocs.ed-fi.org/display/ADMIN'>Admin App documentation</a> for more information.";
 

--- a/Application/EdFi.Ods.AdminApp.Web/Helpers/HtmlHelperExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Helpers/HtmlHelperExtensions.cs
@@ -500,9 +500,7 @@ namespace EdFi.Ods.AdminApp.Web.Helpers
             var spinnerTag = new DivTag();
             spinnerTag.Append(new HtmlTag("i").AddClasses("fa", "fa-spinner", "fa-pulse", "fa-fw"));
 
-            var errorMessage = "Restarting the ODS / API is known to solve issues with first time setup or previously cached information, and may help resolve this issue on its own." +
-                               " Please verify the configuration and try restarting the ODS / API. Then, reload this to see if this same error occurs." +
-                               " If the error persists, please check the application logs and then feel to schedule a ticket via <a href='https://tracker.ed-fi.org/projects/EDFI/issues'>Ed-Fi Tracker</a>" +
+            var errorMessage = "If the error persists, you can find more information and context in the application logs. If you are unable to identify the issue or resolve it, please schedule a ticket via <a href='https://tracker.ed-fi.org/projects/EDFI/issues'>Ed-Fi Tracker</a>" +
                                " or visit <a href='https://techdocs.ed-fi.org/display/ADMIN'>Admin App documentation</a> for more information.";
 
             var contentLoadingArea = new DivTag().Data("source-url", url).Data("error-message", errorMessage).AddClass("load-action-async");

--- a/Application/EdFi.Ods.AdminApp.Web/wwwroot/Scripts/site.js
+++ b/Application/EdFi.Ods.AdminApp.Web/wwwroot/Scripts/site.js
@@ -368,7 +368,7 @@ function LoadAsyncActions() {
                 $target.html(data);
             },
             error: function (jqXhr) {
-                var errorMessage = "The following error occured while loading page content: ";
+                var errorMessage = "The following error occurred while loading page content: ";
                 if (!StringIsNullOrWhitespace(jqXhr.responseText)) {
                     errorMessage = errorMessage + jqXhr.responseText + ". ";
                 }

--- a/Application/EdFi.Ods.AdminApp.Web/wwwroot/Scripts/site.js
+++ b/Application/EdFi.Ods.AdminApp.Web/wwwroot/Scripts/site.js
@@ -368,7 +368,7 @@ function LoadAsyncActions() {
                 $target.html(data);
             },
             error: function (jqXhr) {
-                var errorMessage = "The following error occurred while loading page content: ";
+                var errorMessage = "The following error occurred while loading page content: <br/><br/>";
                 if (!StringIsNullOrWhitespace(jqXhr.responseText)) {
                     errorMessage = errorMessage + "<b>" + jqXhr.responseText + " .</b>";
                 }

--- a/Application/EdFi.Ods.AdminApp.Web/wwwroot/Scripts/site.js
+++ b/Application/EdFi.Ods.AdminApp.Web/wwwroot/Scripts/site.js
@@ -370,11 +370,11 @@ function LoadAsyncActions() {
             error: function (jqXhr) {
                 var errorMessage = "The following error occurred while loading page content: <br/><br/>";
                 if (!StringIsNullOrWhitespace(jqXhr.responseText)) {
-                    errorMessage = errorMessage + "<b>" + jqXhr.responseText + " .</b>";
+                    errorMessage = errorMessage + "<b>" + jqXhr.responseText + "</b>";
                 }
 
                 if (jqXhr.status > 0) {
-                    errorMessage = errorMessage + "Status " + jqXhr.status;
+                    errorMessage = errorMessage + " Status " + jqXhr.status;
                 } else {
                     errorMessage = errorMessage + "No response from server";
                 }

--- a/Application/EdFi.Ods.AdminApp.Web/wwwroot/Scripts/site.js
+++ b/Application/EdFi.Ods.AdminApp.Web/wwwroot/Scripts/site.js
@@ -370,7 +370,7 @@ function LoadAsyncActions() {
             error: function (jqXhr) {
                 var errorMessage = "The following error occurred while loading page content: ";
                 if (!StringIsNullOrWhitespace(jqXhr.responseText)) {
-                    errorMessage = errorMessage + jqXhr.responseText + ". ";
+                    errorMessage = errorMessage + "<b>" + jqXhr.responseText + " .</b>";
                 }
 
                 if (jqXhr.status > 0) {
@@ -380,7 +380,7 @@ function LoadAsyncActions() {
                 }
 
                 if (!StringIsNullOrWhitespace(customErrorMessage)) {
-                    errorMessage = errorMessage + ". <br/><b>" + customErrorMessage + "</b>";
+                    errorMessage = errorMessage + ". <br/><br/>" + customErrorMessage;
                 }
 
                 $target.html("<em class='text-danger'>" + errorMessage + "</em>");


### PR DESCRIPTION
This PR introduces additional exception and response handling to the `TokenRetriever` in an effort to provide more specific messages for given scenarios and additional context within those messages.

- adds new handling and specific messages for `404`, `503`, and empty (`0`) responses
- adds handling and message for non-JSON response
- re-emphasizes error display to put focus on specific message before general handling recommendation