### PR TITLE
[AA-1380] Admin App Installer issue on re-installation 

### DIFF
--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+﻿# SPDX-License-Identifier: Apache-2.0
 # Licensed to the Ed-Fi Alliance under one or more agreements.
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
@@ -164,10 +164,6 @@ function Install-EdFiOdsAdminApp {
         [int]
         $WebSitePort = 443,
 
-        # Directory for the web application. Default: "AdminApp".
-        [string]
-        $WebApplicationDirectory = "AdminApp",
-
         # Web application name. Default: "AdminApp".
         [string]
         $WebApplicationName = "AdminApp",
@@ -273,7 +269,7 @@ function Install-EdFiOdsAdminApp {
     $result = @()
 
     $Config = @{
-        WebApplicationPath = (Join-Path $WebSitePath $WebApplicationDirectory)
+        WebApplicationPath = (Join-Path $WebSitePath $WebApplicationName)
         PackageName = $PackageName
         PackageVersion = $PackageVersion
         PackageSource = $PackageSource
@@ -377,10 +373,6 @@ function Update-EdFiOdsAdminApp {
         [int]
         $WebSitePort = 443,
 
-        # Directory for the web application. Default: "AdminApp".
-        [string]
-        $WebApplicationDirectory = "AdminApp",
-
         # Web application name. Default: "AdminApp".
         [string]
         $WebApplicationName = "AdminApp",
@@ -424,7 +416,7 @@ function Update-EdFiOdsAdminApp {
     $result = @()
 
     $Config = @{
-        WebApplicationPath = (Join-Path $WebSitePath $WebApplicationDirectory)
+        WebApplicationPath = (Join-Path $WebSitePath $WebApplicationName)
         PackageName = $PackageName
         PackageVersion = $PackageVersion
         PackageSource = $PackageSource
@@ -488,8 +480,8 @@ function Uninstall-EdFiOdsAdminApp {
     .EXAMPLE
         PS c:\> $p = @{
             WebSiteName="Ed-Fi-3"
-            WebApplicationPath="d:/octopus/applications/staging/AdminApp-3"
-            WebApplicationName = "AdminApp"
+            WebApplicationPath="c:/inetpub/Ed-Fi-3/AdminApp-3"
+            WebApplicationName = "AdminApp-3"
         }
         PS c:\> Uninstall-EdFiOdsAdminApp @p
 

--- a/EdFi.Suite3.Installer.AdminApp/test.ps1
+++ b/EdFi.Suite3.Installer.AdminApp/test.ps1
@@ -40,7 +40,6 @@ function Invoke-InstallApplication{
         [string] $Version,
         [string] $WebSiteName = "Ed-Fi",
         [string] $WebSitePath = "c:\inetpub\Ed-Fi",
-        [string] $WebApplicationDirectory = "AdminApp",
         [string] $WebApplicationName = "AdminApp"
     )
 
@@ -57,7 +56,6 @@ function Invoke-InstallApplication{
         PackageVersion = $Version
         WebSiteName = $WebSiteName
         WebSitePath = $WebSitePath
-        WebApplicationDirectory = $WebApplicationDirectory
         WebApplicationName = $WebApplicationName
     }
     Install-EdFiOdsAdminApp @p
@@ -94,7 +92,6 @@ function Invoke-Install-WithCustomSettings{
         Version = $newVersion
         WebSiteName = "Ed-Fi-Custom"
         WebSitePath = "c:\inetpub\Ed-Fi-Custom"
-        WebApplicationDirectory = "AdminApp-Custom"
         WebApplicationName = "AdminApp-Custom"
     }
     Invoke-InstallApplication @p
@@ -124,7 +121,6 @@ function Invoke-Upgrade-WithCustomSettings{
         Version = $existingCompatibleVersion
         WebSiteName = "Ed-Fi-Custom"
         WebSitePath = "c:\inetpub\Ed-Fi-Custom"
-        WebApplicationDirectory = "AdminApp-Custom"
         WebApplicationName = "AdminApp-Custom"
     }
     Invoke-InstallApplication @p
@@ -133,7 +129,6 @@ function Invoke-Upgrade-WithCustomSettings{
         PackageVersion = $newVersion
         WebSiteName = "Ed-Fi-Custom"
         WebSitePath = "c:\inetpub\Ed-Fi-Custom"
-        WebApplicationDirectory = "AdminApp-Custom"
         WebApplicationName = "AdminApp-Custom"
     }
     Update-EdFiOdsAdminApp @upgradeParam

--- a/EdFi.Suite3.Installer.AdminApp/uninstall.ps1
+++ b/EdFi.Suite3.Installer.AdminApp/uninstall.ps1
@@ -12,8 +12,8 @@ This script will uninstall your existing Admin App installation.
     $p = @{
         ToolsPath = "C:/temp/tools"
         WebSiteName="Ed-Fi-3"
-        WebApplicationPath="d:/edfi/applications/staging/AdminApp-3"
-        WebApplicationName = "AdminApp"
+        WebApplicationPath="c:/inetpub/Ed-Fi-3/AdminApp-3"
+        WebApplicationName = "AdminApp-3"
     }
 #>
 


### PR DESCRIPTION
@pmcvtm @saa14 
Please help review and merge the changes.
1. Removed WebApplicationDirectory, since it was confusing to have both WebApplicationname and WebApplicationDirectory. 
If user wants to provide custom name for AdminApp application, it can be provided with WebApplicationname  parameter. Internally the WebApplication path will be generated by combining Websitepath and WebApplicationname
2. Actual error (AA-1380) cannot be reproduced, since user doesn't have option to provide two different values for WebApplicationname and WebApplicationDirectory as before.
3. Testing: General testing on install, upgrade and uninstall flows. For testing with custom values Install-WithCustomSettings, Upgrade-ApplicationWithCustomSettings scenarios from .\test.ps1 can be used.
Thanks