### PR TITLE
[AA-1371] - Prompt and restart IIS from powershell when upgrading and uninstalling

### DIFF
--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -819,6 +819,22 @@ function Invoke-StartWebSite($webSiteName, $portNumber){
     }
 }
 
+function Invoke-ResetIIS {
+    Invoke-Task -Name ($MyInvocation.MyCommand.Name) -Task {
+        $default = 'n'
+        Write-Warning "NOTICE: In order to upgrade or uninstall, Information Internet Service (IIS) needs to be stopped during the process. This will impact availability if users are using applications hosted with IIS."
+        $confirmation = Read-Host -Prompt "Please enter 'y' to proceed with an IIS reset or enter 'n' to stop the upgrade or uninstall. [Default Action: '$default']"
+        if (!$confirmation) { $confirmation = $default}
+        if ($confirmation -ieq 'y') {
+            & {iisreset}
+        }
+        else {
+            Write-Warning "Exiting the uninstall/upgrade process."
+            exit
+        }
+    }
+}
+
 function Initialize-Configuration {
     [CmdletBinding()]
     param (

--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -447,6 +447,7 @@ function Update-EdFiOdsAdminApp {
     }
 
     $elapsed = Use-StopWatch {
+        $result += Invoke-ResetIIS
         $result += Invoke-ApplicationUpgrade -Config $Config
         $result += Get-AdminAppPackage -Config $Config
         $result += Get-DbDeploy -Config $Config
@@ -527,13 +528,10 @@ function Uninstall-EdFiOdsAdminApp {
     $result = @()
 
     $elapsed = Use-StopWatch {
-        $parameters = @{
-            WebApplicationPath = $config.WebApplicationPath
-            WebApplicationName = $config.WebApplicationName
-            WebSiteName = $config.WebSiteName
-        }
 
-        Uninstall-EdFiApplicationFromIIS @parameters
+        Invoke-ResetIIS
+
+        UninstallAdminApp $config
 
         $result
     }
@@ -545,6 +543,17 @@ function Uninstall-EdFiOdsAdminApp {
         $result += New-TaskResult -name $MyInvocation.MyCommand.Name -duration $elapsed.format
         $result | Format-Table
     }
+}
+
+function UninstallAdminApp($config)
+{
+    $parameters = @{
+        WebApplicationPath = $config.WebApplicationPath
+        WebApplicationName = $config.WebApplicationName
+        WebSiteName = $config.WebSiteName
+    }
+
+    Uninstall-EdFiApplicationFromIIS @parameters
 }
 
 
@@ -677,13 +686,11 @@ function Invoke-ApplicationUpgrade {
         $Config.WebSitePath = $existingWebSitePath
 
         $parameters = @{
-            ToolsPath = $Config.ToolsPath
             WebApplicationPath = $existingApplicationPath
             WebApplicationName = $existingAppName
             WebSiteName = $existingWebSiteName
-            NoDuration = $Config.NoDuration
         }
-        Uninstall-EdFiOdsAdminApp @parameters
+        UninstallAdminApp $parameters
     }
 }
 

--- a/EdFi.Suite3.Installer.AdminApp/uninstall.ps1
+++ b/EdFi.Suite3.Installer.AdminApp/uninstall.ps1
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+import-module -force "$PSScriptRoot/Install-EdFiOdsAdminApp.psm1"
+
+<#
+This script will uninstall your existing Admin App installation.
+
+.EXAMPLE
+    $p = @{
+        ToolsPath = "C:/temp/tools"
+        WebSiteName="Ed-Fi-3"
+        WebApplicationPath="d:/edfi/applications/staging/AdminApp-3"
+        WebApplicationName = "AdminApp"
+    }
+#>
+
+$p = @{
+    ToolsPath = "C:/temp/tools"
+}
+
+Uninstall-EdFiOdsAdminApp @p
+


### PR DESCRIPTION
**Description**
- Added Invoke-ResetIIS function to prompt the user to choose whether to reset IIS or not.
- Refactored Uninstall-EdFiOdsAdminApp to move out the Uninstall-EdFiApplicationFromIIS call to a separate function in order to allow Invoke-ResetIIS to be called separately from the uninstall flow. Added calls to Invoke-ResetIIS for both update and uninstall flows.
- Added an uninstall.ps1 script.