### PR TITLE
[AA-1392] Success Message When Delete Fails

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.UnitTests/Api/OdsApiFacadeTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.UnitTests/Api/OdsApiFacadeTests.cs
@@ -312,13 +312,11 @@ namespace EdFi.Ods.AdminApp.Management.UnitTests.Api
             _facade = new OdsApiFacade(_mapper, mockOdsRestClient);
 
             // Act
-            var ex = Assert.Throws<OdsApiConnectionException>(() => _facade.GetAllDescriptors());
+            var result = _facade.DeleteSchool(SchoolId);
 
             // Assert
-            Assert.AreEqual(errorMsg, ex.ResponseMessage);
-
-            // Assert
-            ex.Message.ShouldBe(errorMsg);
+            result.Success.ShouldBe(false);
+            result.ErrorMessage.ShouldBe(errorMsg);
         }
 
         [Test]

--- a/Application/EdFi.Ods.AdminApp.Management.UnitTests/Api/OdsApiFacadeTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.UnitTests/Api/OdsApiFacadeTests.cs
@@ -294,6 +294,34 @@ namespace EdFi.Ods.AdminApp.Management.UnitTests.Api
         }
 
         [Test]
+        public void Should_DeleteSchool_returns_not_success_result_when_api_returns_not_ok_response()
+        {
+            // Arrange
+            const string errorMsg = "exception";
+            var mockRestClient = new Mock<IRestClient>();
+            mockRestClient.Setup(x => x.BaseUrl).Returns(new Uri(_connectionInformation.ApiBaseUrl));
+            mockRestClient.Setup(x => x.Execute(It.IsAny<RestRequest>())).Returns(new RestResponse
+                { StatusCode = HttpStatusCode.NotFound, ErrorMessage = errorMsg });
+
+            var mockTokenRetriever = new Mock<ITokenRetriever>();
+            mockTokenRetriever.Setup(x => x.ObtainNewBearerToken()).Returns("Token");
+
+            var mockOdsRestClient =
+                new OdsRestClient(_connectionInformation, mockRestClient.Object, mockTokenRetriever.Object);
+
+            _facade = new OdsApiFacade(_mapper, mockOdsRestClient);
+
+            // Act
+            var ex = Assert.Throws<OdsApiConnectionException>(() => _facade.GetAllDescriptors());
+
+            // Assert
+            Assert.AreEqual(errorMsg, ex.ResponseMessage);
+
+            // Assert
+            ex.Message.ShouldBe(errorMsg);
+        }
+
+        [Test]
         public void Should_GetAllDescriptors_returns_expected_descriptors_list()
         {
             // Arrange

--- a/Application/EdFi.Ods.AdminApp.Management.UnitTests/Api/OdsApiFacadeTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.UnitTests/Api/OdsApiFacadeTests.cs
@@ -13,6 +13,7 @@ using EdFi.Ods.AdminApp.Management.Api.Automapper;
 using EdFi.Ods.AdminApp.Management.Api.Common;
 using EdFi.Ods.AdminApp.Management.Api.DomainModels;
 using EdFi.Ods.AdminApp.Management.Api.Models;
+using EdFi.Ods.AdminApp.Management.ErrorHandling;
 using EdFi.Ods.AdminApp.Management.Instances;
 using NUnit.Framework;
 using Moq;
@@ -99,7 +100,7 @@ namespace EdFi.Ods.AdminApp.Management.UnitTests.Api
             _facade = new OdsApiFacade(_mapper, mockOdsRestClient);
 
             //Act
-            var ex = Assert.Throws<Exception>(() => _facade.GetAllSchools());
+            var ex = Assert.Throws<OdsApiConnectionException>(() => _facade.GetAllSchools());
 
             // Assert
             Assert.AreEqual(errorMessage, ex.Message);
@@ -154,7 +155,7 @@ namespace EdFi.Ods.AdminApp.Management.UnitTests.Api
             _facade = new OdsApiFacade(_mapper, mockOdsRestClient);
 
             //Act
-            var ex = Assert.Throws<Exception>(() => _facade.GetSchoolsByLeaIds(new List<int> { LocalEducationAgencyId }));
+            var ex = Assert.Throws<OdsApiConnectionException>(() => _facade.GetSchoolsByLeaIds(new List<int> { LocalEducationAgencyId }));
 
             // Assert
             Assert.AreEqual(errorMessage, ex.Message);
@@ -200,7 +201,7 @@ namespace EdFi.Ods.AdminApp.Management.UnitTests.Api
             _facade = new OdsApiFacade(_mapper, mockOdsRestClient);
 
             //Act
-            var ex = Assert.Throws<Exception>(() => _facade.GetSchoolById(SchoolId));
+            var ex = Assert.Throws<OdsApiConnectionException>(() => _facade.GetSchoolById(SchoolId));
 
             // Assert
             Assert.AreEqual(errorMessage, ex.Message);
@@ -341,7 +342,7 @@ namespace EdFi.Ods.AdminApp.Management.UnitTests.Api
             _facade = new OdsApiFacade(_mapper, mockOdsRestClient);
 
             //Act
-            var ex = Assert.Throws<Exception>(() => _facade.GetAllDescriptors());
+            var ex = Assert.Throws<OdsApiConnectionException>(() => _facade.GetAllDescriptors());
 
             // Assert
             Assert.AreEqual(errorMessage, ex.Message);

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiResult.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiResult.cs
@@ -3,30 +3,11 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using RestSharp;
-using RestSharp.Serialization.Json;
-
 namespace EdFi.Ods.AdminApp.Management.Api
 {
     public class OdsApiResult
     {
         public string ErrorMessage { get; set; }
         public bool Success => string.IsNullOrEmpty(ErrorMessage);
-
-        public OdsApiResult() { }
-        public OdsApiResult(IRestResponse response)
-        {
-            if (!response.IsSuccessful)
-            {
-                var content = JsonConvert.DeserializeObject<JObject>(response.Content);
-                content.TryGetValue("message", out var contentMessage);
-
-                ErrorMessage = !string.IsNullOrEmpty(response.ErrorMessage)
-                    ? response.ErrorMessage
-                    : contentMessage?.ToString() ?? $"ODS API failure with no message. Status Code: {response.StatusCode}";
-            }
-        }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiResult.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiResult.cs
@@ -20,9 +20,12 @@ namespace EdFi.Ods.AdminApp.Management.Api
         {
             if (!response.IsSuccessful)
             {
+                var content = JsonConvert.DeserializeObject<JObject>(response.Content);
+                content.TryGetValue("message", out var contentMessage);
+
                 ErrorMessage = !string.IsNullOrEmpty(response.ErrorMessage)
                     ? response.ErrorMessage
-                    : $"ODS API failure with no message. Status Code: {response.StatusCode}";
+                    : contentMessage?.ToString() ?? $"ODS API failure with no message. Status Code: {response.StatusCode}";
             }
         }
     }

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiResult.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiResult.cs
@@ -3,11 +3,25 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using RestSharp;
+using RestSharp.Serialization.Json;
+
 namespace EdFi.Ods.AdminApp.Management.Api
 {
     public class OdsApiResult
     {
         public string ErrorMessage { get; set; }
         public bool Success => string.IsNullOrEmpty(ErrorMessage);
+
+        public OdsApiResult() { }
+        public OdsApiResult(IRestResponse response)
+        {
+            if (!response.IsSuccessful)
+            {
+                ErrorMessage = response.ErrorMessage;
+            }
+        }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiResult.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiResult.cs
@@ -20,7 +20,9 @@ namespace EdFi.Ods.AdminApp.Management.Api
         {
             if (!response.IsSuccessful)
             {
-                ErrorMessage = response.ErrorMessage;
+                ErrorMessage = !string.IsNullOrEmpty(response.ErrorMessage)
+                    ? response.ErrorMessage
+                    : $"ODS API failure with no message. Status Code: {response.StatusCode}";
             }
         }
     }

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
@@ -80,7 +80,7 @@ namespace EdFi.Ods.AdminApp.Management.Api
             pageItems = JsonConvert.DeserializeObject<List<T>>(restResponse.Content);
             responseList.AddRange(pageItems);
 
-            return responseList; 
+            return responseList;
         }
 
         public IReadOnlyList<T> GetAll<T>(string elementPath) where T : class
@@ -108,7 +108,7 @@ namespace EdFi.Ods.AdminApp.Management.Api
             }
             while (pageItems.Count >= limit);
 
-            return responseList; 
+            return responseList;
         }
 
         public IReadOnlyList<T> GetAll<T>(string elementPath, Dictionary<string, object> filters) where T : class

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using EdFi.Ods.AdminApp.Management.ErrorHandling;
 using log4net;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -61,7 +62,7 @@ namespace EdFi.Ods.AdminApp.Management.Api
                 _logger.Debug("*** ErrorException:");
                 _logger.Debug(response.ErrorException);
 
-                throw new Exception(response.ErrorMessage);
+                throw new OdsApiConnectionException(response.StatusCode, response.ErrorMessage, response.ErrorException?.Message);
             }
         }
 

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
@@ -62,7 +62,7 @@ namespace EdFi.Ods.AdminApp.Management.Api
                 _logger.Debug("*** ErrorException:");
                 _logger.Debug(response.ErrorException);
 
-                throw new OdsApiConnectionException(response.StatusCode, response.ErrorMessage, response.ErrorException?.Message);
+                throw new OdsApiConnectionException(response.StatusCode, response.ErrorMessage, response.ErrorException?.Message ?? response.ErrorMessage);
             }
         }
 

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
@@ -241,8 +241,8 @@ namespace EdFi.Ods.AdminApp.Management.Api
                 var request = OdsRequest(elementPath);
                 request.Method = Method.DELETE;
                 request.AddUrlSegment("id", id);
-                _restClient.Execute(request);
-                return new OdsApiResult();
+                var response = _restClient.Execute(request);
+                return new OdsApiResult(response);
             }
             catch (Exception ex)
             {

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
@@ -242,8 +242,9 @@ namespace EdFi.Ods.AdminApp.Management.Api
                 var request = OdsRequest(elementPath);
                 request.Method = Method.DELETE;
                 request.AddUrlSegment("id", id);
-                var response = _restClient.Execute(request);
-                return new OdsApiResult(response);
+                var restResponse = _restClient.Execute(request);
+                HandleErrorResponse(restResponse);
+                return new OdsApiResult();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Fix the ODS API client `Delete` handler to check if the response is a success and set the error message appropriately (instead of just on exception).

Included default message as well as potentially a Content message. Other client methods are correctly checking this and changing the status accordingly.

This _does not_ adjust the delete JavaScript handling to wire into the new error page handling, so it still shows a toast.