### PR TITLE
[EDFI-991] Missing TLS Configuration During Build

### DIFF
--- a/eng/package-manager.psm1
+++ b/eng/package-manager.psm1
@@ -37,6 +37,11 @@ function MeetsMinimumNuGetVersion {
     }
 }
 
+function Set-TlsVersion {
+
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls11 -bor [Net.SecurityProtocolType]::Tls12 -bor [Net.SecurityProtocolType]::Tls13
+}
+
 function Install-NugetCli {
     param(
         [string]
@@ -65,6 +70,7 @@ function Install-NugetCli {
 
     Write-Host "Downloading nuget.exe official distribution from " $sourceNugetExe
     Write-Host "Saving to $exePath"
+    Set-TlsVersion
     Invoke-WebRequest $sourceNugetExe -OutFile $exePath
 
     return $exePath


### PR DESCRIPTION
Update the TLS configuration before fetching the nuget.exe from the web to ensure the download executes correctly regardless of server config.

To test:
- Remove nuget from PATH environment variable (if you have one)
- Delete `eng\.tools\nuget.exe`
- Run default `build.ps1`

Build should fetch `nuget.exe` and continue executing successfully.