### PR TITLE
[AA-1379] TPDM verification from Admin App

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Controllers/EducationOrganizationsControllerTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Controllers/EducationOrganizationsControllerTests.cs
@@ -19,6 +19,7 @@ using EdFi.Ods.AdminApp.Web.Models.ViewModels.EducationOrganizations;
 using Moq;
 using NUnit.Framework;
 using Shouldly;
+using System.Runtime.Caching;
 
 namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
 {
@@ -32,6 +33,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
         private Mock<InstanceContext> _mockInstanceContext;
         private Mock<ITabDisplayService> _tabDisplayService;
         private IInferExtensionDetails _inferExtensionDetails;
+        private Mock<IInferExtensionDetails> _mockInferExtensionDetails;
 
         [SetUp]
         public void Init()
@@ -41,7 +43,9 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             _mockOdsApiFacade = new Mock<IOdsApiFacade>();
             _mockInstanceContext = new Mock<InstanceContext>();
             _tabDisplayService = new Mock<ITabDisplayService>();
+            _mockInferExtensionDetails = new Mock<IInferExtensionDetails>();
             _inferExtensionDetails = new InferExtensionDetails(new Mock<ISimpleGetRequest>().Object);
+            MemoryCache.Default.Remove("TpdmExtensionVersion");
         }
 
         [Test]
@@ -351,6 +355,12 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
                 Name = name
             };
 
+            var tpdmVersionDetails = new TpdmExtensionDetails
+            {
+                TpdmVersion = "1.1.0", IsTpdmCommunityVersion = true
+            };            
+            _mockInferExtensionDetails.Setup(x => x.TpdmExtensionVersion(It.IsAny<string>())).Returns(tpdmVersionDetails);
+
             _mockOdsApiFacade.Setup(x => x.GetPsiSchoolById(schoolId))
                 .Returns(new PsiSchool());
             _mockMapper.Setup(x => x.Map<EditPsiSchoolModel>(It.IsAny<PsiSchool>()))
@@ -366,7 +376,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
                 .Returns(new List<SelectOptionModel>
                     {new SelectOptionModel {DisplayText = federalLocaleCode, Value = federalLocaleCodeValue}});
             _controller =
-                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _mockInferExtensionDetails.Object);
 
             // Act
             var result = _controller.EditPsiSchoolModal(schoolId).Result as PartialViewResult;
@@ -388,6 +398,53 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             var federalLocaleCodeOption = model.FederalLocaleCodeOptions.Single(x => x.Value != null);
             federalLocaleCodeOption.DisplayText.ShouldBe(federalLocaleCode);
             federalLocaleCodeOption.Value.ShouldBe(federalLocaleCodeValue);
+        }
+
+        [Test]
+        public void When_Perform_Get_Request_To_EditPsiSchoolModal_Return_PartialView_With_Expected_Model_On_TpdmCore()
+        {
+            // Arrange
+            const string gradeLevel = "FirstGrade";
+            var value = "Namespace#FirstGrade";
+            var schoolId = "id";
+            var name = "school";           
+
+            var editPsiSchoolModel = new EditPsiSchoolModel
+            {
+                Name = name
+            };
+
+            var tpdmVersionDetails = new TpdmExtensionDetails()
+            {
+                TpdmVersion = "1.1.0", IsTpdmCommunityVersion = false
+            };          
+            _mockInferExtensionDetails.Setup(x => x.TpdmExtensionVersion(It.IsAny<string>())).Returns(tpdmVersionDetails);
+
+            _mockOdsApiFacade.Setup(x => x.GetPsiSchoolById(schoolId))
+                .Returns(new PsiSchool());
+            _mockMapper.Setup(x => x.Map<EditPsiSchoolModel>(It.IsAny<PsiSchool>()))
+                .Returns(editPsiSchoolModel);
+            _mockOdsApiFacade.Setup(x => x.GetAllGradeLevels())
+                .Returns(new List<SelectOptionModel> { new SelectOptionModel { DisplayText = gradeLevel, Value = value } });
+            _mockOdsApiFacadeFactory.Setup(x => x.Create())
+                .Returns(Task.FromResult(_mockOdsApiFacade.Object));          
+            _controller =
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _mockInferExtensionDetails.Object);
+
+            // Act
+            var result = _controller.EditPsiSchoolModal(schoolId).Result as PartialViewResult;
+
+            // Assert
+            result.ShouldNotBeNull();
+            var model = (EditPsiSchoolModel)result.ViewData.Model;
+            model.ShouldNotBeNull();
+            model.GradeLevelOptions.Count.ShouldBeGreaterThan(0);
+            model.GradeLevelOptions.First().DisplayText.ShouldBe(gradeLevel);
+            model.GradeLevelOptions.First().Value.ShouldBe(value);
+            model.Name.ShouldMatch(name);
+
+            model.AccreditationStatusOptions.ShouldBeNull();
+            model.FederalLocaleCodeOptions.ShouldBeNull();        
         }
 
         [Test]
@@ -584,6 +641,12 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             const string federalLocaleCode = "Test Federal Locale Code";
             const string federalLocaleCodeValue = "Namespace#Test Federal Locale Code";
 
+            var tpdmVersionDetails = new TpdmExtensionDetails()
+            {
+                TpdmVersion = "1.1.0", IsTpdmCommunityVersion = true
+            };          
+            _mockInferExtensionDetails.Setup(x => x.TpdmExtensionVersion(It.IsAny<string>())).Returns(tpdmVersionDetails);
+
             _mockOdsApiFacade.Setup(x => x.GetAllPsiSchools()).Returns(schools);
             _mockOdsApiFacade.Setup(x => x.GetLocalEducationAgenciesByPage(0, Page<LocalEducationAgency>.DefaultPageSize + 1)).Returns(leas);
             _mockOdsApiFacade.Setup(x => x.GetPostSecondaryInstitutionsByPage(0, Page<PostSecondaryInstitution>.DefaultPageSize + 1)).Returns(psis);
@@ -604,7 +667,82 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
                 .Returns(new List<SelectOptionModel>
                     {new SelectOptionModel {DisplayText = federalLocaleCode, Value = federalLocaleCodeValue}});
             _controller =
-                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _mockInferExtensionDetails.Object);
+
+            // Act
+            var result = _controller.PostSecondaryInstitutionsList(1).Result as PartialViewResult;
+
+            // Assert
+            result.ShouldNotBeNull();
+            var model = (PostSecondaryInstitutionViewModel)result.ViewData.Model;
+            model.ShouldNotBeNull();
+            model.Schools.Count.ShouldBeGreaterThan(0);
+            model.PostSecondaryInstitutions.Items.Count().ShouldBeGreaterThan(0);
+
+            var addSchoolModel = model.AddPsiSchoolModel;
+            addSchoolModel.ShouldNotBeNull();
+            addSchoolModel.GradeLevelOptions.Count.ShouldBe(1);
+            addSchoolModel.GradeLevelOptions.Single().DisplayText.ShouldBe(gradeLevel);
+            addSchoolModel.GradeLevelOptions.Single().Value.ShouldBe(value);
+
+            var addPostSecondaryInstitutionModel = model.AddPostSecondaryInstitutionModel;
+            addPostSecondaryInstitutionModel.ShouldNotBeNull();
+            addPostSecondaryInstitutionModel.PostSecondaryInstitutionLevelOptions.Count.ShouldBeGreaterThan(0);
+            addPostSecondaryInstitutionModel.AdministrativeFundingControlOptions.Count.ShouldBeGreaterThan(0);
+            var postSecondaryInstitutionLevelOption = addPostSecondaryInstitutionModel.PostSecondaryInstitutionLevelOptions.Single(x => x.Value != null);
+            postSecondaryInstitutionLevelOption.DisplayText.ShouldBe(postSecondaryInstitutionLevel);
+            postSecondaryInstitutionLevelOption.Value.ShouldBe(postSecondaryInstitutionLevelValue);
+            var administrativeFundingControlOption = addPostSecondaryInstitutionModel.AdministrativeFundingControlOptions.Single(x => x.Value != null);
+            administrativeFundingControlOption.DisplayText.ShouldBe(administrativeFundingControl);
+            administrativeFundingControlOption.Value.ShouldBe(administrativeFundingControlValue);
+        }
+
+        [Test]
+        public void When_Perform_Get_Request_To_PostSecondaryInstitutionsList_Return_Post_Secondary_Institutions_List_On_TpdmCore()
+        {
+            // Arrange
+            var schools = new List<PsiSchool>
+            {
+                new PsiSchool()
+            };
+
+            var leas = new List<LocalEducationAgency>
+            {
+                new LocalEducationAgency()
+            };
+
+            var psis = new List<PostSecondaryInstitution>
+            {
+                new PostSecondaryInstitution()
+            };
+            const string gradeLevel = "FirstGrade";
+            const string value = "Namespace#FirstGrade";
+            const string postSecondaryInstitutionLevel = "Four or more years";
+            const string postSecondaryInstitutionLevelValue = "Namespace#Four or more years";
+            const string administrativeFundingControl = "Private School";
+            const string administrativeFundingControlValue = "Namespace#Private School";          
+
+            var tpdmVersionDetails = new TpdmExtensionDetails()
+            {
+                TpdmVersion = "1.1.0", IsTpdmCommunityVersion = false
+            };
+            _mockInferExtensionDetails.Setup(x => x.TpdmExtensionVersion(It.IsAny<string>())).Returns(tpdmVersionDetails);
+
+            _mockOdsApiFacade.Setup(x => x.GetAllPsiSchools()).Returns(schools);
+            _mockOdsApiFacade.Setup(x => x.GetLocalEducationAgenciesByPage(0, Page<LocalEducationAgency>.DefaultPageSize + 1)).Returns(leas);
+            _mockOdsApiFacade.Setup(x => x.GetPostSecondaryInstitutionsByPage(0, Page<PostSecondaryInstitution>.DefaultPageSize + 1)).Returns(psis);
+            _mockOdsApiFacadeFactory.Setup(x => x.Create())
+                .Returns(Task.FromResult(_mockOdsApiFacade.Object));
+            _mockOdsApiFacade.Setup(x => x.GetAllGradeLevels())
+                .Returns(new List<SelectOptionModel> { new SelectOptionModel { DisplayText = gradeLevel, Value = value } });
+            _mockOdsApiFacade.Setup(x => x.GetPostSecondaryInstitutionLevels())
+                .Returns(new List<SelectOptionModel>
+                    {new SelectOptionModel {DisplayText = postSecondaryInstitutionLevel, Value = postSecondaryInstitutionLevelValue}});
+            _mockOdsApiFacade.Setup(x => x.GetAdministrativeFundingControls())
+                .Returns(new List<SelectOptionModel>
+                    {new SelectOptionModel {DisplayText = administrativeFundingControl, Value = administrativeFundingControlValue}});         
+            _controller =
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _mockInferExtensionDetails.Object);
 
             // Act
             var result = _controller.PostSecondaryInstitutionsList(1).Result as PartialViewResult;

--- a/Application/EdFi.Ods.AdminApp.Management/Api/InferExtensionDetails.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/InferExtensionDetails.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System;
+using System.Globalization;
 using EdFi.Ods.AdminApp.Management.Services;
 using Newtonsoft.Json.Linq;
 
@@ -11,7 +12,7 @@ namespace EdFi.Ods.AdminApp.Management.Api
 {
     public interface IInferExtensionDetails
     {
-        string TpdmExtensionVersion(string apiServerUrl);
+        TpdmExtensionDetails TpdmExtensionVersion(string apiServerUrl);        
     }
 
     public class InferExtensionDetails : IInferExtensionDetails
@@ -20,27 +21,42 @@ namespace EdFi.Ods.AdminApp.Management.Api
 
         public InferExtensionDetails(ISimpleGetRequest getRequest) => _getRequest = getRequest;
 
-        public string TpdmExtensionVersion(string apiServerUrl)
+        public TpdmExtensionDetails TpdmExtensionVersion(string apiServerUrl)
+        {
+            return GetVersion(apiServerUrl);          
+        }
+
+        private TpdmExtensionDetails GetVersion(string apiServerUrl)
         {
             var response = JToken.Parse(_getRequest.DownloadString(apiServerUrl));
-
+            var versionDetails = new TpdmExtensionDetails();
             if (response["dataModels"] is JArray dataModels)
             {
                 foreach (var dataModel in dataModels)
                 {
                     if (dataModel is JObject && dataModel["name"] is JValue nameToken)
-                        if (nameToken.ToString().ToUpper() == "TPDM")
+                        if (nameToken.ToString(CultureInfo.InvariantCulture).ToUpper() == "TPDM")
+                        {
                             if (dataModel["version"] is JValue versionToken)
                             {
-                                var version = versionToken.ToString();
-
-                                if (new Version(version) >= new Version("1.0.0"))
-                                    return version;
+                                var version = versionToken.ToString(CultureInfo.InvariantCulture);
+                                versionDetails.TpdmVersion = new Version(version) >= new Version("1.0.0") ? version : string.Empty;
                             }
+                            versionDetails.IsTpdmCommunityVersion = dataModel["informationalVersion"] == null
+                                    || !(dataModel["informationalVersion"] is JValue informationalVersionToken
+                                    && informationalVersionToken.ToString(CultureInfo.InvariantCulture).ToLower().Equals("tpdm-core"));
+                        }
                 }
             }
 
-            return "";
+            return versionDetails;
         }
+    }
+
+    public class TpdmExtensionDetails
+    {
+        public string TpdmVersion { get; set; }
+
+        public bool IsTpdmCommunityVersion { get; set; }       
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ApplicationController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ApplicationController.cs
@@ -276,12 +276,12 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
 
         private bool TpdmEnabled()
         {
-            var version = InMemoryCache.Instance.GetOrSet(
+            var versionDetails = InMemoryCache.Instance.GetOrSet(
                 "TpdmExtensionVersion", () =>
                     _inferExtensionDetails.TpdmExtensionVersion(
                         CloudOdsAdminAppSettings.Instance.ProductionApiUrl));
 
-            return !string.IsNullOrEmpty(version);
+            return !string.IsNullOrEmpty(versionDetails.TpdmVersion);
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/OdsInstanceSettingsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/OdsInstanceSettingsController.cs
@@ -73,10 +73,12 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
                 model.OdsApiVersion = InMemoryCache.Instance
                     .GetOrSet("OdsApiVersion", () => new InferOdsApiVersion().Version(CloudOdsAdminAppSettings.Instance.ProductionApiUrl));
 
-                model.TpdmVersion = InMemoryCache.Instance.GetOrSet(
+                var tpdmVersionDetails =InMemoryCache.Instance.GetOrSet(
                     "TpdmExtensionVersion", () =>
                         _inferExtensionDetails.TpdmExtensionVersion(
                             CloudOdsAdminAppSettings.Instance.ProductionApiUrl));
+
+                model.TpdmVersion = tpdmVersionDetails.TpdmVersion;
             }
             catch (Exception exception)
             {

--- a/Application/EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_AddPsiSchoolModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_AddPsiSchoolModal.cshtml
@@ -30,11 +30,11 @@ See the LICENSE and NOTICES files in the project root for more information.
                 @Html.InputBlock(m => m.City).AddClass("reset-included")
                 @Html.SelectListBlock(m => m.State, Model.StateOptions, x => new SelectListItem { Text = x.DisplayText, Value = x.Value })
                 @Html.InputBlock(m => m.ZipCode).AddClass("reset-included")
-                if (Model.AccreditationStatusOptions.Count > 1)
+                if (Model.AccreditationStatusOptions != null && Model.AccreditationStatusOptions.Count > 1)
                 {
                     @Html.SelectListBlock(m => m.AccreditationStatus, Model.AccreditationStatusOptions, x => new SelectListItem { Text = x.DisplayText, Value = x.Value })
                 }
-                if (Model.FederalLocaleCodeOptions.Count > 1)
+                if (Model.FederalLocaleCodeOptions != null && Model.FederalLocaleCodeOptions.Count > 1)
                 {
                     @Html.SelectListBlock(m => m.FederalLocaleCode, Model.FederalLocaleCodeOptions, x => new SelectListItem { Text = x.DisplayText, Value = x.Value })
                 }

--- a/Application/EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_EditPsiSchoolModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/EducationOrganizations/_EditPsiSchoolModal.cshtml
@@ -29,11 +29,11 @@ See the LICENSE and NOTICES files in the project root for more information.
                     @Html.InputBlock(m => m.City)
                     @Html.SelectListBlock(m => m.State, Model.StateOptions, x => new SelectListItem { Text = x.DisplayText, Value = x.Value, Selected = Model.State == x.Value })
                     @Html.InputBlock(m => m.ZipCode)
-                    if (Model.AccreditationStatusOptions.Count > 1)
+                    if (Model.AccreditationStatusOptions != null && Model.AccreditationStatusOptions.Count > 1)
                     {
                         @Html.SelectListBlock(m => m.AccreditationStatus, Model.AccreditationStatusOptions, x => new SelectListItem { Text = x.DisplayText, Value = x.Value, Selected = Model.AccreditationStatus == x.Value})
                     }
-                    if (Model.FederalLocaleCodeOptions.Count > 1)
+                    if (Model.FederalLocaleCodeOptions != null && Model.FederalLocaleCodeOptions.Count > 1)
                     {
                         @Html.SelectListBlock(m => m.FederalLocaleCode, Model.FederalLocaleCodeOptions, x => new SelectListItem { Text = x.DisplayText, Value = x.Value, Selected = Model.FederalLocaleCode == x.Value})
                     }


### PR DESCRIPTION
@pmcvtm @saa14 
Please help review and merge the changes.
Changes include to 
* Find the tpdm informational (core, community) version. 
* If no informational version present on the tpdm module or tpdm-community then will consider as "tpdm-community", so will populate the FederalLocaleCodes, AccreditationStatusOptions dropdowns on the Psi School page. 
* If tpdm module is "tpdm-core", then those dropdowns won't be populated ( wont try accessing the "/tpdm/federalLocaleCodeDescriptors", "/tpdm/accreditationStatusDescriptors")
Thanks