### PR TITLE
[AA-1361] Show Error Message on Upgrade Script When Version Specified Is Same or Previous

### DIFF
--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -711,12 +711,17 @@ function CheckForCompatibleUpdate($webSitePath,  $existingAdminApp, $targetVersi
     return $existingApplicationPath, $versionString
 }
 
-function IsVersionHigherThanOther($versionString, $otherVersionString){
-    $version = [System.Version]::Parse($versionString)
-    $otherVersion = [System.Version]::Parse($otherVersionString)
+function IsVersionHigherThanOther($versionString, $otherVersionString) {
+    $version = ParseVersionWithoutTag($versionString)
+    $otherVersion = ParseVersionWithoutTag($otherVersionString)
 
     $result = $version.CompareTo($otherVersion)
     return $result -gt 0
+}
+
+function ParseVersionWithoutTag($versionString) {
+    $splitByTags = $versionString -split '-'
+    return ([System.Version]::Parse($splitByTags[0]))
 }
 
 function Invoke-TransferAppsettings {

--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -565,11 +565,6 @@ function Invoke-InstallationPreCheck{
         {
             $sitePath = $webSite.PhysicalPath
             $existingApplicationPath, $versionString, $compatibleVersionIsInstalled = CheckForCompatibleVersion $sitePath $existingAdminAppApplication
-            if(-not $compatibleVersionIsInstalled)
-            {
-                Write-Warning "We found a preexisting Admin App $versionString installation. That version cannot be automatically upgraded in-place by this script. Please refer to https://techdocs.ed-fi.org/display/ADMIN/Upgrading+Admin+App+from+1.x+Line for setting up the newer version of AdminApp."
-                exit
-            }
 
             Write-Host "We found a preexisting Admin App $versionString installation. Most likely, you intended to use the upgrade script instead of this install script." -ForegroundColor Green
             $confirmation = Read-Host -Prompt "Please enter 'y' to continue the installation process, or enter 'n' to stop the installation so that you can instead run the upgrade script. Note: Using the upgrade script, all the appsettings and database connection string values would be copied forward from the existing installation, so only enter 'y' to continue if you are sure this is not an upgrade."
@@ -633,10 +628,6 @@ function Invoke-ApplicationUpgrade {
         }
 
         $existingApplicationPath, $versionString, $compatibleVersionIsInstalled = CheckForCompatibleVersion $existingWebSitePath $existingAdminApp
-        if(-not $compatibleVersionIsInstalled)
-        {
-            throw "We found a preexisting Admin App $versionString installation. That version cannot be automatically upgraded in-place by this script. Please refer to https://techdocs.ed-fi.org/display/ADMIN/Upgrading+Admin+App+from+1.x+Line for setting up the newer version of AdminApp."
-        }
 
         Write-Host "Stopping the $existingWebSiteName before taking application files back up."
         Stop-IISSite -Name $existingWebSiteName
@@ -703,7 +694,8 @@ function CheckForCompatibleVersion($webSitePath,  $existingAdminApp) {
     if($existingApplicationVersion.Major -lt $requiredMajor -OR
     ($existingApplicationVersion.Major -eq $requiredMajor -AND $existingApplicationVersion.Minor -lt $requiredMinor))
     {
-        $compatibleVersionIsInstalled  = $false
+        Write-Warning "We found a preexisting Admin App $versionString installation. That version cannot be automatically upgraded in-place by this script. Please refer to https://techdocs.ed-fi.org/display/ADMIN/Upgrading+Admin+App+from+1.x+Line for setting up the newer version of AdminApp."
+        exit
     }
     else {
         $compatibleVersionIsInstalled =$true

--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -588,7 +588,7 @@ function Invoke-InstallationPreCheck{
                 Write-Warning "We found a preexisting Admin App $versionString installation. That version cannot be automatically upgraded in-place by this script. Please refer to https://techdocs.ed-fi.org/display/ADMIN/Upgrading+Admin+App+from+1.x+Line for setting up the newer version of AdminApp. Exiting."
                 exit
             }else {
-                Write-Warning "We found a preexisting Admin App $versionString installation newer than the target version $installVersionString. Downgrades are not supported. Please fully uninstall the existing Admin App first and retry."
+                Write-Warning "We found a preexisting Admin App $versionString installation newer than the target version $installVersionString. Downgrades are not supported. Please fully uninstall the existing Admin App first and retry. Exiting."
                 exit
             }
         }

--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -564,25 +564,7 @@ function Invoke-InstallationPreCheck{
         if($webSite -AND $existingAdminAppApplication)
         {
             $sitePath = $webSite.PhysicalPath
-            $existingApplicationPath, $versionString = CheckForInstallVersion $sitePath $existingAdminAppApplication
-
-            Write-Host "We found a preexisting Admin App $versionString installation. Most likely, you intended to use the upgrade script instead of this install script." -ForegroundColor Green
-            $confirmation = Read-Host -Prompt "Please enter 'y' to continue the installation process, or enter 'n' to stop the installation so that you can instead run the upgrade script. Note: Using the upgrade script, all the appsettings and database connection string values would be copied forward from the existing installation, so only enter 'y' to continue if you are sure this is not an upgrade."
-            if($confirmation -ieq 'y')
-            {
-                $appsettingsFile =  Join-Path $existingApplicationPath "appsettings.json"
-                if(Test-Path -Path $appsettingsFile)
-                {
-                    Write-Host "To ensure your existing ODS / API Key and Secret values will continue to work, your existing encryption key is being copied forward from the appsettings.json file at $appsettingsFile"
-                    $appSettings = Get-Content $appsettingsFile | ConvertFrom-Json | ConvertTo-Hashtable
-                    $Config.EncryptionKey = $appSettings.AppSettings.EncryptionKey
-                }
-            }
-            else
-            {
-                Write-Warning "Exiting the installation."
-                exit
-            }
+            $existingApplicationPath, $versionString = CheckForInstallVersion $sitePath $existingAdminAppApplication $Config.PackageVersion
         }
     }
 }
@@ -695,12 +677,21 @@ function CheckVersionSupportsUpgrade($versionString) {
     return -not $versionIsBeforeUpgradeSupport
 }
 
-function CheckForInstallVersion($webSitePath,  $existingAdminApp) {
+function CheckForInstallVersion($webSitePath,  $existingAdminApp, $installVersionString) {
     $existingApplicationPath, $versionString = GetExistingAppVersion $webSitePath $existingAdminApp
 
-    if(-not (CheckVersionSupportsUpgrade $versionString))
+    $targetIsNewer = IsVersionHigherThanOther $installVersionString $versionString
+    $upgradeIsSupported = CheckVersionSupportsUpgrade $versionString
+
+    if($targetIsNewer -and $upgradeIsSupported)
     {
-        Write-Warning "We found a preexisting Admin App $versionString installation. That version cannot be automatically upgraded in-place by this script. Please refer to https://techdocs.ed-fi.org/display/ADMIN/Upgrading+Admin+App+from+1.x+Line for setting up the newer version of AdminApp."
+        Write-Host "We found a preexisting Admin App $versionString installation. To install the new version, use the included upgrade script instead of this install script. Exiting." -ForegroundColor Green
+        exit
+    }elseif ($targetIsNewer) {
+        Write-Warning "We found a preexisting Admin App $versionString installation. That version cannot be automatically upgraded in-place by this script. Please refer to https://techdocs.ed-fi.org/display/ADMIN/Upgrading+Admin+App+from+1.x+Line for setting up the newer version of AdminApp. Exiting."
+        exit
+    }else {
+        Write-Warning "We found a preexisting Admin App $versionString installation older than the target version $installVersionString. Downgrades are not supported. Please fully uninstall the existing Admin App first and retry."
         exit
     }
 

--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -571,7 +571,8 @@ function Invoke-InstallationPreCheck{
 
             if($targetIsNewer -and $upgradeIsSupported) {
                 Write-Host "We found a preexisting Admin App $versionString installation. If you are seeking to upgrade to the new version, consider using the included upgrade script instead." -ForegroundColor Green
-                $confirmation = Read-Host -Prompt "Please enter 'y' to continue the installation process, or enter 'n' to cancel the installation so that you can instead run the upgrade script. Note: Using the upgrade script, all the appsettings and database connection string values would be copied forward from the existing installation, so only enter 'y' to continue if you are you seeking to change the configuration."
+                Write-Host "Note: Using the upgrade script, all the appsettings and database connection string values would be copied forward from the existing installation, so only continue if you are you seeking to change the configuration." -ForegroundColor Yellow
+                $confirmation = Read-Host -Prompt "Please enter 'y' to continue the installation process, or enter 'n' to cancel the installation so that you can instead run the upgrade script"
                 if(-not ($confirmation -ieq 'y')) {
                     Write-Host "Exiting."
                     exit

--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -570,8 +570,20 @@ function Invoke-InstallationPreCheck{
             $upgradeIsSupported = CheckVersionSupportsUpgrade $versionString
 
             if($targetIsNewer -and $upgradeIsSupported) {
-                Write-Warning "We found a preexisting Admin App $versionString installation. To install the new version $installVersionString, use the included upgrade script instead of this install script. Exiting."
-                exit
+                Write-Host "We found a preexisting Admin App $versionString installation. If you are seeking to upgrade to the new version, consider using the included upgrade script instead." -ForegroundColor Green
+                $confirmation = Read-Host -Prompt "Please enter 'y' to continue the installation process, or enter 'n' to cancel the installation so that you can instead run the upgrade script. Note: Using the upgrade script, all the appsettings and database connection string values would be copied forward from the existing installation, so only enter 'y' to continue if you are you seeking to change the configuration."
+                if(-not ($confirmation -ieq 'y')) {
+                    Write-Host "Exiting."
+                    exit
+                }else {
+                    $appsettingsFile =  Join-Path $existingApplicationPath "appsettings.json"
+                    if(Test-Path -Path $appsettingsFile)
+                    {
+                        Write-Host "To ensure your existing ODS / API Key and Secret values will continue to work, your existing encryption key is being copied forward from the appsettings.json file at $appsettingsFile"
+                        $appSettings = Get-Content $appsettingsFile | ConvertFrom-Json | ConvertTo-Hashtable
+                        $Config.EncryptionKey = $appSettings.AppSettings.EncryptionKey
+                    }
+                }
             }elseif ($targetIsNewer) {
                 Write-Warning "We found a preexisting Admin App $versionString installation. That version cannot be automatically upgraded in-place by this script. Please refer to https://techdocs.ed-fi.org/display/ADMIN/Upgrading+Admin+App+from+1.x+Line for setting up the newer version of AdminApp. Exiting."
                 exit

--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -570,7 +570,7 @@ function Invoke-InstallationPreCheck{
             $upgradeIsSupported = CheckVersionSupportsUpgrade $versionString
 
             if($targetIsNewer -and $upgradeIsSupported) {
-                Write-Host "We found a preexisting Admin App $versionString installation. To install the new version, use the included upgrade script instead of this install script. Exiting." -ForegroundColor Green
+                Write-Warning "We found a preexisting Admin App $versionString installation. To install the new version $installVersionString, use the included upgrade script instead of this install script. Exiting."
                 exit
             }elseif ($targetIsNewer) {
                 Write-Warning "We found a preexisting Admin App $versionString installation. That version cannot be automatically upgraded in-place by this script. Please refer to https://techdocs.ed-fi.org/display/ADMIN/Upgrading+Admin+App+from+1.x+Line for setting up the newer version of AdminApp. Exiting."

--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -576,7 +576,7 @@ function Invoke-InstallationPreCheck{
                 Write-Warning "We found a preexisting Admin App $versionString installation. That version cannot be automatically upgraded in-place by this script. Please refer to https://techdocs.ed-fi.org/display/ADMIN/Upgrading+Admin+App+from+1.x+Line for setting up the newer version of AdminApp. Exiting."
                 exit
             }else {
-                Write-Warning "We found a preexisting Admin App $versionString installation older than the target version $installVersionString. Downgrades are not supported. Please fully uninstall the existing Admin App first and retry."
+                Write-Warning "We found a preexisting Admin App $versionString installation newer than the target version $installVersionString. Downgrades are not supported. Please fully uninstall the existing Admin App first and retry."
                 exit
             }
         }

--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -704,7 +704,7 @@ function CheckForCompatibleUpdate($webSitePath,  $existingAdminApp, $targetVersi
 
     if(-not $targetIsNewer)
     {
-        Write-Warning "Upgrade version $targetVersionString is the same or lower than existing installation $versionString. Downgrades are not supported. Exiting."
+        Write-Warning "Upgrade version $targetVersionString is the same or lower than existing installation $versionString. Downgrades are not supported. Instead,  fully uninstall the existing Admin App and install the desired version."
         exit
     }
 

--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -690,11 +690,15 @@ function GetExistingAppVersion($webSitePath,  $existingAdminApp) {
     return $existingApplicationPath, $versionString
 }
 
+function CheckVersionSupportsUpgrade($versionString) { 
+    $versionIsBeforeUpgradeSupport = IsVersionHigherThanOther '2.2' $versionString
+    return -not $versionIsBeforeUpgradeSupport
+}
+
 function CheckForCompatibleVersion($webSitePath,  $existingAdminApp) {
     $existingApplicationPath, $versionString = GetExistingAppVersion $webSitePath $existingAdminApp
 
-    $versionIsBeforeUpgradeSupport = IsVersionHigherThanOther '2.2' $versionString
-    if($versionIsBeforeUpgradeSupport)
+    if(-not (CheckVersionSupportsUpgrade $versionString))
     {
         Write-Warning "We found a preexisting Admin App $versionString installation. That version cannot be automatically upgraded in-place by this script. Please refer to https://techdocs.ed-fi.org/display/ADMIN/Upgrading+Admin+App+from+1.x+Line for setting up the newer version of AdminApp."
         exit
@@ -705,6 +709,12 @@ function CheckForCompatibleVersion($webSitePath,  $existingAdminApp) {
 
 function CheckForCompatibleUpdate($webSitePath,  $existingAdminApp, $targetVersionString) {
     $existingApplicationPath, $versionString = GetExistingAppVersion $webSitePath $existingAdminApp
+
+    if(-not (CheckVersionSupportsUpgrade $versionString))
+    {
+        Write-Warning "Preexisting Admin App version $versionString cannot be automatically upgraded in-place by this script. Please refer to https://techdocs.ed-fi.org/display/ADMIN/Upgrading+Admin+App+from+1.x+Line for setting up the newer version of AdminApp."
+        exit
+    }
 
     $targetIsNewer = IsVersionHigherThanOther $targetVersionString $versionString 
 

--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -564,7 +564,7 @@ function Invoke-InstallationPreCheck{
         if($webSite -AND $existingAdminAppApplication)
         {
             $sitePath = $webSite.PhysicalPath
-            $existingApplicationPath, $versionString = CheckForCompatibleVersion $sitePath $existingAdminAppApplication
+            $existingApplicationPath, $versionString = CheckForInstallVersion $sitePath $existingAdminAppApplication
 
             Write-Host "We found a preexisting Admin App $versionString installation. Most likely, you intended to use the upgrade script instead of this install script." -ForegroundColor Green
             $confirmation = Read-Host -Prompt "Please enter 'y' to continue the installation process, or enter 'n' to stop the installation so that you can instead run the upgrade script. Note: Using the upgrade script, all the appsettings and database connection string values would be copied forward from the existing installation, so only enter 'y' to continue if you are sure this is not an upgrade."
@@ -695,7 +695,7 @@ function CheckVersionSupportsUpgrade($versionString) {
     return -not $versionIsBeforeUpgradeSupport
 }
 
-function CheckForCompatibleVersion($webSitePath,  $existingAdminApp) {
+function CheckForInstallVersion($webSitePath,  $existingAdminApp) {
     $existingApplicationPath, $versionString = GetExistingAppVersion $webSitePath $existingAdminApp
 
     if(-not (CheckVersionSupportsUpgrade $versionString))

--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -700,10 +700,7 @@ function CheckForCompatibleVersion($webSitePath,  $existingAdminApp) {
 function CheckForCompatibleUpdate($webSitePath,  $existingAdminApp, $targetVersionString) {
     $existingApplicationPath, $versionString = CheckForCompatibleVersion $webSitePath $existingAdminApp
 
-    $currentVersion = [System.Version]::Parse($versionString)
-    $targetVersion = [System.Version]::Parse($targetVersionString)
-
-    $targetIsNewer = IsVersionHigherThanOther $targetVersion $currentVersion 
+    $targetIsNewer = IsVersionHigherThanOther $targetVersionString $versionString 
 
     if(-not $targetIsNewer)
     {

--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -687,12 +687,8 @@ function CheckForCompatibleVersion($webSitePath,  $existingAdminApp) {
     }
     $versionString = [System.Diagnostics.FileVersionInfo]::GetVersionInfo("$existingApplicationPath\EdFi.Ods.AdminApp.Web.exe").FileVersion
 
-    $requiredMajor = 2
-    $requiredMinor = 2
-    $existingApplicationVersion = [System.Version]::Parse($versionString)
-
-    if($existingApplicationVersion.Major -lt $requiredMajor -OR
-    ($existingApplicationVersion.Major -eq $requiredMajor -AND $existingApplicationVersion.Minor -lt $requiredMinor))
+    $versionIsBeforeUpgradeSupport = IsVersionHigherThanOther '2.2' $versionString
+    if($versionIsBeforeUpgradeSupport)
     {
         Write-Warning "We found a preexisting Admin App $versionString installation. That version cannot be automatically upgraded in-place by this script. Please refer to https://techdocs.ed-fi.org/display/ADMIN/Upgrading+Admin+App+from+1.x+Line for setting up the newer version of AdminApp."
         exit

--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -564,7 +564,7 @@ function Invoke-InstallationPreCheck{
         if($webSite -AND $existingAdminAppApplication)
         {
             $sitePath = $webSite.PhysicalPath
-            $existingApplicationPath, $versionString, $compatibleVersionIsInstalled = CheckForCompatibleVersion $sitePath $existingAdminAppApplication
+            $existingApplicationPath, $versionString = CheckForCompatibleVersion $sitePath $existingAdminAppApplication
 
             Write-Host "We found a preexisting Admin App $versionString installation. Most likely, you intended to use the upgrade script instead of this install script." -ForegroundColor Green
             $confirmation = Read-Host -Prompt "Please enter 'y' to continue the installation process, or enter 'n' to stop the installation so that you can instead run the upgrade script. Note: Using the upgrade script, all the appsettings and database connection string values would be copied forward from the existing installation, so only enter 'y' to continue if you are sure this is not an upgrade."
@@ -627,7 +627,7 @@ function Invoke-ApplicationUpgrade {
             $existingAppName = $customApplicationName
         }
 
-        $existingApplicationPath, $versionString, $compatibleVersionIsInstalled = CheckForCompatibleVersion $existingWebSitePath $existingAdminApp
+        $existingApplicationPath, $versionString = CheckForCompatibleVersion $existingWebSitePath $existingAdminApp
 
         Write-Host "Stopping the $existingWebSiteName before taking application files back up."
         Stop-IISSite -Name $existingWebSiteName
@@ -697,11 +697,8 @@ function CheckForCompatibleVersion($webSitePath,  $existingAdminApp) {
         Write-Warning "We found a preexisting Admin App $versionString installation. That version cannot be automatically upgraded in-place by this script. Please refer to https://techdocs.ed-fi.org/display/ADMIN/Upgrading+Admin+App+from+1.x+Line for setting up the newer version of AdminApp."
         exit
     }
-    else {
-        $compatibleVersionIsInstalled =$true
-    }
 
-    return $existingApplicationPath, $versionString, $compatibleVersionIsInstalled
+    return $existingApplicationPath, $versionString
 }
 
 function Invoke-TransferAppsettings {

--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -721,7 +721,13 @@ function IsVersionHigherThanOther($versionString, $otherVersionString) {
 
 function ParseVersionWithoutTag($versionString) {
     $splitByTags = $versionString -split '-'
-    return ([System.Version]::Parse($splitByTags[0]))
+    
+    try { return [System.Version]::Parse($splitByTags[0]) }
+    catch
+    {
+        Write-Warning "Failed to parse version configuration $versionString. Please correct and try again."
+        exit
+    }
 }
 
 function Invoke-TransferAppsettings {

--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -627,7 +627,7 @@ function Invoke-ApplicationUpgrade {
             $existingAppName = $customApplicationName
         }
 
-        $existingApplicationPath, $versionString = CheckForCompatibleVersion $existingWebSitePath $existingAdminApp
+        $existingApplicationPath, $versionString = CheckForCompatibleUpdate $existingWebSitePath $existingAdminApp $Config.PackageVersion
 
         Write-Host "Stopping the $existingWebSiteName before taking application files back up."
         Stop-IISSite -Name $existingWebSiteName
@@ -695,6 +695,23 @@ function CheckForCompatibleVersion($webSitePath,  $existingAdminApp) {
     ($existingApplicationVersion.Major -eq $requiredMajor -AND $existingApplicationVersion.Minor -lt $requiredMinor))
     {
         Write-Warning "We found a preexisting Admin App $versionString installation. That version cannot be automatically upgraded in-place by this script. Please refer to https://techdocs.ed-fi.org/display/ADMIN/Upgrading+Admin+App+from+1.x+Line for setting up the newer version of AdminApp."
+        exit
+    }
+
+    return $existingApplicationPath, $versionString
+}
+
+function CheckForCompatibleUpdate($webSitePath,  $existingAdminApp, $targetVersionString) {
+    $existingApplicationPath, $versionString = CheckForCompatibleVersion $webSitePath $existingAdminApp
+
+    $currentVersion = [System.Version]::Parse($versionString)
+    $targetVersion = [System.Version]::Parse($targetVersionString)
+
+    $comparison = $targetVersion.CompareTo($currentVersion)
+
+    if($comparison -le 0)
+    {
+        Write-Warning "Upgrade version $targetVersionString is the same or lower than existing installation $versionString. Downgrades are not supported. Exiting."
         exit
     }
 

--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -676,8 +676,7 @@ function Invoke-ApplicationUpgrade {
     }
 }
 
-function CheckForCompatibleVersion($webSitePath,  $existingAdminApp) {
-
+function GetExistingAppVersion($webSitePath,  $existingAdminApp) {
     $existingApplicationPath = ($existingAdminApp).PhysicalPath
     if(!$existingApplicationPath)
     {
@@ -685,7 +684,14 @@ function CheckForCompatibleVersion($webSitePath,  $existingAdminApp) {
         $appPath = $existingAdminApp.path.trimstart('/')
         $existingApplicationPath = "$webSitePath\$appPath"
     }
+
     $versionString = [System.Diagnostics.FileVersionInfo]::GetVersionInfo("$existingApplicationPath\EdFi.Ods.AdminApp.Web.exe").FileVersion
+
+    return $existingApplicationPath, $versionString
+}
+
+function CheckForCompatibleVersion($webSitePath,  $existingAdminApp) {
+    $existingApplicationPath, $versionString = GetExistingAppVersion $webSitePath $existingAdminApp
 
     $versionIsBeforeUpgradeSupport = IsVersionHigherThanOther '2.2' $versionString
     if($versionIsBeforeUpgradeSupport)
@@ -698,7 +704,7 @@ function CheckForCompatibleVersion($webSitePath,  $existingAdminApp) {
 }
 
 function CheckForCompatibleUpdate($webSitePath,  $existingAdminApp, $targetVersionString) {
-    $existingApplicationPath, $versionString = CheckForCompatibleVersion $webSitePath $existingAdminApp
+    $existingApplicationPath, $versionString = GetExistingAppVersion $webSitePath $existingAdminApp
 
     $targetIsNewer = IsVersionHigherThanOther $targetVersionString $versionString 
 

--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -707,15 +707,23 @@ function CheckForCompatibleUpdate($webSitePath,  $existingAdminApp, $targetVersi
     $currentVersion = [System.Version]::Parse($versionString)
     $targetVersion = [System.Version]::Parse($targetVersionString)
 
-    $comparison = $targetVersion.CompareTo($currentVersion)
+    $targetIsNewer = IsVersionHigherThanOther $targetVersion $currentVersion 
 
-    if($comparison -le 0)
+    if(-not $targetIsNewer)
     {
         Write-Warning "Upgrade version $targetVersionString is the same or lower than existing installation $versionString. Downgrades are not supported. Exiting."
         exit
     }
 
     return $existingApplicationPath, $versionString
+}
+
+function IsVersionHigherThanOther($versionString, $otherVersionString){
+    $version = [System.Version]::Parse($versionString)
+    $otherVersion = [System.Version]::Parse($otherVersionString)
+
+    $result = $version.CompareTo($otherVersion)
+    return $result -gt 0
 }
 
 function Invoke-TransferAppsettings {

--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -565,29 +565,27 @@ function Invoke-InstallationPreCheck{
         {
             $sitePath = $webSite.PhysicalPath
             $existingApplicationPath, $versionString, $compatibleVersionIsInstalled = CheckForCompatibleVersion $sitePath $existingAdminAppApplication
-            if($compatibleVersionIsInstalled)
+            if(-not $compatibleVersionIsInstalled)
             {
-                Write-Host "We found a preexisting Admin App $versionString installation. Most likely, you intended to use the upgrade script instead of this install script." -ForegroundColor Green
-                $confirmation = Read-Host -Prompt "Please enter 'y' to continue the installation process, or enter 'n' to stop the installation so that you can instead run the upgrade script. Note: Using the upgrade script, all the appsettings and database connection string values would be copied forward from the existing installation, so only enter 'y' to continue if you are sure this is not an upgrade."
-                if($confirmation -ieq 'y')
+                Write-Warning "We found a preexisting Admin App $versionString installation. That version cannot be automatically upgraded in-place by this script. Please refer to https://techdocs.ed-fi.org/display/ADMIN/Upgrading+Admin+App+from+1.x+Line for setting up the newer version of AdminApp."
+                exit
+            }
+
+            Write-Host "We found a preexisting Admin App $versionString installation. Most likely, you intended to use the upgrade script instead of this install script." -ForegroundColor Green
+            $confirmation = Read-Host -Prompt "Please enter 'y' to continue the installation process, or enter 'n' to stop the installation so that you can instead run the upgrade script. Note: Using the upgrade script, all the appsettings and database connection string values would be copied forward from the existing installation, so only enter 'y' to continue if you are sure this is not an upgrade."
+            if($confirmation -ieq 'y')
+            {
+                $appsettingsFile =  Join-Path $existingApplicationPath "appsettings.json"
+                if(Test-Path -Path $appsettingsFile)
                 {
-                    $appsettingsFile =  Join-Path $existingApplicationPath "appsettings.json"
-                    if(Test-Path -Path $appsettingsFile)
-                    {
-                        Write-Host "To ensure your existing ODS / API Key and Secret values will continue to work, your existing encryption key is being copied forward from the appsettings.json file at $appsettingsFile"
-                        $appSettings = Get-Content $appsettingsFile | ConvertFrom-Json | ConvertTo-Hashtable
-                        $Config.EncryptionKey = $appSettings.AppSettings.EncryptionKey
-                    }
-                }
-                else
-                {
-                    Write-Warning "Exiting the installation."
-                    exit
+                    Write-Host "To ensure your existing ODS / API Key and Secret values will continue to work, your existing encryption key is being copied forward from the appsettings.json file at $appsettingsFile"
+                    $appSettings = Get-Content $appsettingsFile | ConvertFrom-Json | ConvertTo-Hashtable
+                    $Config.EncryptionKey = $appSettings.AppSettings.EncryptionKey
                 }
             }
             else
             {
-                Write-Warning "We found a preexisting Admin App $versionString installation. That version cannot be automatically upgraded in-place by this script. Please refer to https://techdocs.ed-fi.org/display/ADMIN/Upgrading+Admin+App+from+1.x+Line for setting up the newer version of AdminApp."
+                Write-Warning "Exiting the installation."
                 exit
             }
         }

--- a/EdFi.Suite3.Installer.AdminApp/test.ps1
+++ b/EdFi.Suite3.Installer.AdminApp/test.ps1
@@ -147,6 +147,14 @@ function Invoke-Upgrade-OldVersion{
     Update-EdFiOdsAdminApp -PackageVersion $existingInCompatibleVersion
 }
 
+function Invoke-Upgrade-Nonsense{
+
+    Invoke-InstallApplication $existingCompatibleVersion
+
+    # Upgrade to not a version (should fail)
+    Update-EdFiOdsAdminApp -PackageVersion "asfjaslkdja"
+}
+
 function Invoke-InstallMultiInstanceSqlServer {
 
     $dbConnectionInfo = @{
@@ -235,6 +243,7 @@ try {
         "Upgrade-ApplicationWithCustomSettings" { Invoke-Upgrade-WithCustomSettings }
         "Upgrade-SameVersion" { Invoke-Upgrade-SameVersion }
         "Upgrade-OldVersion" { Invoke-Upgrade-OldVersion }
+        "Upgrade-Nonsense" { Invoke-Upgrade-Nonsense }
         "Uninstall" { Invoke-Uninstall }
         default {
             Write-Host "Valid test scenarios are: "
@@ -251,6 +260,7 @@ try {
             Write-Host "    Upgrade-ApplicationWithCustomSettings"
             Write-Host "    Upgrade-SameVersion"
             Write-Host "    Upgrade-OldVersion"
+            Write-Host "    Upgrade-Nonsense"
         }
     }
 }

--- a/EdFi.Suite3.Installer.AdminApp/test.ps1
+++ b/EdFi.Suite3.Installer.AdminApp/test.ps1
@@ -75,8 +75,16 @@ function Invoke-Install-InCompatibleVersion {
 
     Invoke-InstallApplication $existingInCompatibleVersion
 
-    # Install newer version
+    # Install newer version (should exit with warning)
     Invoke-InstallApplication $newVersion
+}
+
+function Invoke-Install-OldVersion {
+
+    Invoke-InstallApplication $existingInCompatibleVersion
+
+    # Install older version (should exit with warning)
+    Invoke-InstallApplication $existingInCompatibleVersion
 }
 
 function Invoke-Install-WithCustomSettings{
@@ -237,6 +245,7 @@ try {
         "InstallPostgresMultiInstance" { Invoke-InstallMultiInstancePostgres }
         "Install-CompatibleVersion" { Invoke-Install-CompatibleVersion }
         "Install-InCompatibleVersion" { Invoke-Install-InCompatibleVersion }
+        "Install-OldVersion" { Invoke-Install-OldVersion }
         "Install-WithCustomSettings" { Invoke-Install-WithCustomSettings }
         "Upgrade-CompatibleVersion" { Invoke-Upgrade-CompatibleVersion }
         "Upgrade-InCompatibleVersion" { Invoke-Upgrade-InCompatibleVersion }
@@ -254,6 +263,7 @@ try {
             Write-Host "    Uninstall"
             Write-Host "    Install-CompatibleVersion"
             Write-Host "    Install-InCompatibleVersion"
+            Write-Host "    Install-OldVersion"
             Write-Host "    Install-WithCustomSettings"
             Write-Host "    Upgrade-CompatibleVersion"
             Write-Host "    Upgrade-InCompatibleVersion"

--- a/EdFi.Suite3.Installer.AdminApp/test.ps1
+++ b/EdFi.Suite3.Installer.AdminApp/test.ps1
@@ -131,6 +131,22 @@ function Invoke-Upgrade-WithCustomSettings{
     Update-EdFiOdsAdminApp @upgradeParam
 }
 
+function Invoke-Upgrade-SameVersion{
+
+    Invoke-InstallApplication $existingCompatibleVersion
+
+    # Upgrade to same version (should fail)
+    Update-EdFiOdsAdminApp -PackageVersion $existingCompatibleVersion
+}
+
+function Invoke-Upgrade-OldVersion{
+
+    Invoke-InstallApplication $existingCompatibleVersion
+
+    # Upgrade to older version (should fail)
+    Update-EdFiOdsAdminApp -PackageVersion $existingInCompatibleVersion
+}
+
 function Invoke-InstallMultiInstanceSqlServer {
 
     $dbConnectionInfo = @{
@@ -217,6 +233,8 @@ try {
         "Upgrade-CompatibleVersion" { Invoke-Upgrade-CompatibleVersion }
         "Upgrade-InCompatibleVersion" { Invoke-Upgrade-InCompatibleVersion }
         "Upgrade-ApplicationWithCustomSettings" { Invoke-Upgrade-WithCustomSettings }
+        "Upgrade-SameVersion" { Invoke-Upgrade-SameVersion }
+        "Upgrade-OldVersion" { Invoke-Upgrade-OldVersion }
         "Uninstall" { Invoke-Uninstall }
         default {
             Write-Host "Valid test scenarios are: "
@@ -231,6 +249,8 @@ try {
             Write-Host "    Upgrade-CompatibleVersion"
             Write-Host "    Upgrade-InCompatibleVersion"
             Write-Host "    Upgrade-ApplicationWithCustomSettings"
+            Write-Host "    Upgrade-SameVersion"
+            Write-Host "    Upgrade-OldVersion"
         }
     }
 }


### PR DESCRIPTION
Adds a new check in the Upgrade script to verify the specified upgrade version is newer than the existing install.

In addition:

- adds helper function for version checking
  - update other compatibility check to use it as well
- minor readability refactors (favor early exit over `if/else`