### PR TITLE
[AA-1386] Upgrade script is not working with newer 'pre' versions

### DIFF
--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -734,14 +734,14 @@ function CheckForCompatibleUpdate($webSitePath,  $existingAdminApp, $targetVersi
 }
 
 function IsVersionHigherThanOther($versionString, $otherVersionString) {
-    $version = ParseVersionWithoutTag($versionString)
-    $otherVersion = ParseVersionWithoutTag($otherVersionString)
+    $version = ParseVersion($versionString)
+    $otherVersion = ParseVersion($otherVersionString)
 
     $result = $version.CompareTo($otherVersion)
     return $result -gt 0
 }
 
-function ParseVersionWithoutTag($versionString) {
+function ParseVersion($versionString) {
     $splitByTags = $versionString -split '-'
     $version = $splitByTags[0];
 

--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -743,8 +743,17 @@ function IsVersionHigherThanOther($versionString, $otherVersionString) {
 
 function ParseVersionWithoutTag($versionString) {
     $splitByTags = $versionString -split '-'
+    $version = $splitByTags[0];
 
-    try { return [System.Version]::Parse($splitByTags[0]) }
+    for ($i = 1; $i -lt $splitByTags.Length; $i++) {
+        $preVersion = $splitByTags[$i] -replace '[^0-9.]', ''
+        $cleanedPreVersion = $preVersion.Trim('.')
+        if($cleanedPreVersion -ne '') {
+            $version += ".$cleanedPreVersion"
+        }
+    }
+
+    try { return [System.Version]::Parse($version) }
     catch
     {
         Write-Warning "Failed to parse version configuration $versionString. Please correct and try again."

--- a/EdFi.Suite3.Installer.AdminApp/test.ps1
+++ b/EdFi.Suite3.Installer.AdminApp/test.ps1
@@ -261,6 +261,7 @@ try {
         "Upgrade-SameVersion" { Invoke-Upgrade-SameVersion }
         "Upgrade-OldVersion" { Invoke-Upgrade-OldVersion }
         "Upgrade-Nonsense" { Invoke-Upgrade-Nonsense }
+        "Upgrade-Prerelease" { Invoke-Upgrade-Prerelease }
         "Uninstall" { Invoke-Uninstall }
         default {
             Write-Host "Valid test scenarios are: "
@@ -279,6 +280,7 @@ try {
             Write-Host "    Upgrade-SameVersion"
             Write-Host "    Upgrade-OldVersion"
             Write-Host "    Upgrade-Nonsense"
+            Write-Host "    Upgrade-Prerelease"
         }
     }
 }

--- a/EdFi.Suite3.Installer.AdminApp/test.ps1
+++ b/EdFi.Suite3.Installer.AdminApp/test.ps1
@@ -163,6 +163,14 @@ function Invoke-Upgrade-Nonsense{
     Update-EdFiOdsAdminApp -PackageVersion "asfjaslkdja"
 }
 
+function Invoke-Upgrade-Prerelease{
+
+    Invoke-InstallApplication '2.3.0.41'
+
+    # Upgrade to newer 'pre' build (should succeed)
+    Update-EdFiOdsAdminApp -PackageVersion "2.3.0-pre0043"
+}
+
 function Invoke-InstallMultiInstanceSqlServer {
 
     $dbConnectionInfo = @{

--- a/EdFi.Suite3.Installer.AdminApp/test.ps1
+++ b/EdFi.Suite3.Installer.AdminApp/test.ps1
@@ -165,10 +165,10 @@ function Invoke-Upgrade-Nonsense{
 
 function Invoke-Upgrade-Prerelease{
 
-    Invoke-InstallApplication '2.3.0.41'
+    Invoke-InstallApplication '2.3.0-pre0003'
 
     # Upgrade to newer 'pre' build (should succeed)
-    Update-EdFiOdsAdminApp -PackageVersion "2.3.0-pre0043"
+    Update-EdFiOdsAdminApp -PackageVersion "2.3.0-pre0005"
 }
 
 function Invoke-InstallMultiInstanceSqlServer {


### PR DESCRIPTION
Restores support for checking and comparing `-pre####` versions when using the Upgrade installer script.

Version number is extracted from the `-` tag and appended to the rest of the build number.
For example `2.0.1-pre003` is treated as `2.0.1.003` during version comparison (leading zeros are ignored by default as well)

Supports exhaustive multi-part or multi-tag versions if necessary: `2.0.1-pre003.2-build004` becomes `2.0.1.003.2.004`, though such a versioning scheme would not be recommended for actual use.