### PR TITLE
[AA-893] - Add support for multiple namespace prefixes for a vendor

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Commands/AddVendorCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Commands/AddVendorCommandTests.cs
@@ -3,12 +3,14 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Collections.Generic;
 using EdFi.Ods.AdminApp.Management.Database.Commands;
 using Moq;
 using NUnit.Framework;
 using Shouldly;
 using System.Linq;
 using EdFi.Admin.DataAccess.Contexts;
+using EdFi.Ods.AdminApp.Web.Helpers;
 using static EdFi.Ods.AdminApp.Management.Tests.Testing;
 
 namespace EdFi.Ods.AdminApp.Management.Tests.Database.Commands
@@ -21,7 +23,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Database.Commands
         {
             var newVendor = new Mock<IAddVendorModel>();
             newVendor.Setup(x => x.Company).Returns("test vendor");
-            newVendor.Setup(x => x.NamespacePrefix).Returns("http://www.test.com/");
+            newVendor.Setup(x => x.NamespacePrefixes).Returns("http://www.test.com/");
             newVendor.Setup(x => x.ContactName).Returns("test user");
             newVendor.Setup(x => x.ContactEmailAddress).Returns("test@test.com");
 
@@ -39,6 +41,40 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Database.Commands
                 var vendor = usersContext.Vendors.Single(v => v.VendorId == id);
                 vendor.VendorName.ShouldBe("test vendor");
                 vendor.VendorNamespacePrefixes.First().NamespacePrefix.ShouldBe("http://www.test.com/");
+                vendor.Users.Single().FullName.ShouldBe("test user");
+                vendor.Users.Single().Email.ShouldBe("test@test.com");
+            });
+        }
+
+        [Test]
+        public void ShouldAddVendorIfMultipleNamespacePrefixes()
+        {
+            var newVendor = new Mock<IAddVendorModel>();
+            var namespacePrefixes = new List<string>
+            {
+                "http://www.test1.com/",
+                "http://www.test2.com/",
+                "http://www.test3.com/"
+            };
+            newVendor.Setup(x => x.Company).Returns("test vendor");
+            newVendor.Setup(x => x.NamespacePrefixes).Returns(namespacePrefixes.ToDelimiterSeparated());
+            newVendor.Setup(x => x.ContactName).Returns("test user");
+            newVendor.Setup(x => x.ContactEmailAddress).Returns("test@test.com");
+
+            int id = 0;
+            Scoped<IUsersContext>(usersContext =>
+            {
+                var command = new AddVendorCommand(usersContext);
+
+                id = command.Execute(newVendor.Object);
+                id.ShouldBeGreaterThan(0);
+            });
+
+            Transaction(usersContext =>
+            {
+                var vendor = usersContext.Vendors.Single(v => v.VendorId == id);
+                vendor.VendorName.ShouldBe("test vendor");
+                vendor.VendorNamespacePrefixes.Select(x => x.NamespacePrefix).ShouldBe(namespacePrefixes);
                 vendor.Users.Single().FullName.ShouldBe("test user");
                 vendor.Users.Single().Email.ShouldBe("test@test.com");
             });

--- a/Application/EdFi.Ods.AdminApp.Management/Database/Commands/AddVendorCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/Commands/AddVendorCommand.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Collections.Generic;
+using System.Linq;
 using EdFi.Admin.DataAccess.Contexts;
 using EdFi.Admin.DataAccess.Models;
 using VendorUser = EdFi.Admin.DataAccess.Models.User;
@@ -22,12 +23,15 @@ namespace EdFi.Ods.AdminApp.Management.Database.Commands
         public int Execute(IAddVendorModel newVendor)
         {
             var namespacePrefixes = new List<VendorNamespacePrefix>();
-            if (!string.IsNullOrWhiteSpace(newVendor.NamespacePrefix))
+            if (!string.IsNullOrWhiteSpace(newVendor.NamespacePrefixes))
             {
-                namespacePrefixes.Add(new VendorNamespacePrefix
-                {
-                    NamespacePrefix = newVendor.NamespacePrefix.Trim(),
-                });
+                var namespacePrefixSplits = newVendor.NamespacePrefixes.Split(",");
+
+                namespacePrefixes.AddRange(namespacePrefixSplits.Select(
+                        namespacePrefix => new VendorNamespacePrefix
+                        {
+                            NamespacePrefix = namespacePrefix.Trim()
+                        }));
             }
 
             var vendor = new Vendor
@@ -53,7 +57,7 @@ namespace EdFi.Ods.AdminApp.Management.Database.Commands
     public interface IAddVendorModel
     {
         string Company { get; }
-        string NamespacePrefix { get; }
+        string NamespacePrefixes { get; }
         string ContactName { get; }
         string ContactEmailAddress { get; }
     }

--- a/Application/EdFi.Ods.AdminApp.Management/Database/Commands/EditVendorCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/Commands/EditVendorCommand.cs
@@ -25,30 +25,25 @@ namespace EdFi.Ods.AdminApp.Management.Database.Commands
             var vendor = _context.Vendors.Single(v => v.VendorId == changedVendorData.VendorId);
             vendor.VendorName = changedVendorData.Company;
 
-            // because of no UI support for multiple VendorNamespacePrefixes,
-            // we will always have only one VendorNamespacePrefix associated with vendor.
-            // So, we'll update/remove the first item available.
-            if (!string.IsNullOrEmpty(changedVendorData.NamespacePrefix))
+            if (vendor.VendorNamespacePrefixes.Any())
             {
-                if (vendor.VendorNamespacePrefixes.Any())
+                foreach (var vendorNamespacePrefix in vendor.VendorNamespacePrefixes.ToList())
                 {
-                    vendor.VendorNamespacePrefixes.First().NamespacePrefix = changedVendorData.NamespacePrefix;
-                }
-                else
-                {
-                    vendor.VendorNamespacePrefixes.Add(new VendorNamespacePrefix
-                    {
-                        NamespacePrefix = changedVendorData.NamespacePrefix,
-                        Vendor = vendor
-                    });
+                     _context.VendorNamespacePrefixes.Remove(vendorNamespacePrefix);    
                 }
             }
-            else
+
+            if (!string.IsNullOrEmpty(changedVendorData.NamespacePrefixes))
             {
-                if (vendor.VendorNamespacePrefixes.Any())
+                var namespacePrefixSplits = changedVendorData.NamespacePrefixes.Split(",");
+
+                foreach (var namespacePrefix in namespacePrefixSplits)
                 {
-                    var toRemove = vendor.VendorNamespacePrefixes.First();
-                    _context.VendorNamespacePrefixes.Remove(toRemove);
+                    _context.VendorNamespacePrefixes.Add(new VendorNamespacePrefix
+                    {
+                        NamespacePrefix = namespacePrefix,
+                        Vendor = vendor
+                    });
                 }
             }
 
@@ -77,7 +72,7 @@ namespace EdFi.Ods.AdminApp.Management.Database.Commands
     {
         int VendorId { get; set; }
         string Company { get; set; }
-        string NamespacePrefix { get; set; }
+        string NamespacePrefixes { get; set; }
         string ContactName { get; set; }
         string ContactEmailAddress { get; set; }
     }

--- a/Application/EdFi.Ods.AdminApp.Web/Helpers/HtmlHelperExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Helpers/HtmlHelperExtensions.cs
@@ -139,6 +139,42 @@ namespace EdFi.Ods.AdminApp.Web.Helpers
             return FormBlock(label, input, helpTooltip);
         }
 
+        public static HtmlTag InputTextAreaBlock<T>(this IHtmlHelper<T> helper, Expression<Func<T, object>> expression, string value = null, string placeholderText = null, string helpText = null, Action<HtmlTag> inputModifier = null, string customLabelText = null) where T : class
+        {
+            Preconditions.ThrowIfNull(helper, nameof(helper));
+            Preconditions.ThrowIfNull(expression, nameof(expression));
+
+            var label = helper.Label(expression);
+            if (customLabelText != null)
+            {
+                label.Text(customLabelText);
+            }
+            label = label.WrapWith(new DivTag().AddClasses("col-xs-4", "text-right"));
+
+            var expressionPropertyName = Property.From(expression).Name;
+
+            var textAreaInput = new HtmlTag("textarea")
+                .Id(expressionPropertyName)
+                .Name(expressionPropertyName)
+                .AddClass("form-control");
+
+            if (!string.IsNullOrEmpty(value))
+            {
+                textAreaInput.AppendText(value);
+            }
+
+            if (!string.IsNullOrEmpty(placeholderText))
+            {
+                textAreaInput.AddPlaceholder(placeholderText);
+            }
+            inputModifier?.Invoke(textAreaInput);
+
+            textAreaInput = textAreaInput.WrapWith(new DivTag().AddClasses("col-xs-6", "text-left"));
+            textAreaInput.Append(new HtmlTag("small").AppendText(helpText).AddClass("text-muted"));
+
+            return FormBlock(label, textAreaInput, HtmlTag.Empty());
+        }
+
         public static HtmlTag SelectList<T, TR>(this IHtmlHelper<T> helper, Expression<Func<T, TR>> expression, bool includeBlankOption = false)
             where T : class
             where TR : Enumeration<TR>

--- a/Application/EdFi.Ods.AdminApp.Web/Helpers/StringExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Helpers/StringExtensions.cs
@@ -4,7 +4,9 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -64,6 +66,15 @@ namespace EdFi.Ods.AdminApp.Web.Helpers
             }
 
             return descriptorPath;
+        }
+
+        public static string ToDelimiterSeparated(this IEnumerable<string> inputStrings, string separator = ",")
+        {
+            var listOfStrings = inputStrings.ToList();
+
+            return listOfStrings.Any()
+                ? string.Join(separator, listOfStrings)
+                : string.Empty;
         }
 
         private static string CapitalizeFirstLetter(this string text)

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/AutoMapper/AdminWebMappingProfile.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/AutoMapper/AdminWebMappingProfile.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Collections.Generic;
 using EdFi.Ods.AdminApp.Management.Api.Models;
 using EdFi.Ods.AdminApp.Web.Helpers;
 using EdFi.Ods.AdminApp.Web.Models.ViewModels;
@@ -12,7 +13,6 @@ using System.Linq;
 using EdFi.Admin.DataAccess.Models;
 using EdFi.Ods.AdminApp.Management.Database.Models;
 using EdFi.Ods.AdminApp.Web.Models.ViewModels.Global;
-using EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstances;
 using EdFi.Security.DataAccess.Models;
 using Application = EdFi.Admin.DataAccess.Models.Application;
 using Profile = AutoMapper.Profile;
@@ -37,20 +37,14 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure.AutoMapper
                 .ForMember(dst => dst.Company, opt => opt.MapFrom(src => src.VendorName))
                 .ForMember(dst => dst.ContactName, opt => opt.MapFrom(src => src.ContactName()))
                 .ForMember(dst => dst.ContactEmailAddress, opt => opt.MapFrom(src => src.ContactEmail()))
-                .ForMember(dst => dst.NamespacePrefix, opt => opt.MapFrom(src =>
-                    src.VendorNamespacePrefixes != null && src.VendorNamespacePrefixes.Any()
-                        ? src.VendorNamespacePrefixes.First().NamespacePrefix
-                        : string.Empty));
+                .ForMember(dst => dst.NamespacePrefixes, opt => opt.MapFrom(src => ToCommaSeparated(src.VendorNamespacePrefixes)));
             
             CreateMap<Vendor, VendorApplicationsModel>()
                 .ForMember(dst => dst.Applications,
                     opt => opt.MapFrom(src => src.Applications == null ? null : src.Applications.Where(app => app.OdsInstance != null)));
 
             CreateMap<Vendor, VendorOverviewModel>()
-                .ForMember(dst => dst.NamespacePrefix, opt => opt.MapFrom(src =>
-                        src.VendorNamespacePrefixes != null && src.VendorNamespacePrefixes.Any()
-                            ? src.VendorNamespacePrefixes.First().NamespacePrefix
-                            : string.Empty));
+                .ForMember(dst => dst.NamespacePrefixes, opt => opt.MapFrom(src => ToCommaSeparated(src.VendorNamespacePrefixes)));
 
             CreateMap<EducationOrganization, EducationOrganizationModel>();
             CreateMap<LocalEducationAgency, EducationOrganizationModel>();
@@ -128,6 +122,13 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure.AutoMapper
 
             CreateMap<AdminAppUser, UserModel>()
                 .ForMember(dst => dst.UserId, opt => opt.MapFrom(src => src.Id));
+        }
+
+        private string ToCommaSeparated(ICollection<VendorNamespacePrefix> vendorNamespacePrefixes)
+        {
+            return vendorNamespacePrefixes != null && vendorNamespacePrefixes.Any()
+                            ? vendorNamespacePrefixes.Select(x => x.NamespacePrefix).ToDelimiterSeparated()
+                            : string.Empty;
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Global/AddVendorModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Global/AddVendorModel.cs
@@ -5,7 +5,6 @@
 
 using EdFi.Ods.AdminApp.Management.Database.Commands;
 using EdFi.Ods.AdminApp.Management.Database.Queries;
-using EdFi.Ods.AdminApp.Web.Helpers;
 using FluentValidation;
 
 namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.Global
@@ -13,7 +12,7 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.Global
     public class AddVendorModel : IAddVendorModel
     {
         public string Company { get; set; }
-        public string NamespacePrefix { get; set; }
+        public string NamespacePrefixes { get; set; }
         public string ContactName { get; set; }
         public string ContactEmailAddress { get; set; }
     }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Global/EditVendorModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Global/EditVendorModel.cs
@@ -5,7 +5,6 @@
 
 using EdFi.Ods.AdminApp.Management.Database.Commands;
 using EdFi.Ods.AdminApp.Management.Database.Queries;
-using EdFi.Ods.AdminApp.Web.Helpers;
 using FluentValidation;
 
 namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.Global
@@ -14,7 +13,7 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.Global
     {
         public int VendorId { get; set; }
         public string Company { get; set; }
-        public string NamespacePrefix { get; set; }
+        public string NamespacePrefixes { get; set; }
         public string ContactName { get; set; }
         public string ContactEmailAddress { get; set; }
     }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/VendorOverviewModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/VendorOverviewModel.cs
@@ -9,6 +9,6 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels
     {
         public int VendorId { get; set; }
         public string VendorName { get; set; }
-        public string NamespacePrefix { get; set; }
+        public string NamespacePrefixes { get; set; }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Views/GlobalSettings/_AddVendorModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/GlobalSettings/_AddVendorModal.cshtml
@@ -21,7 +21,28 @@ See the LICENSE and NOTICES files in the project root for more information.
                 {
                     @Html.ValidationBlock()
                     @Html.InputBlock(m => m.Company, "Vendor Name")
-                    @Html.InputBlock(m => m.NamespacePrefix, "http://vendorwebsite.com")
+                    @Html.InputTextAreaBlock(m => m.NamespacePrefixes, placeholderText:"http://vendor1.com, http://vendor2.com, http://vendor3.com ..."
+                        , helpText:"You can provide a comma separated list of vendor namespace prefixes."
+                        , inputModifier: x =>
+                        {
+                            x.Attr("id", "add-vendor-namespaces");
+                            x.Attr("rows", 4);
+                        })
+                    <div class="form-horizontal">
+                        <div class="row form-group">
+                            <div class="col-xs-4"></div>
+                            <div class="col-xs-6 text-left">
+                                <div class="input-group">
+                                    <input id="add-namespace-prefix-input" type="text" class="form-control" placeholder="http://vendorwebsite.com">
+                                    <span class="input-group-btn">
+                                        <button id="add-namespace-prefix" class="btn btn-primary" type="button">Add</button>
+                                    </span>
+                                </div>
+                                <small class="text-muted">Use 'Add' to add a vendor namespace prefix in the textbox above.</small>
+                            </div>
+                            <span class="text-left help-form col-xs-2"><span></span></span>
+                        </div>
+                    </div>
                     @Html.InputBlock(m => m.ContactName, "Jane Smith")
                     @Html.InputBlock(m => m.ContactEmailAddress, "email@vendorwebsite.com")
                 }

--- a/Application/EdFi.Ods.AdminApp.Web/Views/GlobalSettings/_AddVendorModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/GlobalSettings/_AddVendorModal.cshtml
@@ -59,7 +59,26 @@ See the LICENSE and NOTICES files in the project root for more information.
         $(".add-vendor-modal").on("show.bs.modal", function () {            
             $("#addVendorFormModal").get(0).reset();
             $(".form-group").removeClass("has-error");
-            $(".validationSummary").addClass("hidden");         
-        });      
+            $(".validationSummary").addClass("hidden");
+            $("#addVendorFormModal.textarea").val("");
+            $("#addVendorFormModal.input").val("");
+        });
+        $("textarea[id=add-vendor-namespaces]").on("input", function (e) {
+            this.val(e.target.value);
+        });
+        $("#add-namespace-prefix").on("click", function () {
+            var namespacePrefixesInput = $("textarea[id=add-vendor-namespaces]"); 
+            var previousValue = namespacePrefixesInput.val().trim();
+            var namespaceToAdd = $("#add-namespace-prefix-input").val().trim();
+            var newValue = "";
+            if (namespaceToAdd.length) {
+                if (previousValue.length) {
+                    newValue = previousValue + ",";
+                }
+                newValue += namespaceToAdd;
+                namespacePrefixesInput.val(newValue);
+            }
+            $("#add-namespace-prefix-input").val("");
+        });
     });
 </script> 

--- a/Application/EdFi.Ods.AdminApp.Web/Views/GlobalSettings/_EditVendorForm.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/GlobalSettings/_EditVendorForm.cshtml
@@ -21,7 +21,28 @@ else
         @Html.ValidationBlock()
         @Html.Input(m => m.VendorId).Hide()
         @Html.InputBlock(m => m.Company, "Vendor Name")
-        @Html.InputBlock(m => m.NamespacePrefix, "http://vendorwebsite.com")
+        @Html.InputTextAreaBlock(m => m.NamespacePrefixes, Model.NamespacePrefixes, "http://vendor1.com, http://vendor2.com, http://vendor3.com ..."
+            , "You can provide a comma separated list of vendor namespace prefixes. You can remove an already assigned namespace prefixes by not including it in the list."
+            , x =>
+            {
+                x.Attr("id", "edit-vendor-namespaces");
+                x.Attr("rows", 4);
+            })
+        <div class="form-horizontal">
+            <div class="row form-group">
+                <div class="col-xs-4"></div>
+                <div class="col-xs-6 text-left">
+                    <div class="input-group">
+                        <input id="edit-namespace-prefix-input" type="text" class="form-control" placeholder="http://vendorwebsite.com">
+                        <span class="input-group-btn">
+                            <button id="edit-namespace-prefix" class="btn btn-primary" type="button">Add</button>
+                        </span>
+                    </div>
+                    <small class="text-muted">Use 'add' to add a vendor namespace prefix in the textbox above.</small> 
+                </div>
+                <span class="text-left help-form col-xs-2"><span></span></span>
+            </div>
+        </div>
         @Html.InputBlock(m => m.ContactName, "Jane Smith")
         @Html.InputBlock(m => m.ContactEmailAddress, "email@vendorwebsite.com")
     }

--- a/Application/EdFi.Ods.AdminApp.Web/Views/GlobalSettings/_EditVendorForm.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/GlobalSettings/_EditVendorForm.cshtml
@@ -46,4 +46,26 @@ else
         @Html.InputBlock(m => m.ContactName, "Jane Smith")
         @Html.InputBlock(m => m.ContactEmailAddress, "email@vendorwebsite.com")
     }
+
+    <script type="text/javascript">
+        $(function() {
+            $("textarea[id=edit-vendor-namespaces]").on("input", function (e) {
+                this.val(e.target.value);
+            });
+            $("#edit-namespace-prefix").on("click", function () {
+                var namespacePrefixesInput = $("textarea[id=edit-vendor-namespaces]");
+                var previousValue = namespacePrefixesInput.val().trim();
+                var namespaceToAdd = $("#edit-namespace-prefix-input").val().trim();
+                var newValue = "";
+                if (namespaceToAdd.length) {
+                    if (previousValue.length) {
+                        newValue = previousValue + ",";
+                    }
+                    newValue += namespaceToAdd;
+                    namespacePrefixesInput.val(newValue);
+                }
+                $("#edit-namespace-prefix-input").val("");
+            });
+        });
+    </script>
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Views/GlobalSettings/_VendorsTable.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/GlobalSettings/_VendorsTable.cshtml
@@ -9,12 +9,17 @@ See the LICENSE and NOTICES files in the project root for more information.
 @using EdFi.Ods.AdminApp.Web.Models.ViewModels.Global
 @model EdFi.Ods.AdminApp.Web.Models.ViewModels.Global.VendorsListModel
 
-<table class="table table-hover table-custom">
+<table id="vendors-table" class="table table-hover table-custom">
+    <colgroup>
+        <col style="width: 20%">
+        <col style="width: 70%">
+        <col style="width: 10%">
+    </colgroup>
     <thead class="thead-inverse">
         <tr class="tr-custom">
-            <th>Name</th>
-            <th>Name Space Prefix </th>
-            <th>Actions</th>
+            <th scope="col">Name</th>
+            <th scope="col">Name Space Prefixes </th>
+            <th scope="col">Actions</th>
         </tr>
     </thead>
     <tbody>
@@ -22,7 +27,7 @@ See the LICENSE and NOTICES files in the project root for more information.
     {
         <tr class="tr-custom">
             <th>@vendor.VendorName.ToTitleCase()</th>
-            <td>@vendor.NamespacePrefix</td>
+            <td>@vendor.NamespacePrefixes</td>
             <td>
                 <a title="Edit Vendor" href="javascript:void(0)" class="edit-table edit-vendor-link" data-id="@vendor.VendorId"> <span class="fa fa-pencil action-icons"></span></a>
                 <a title="Delete Vendor" href="javascript:void(0)" class="delete-vendor-link" data-id="@vendor.VendorId" data-name="@vendor.VendorName"> <span class="fa fa-trash-o action-icons"></span></a>

--- a/Application/EdFi.Ods.AdminApp.Web/wwwroot/Content/css/Site.css
+++ b/Application/EdFi.Ods.AdminApp.Web/wwwroot/Content/css/Site.css
@@ -1218,6 +1218,16 @@ input[type="checkbox"]:checked + label > .fa-check-square:before {
     content: "\f14a";
 }
 
+#vendors-table {
+    width: 100%;
+    table-layout: fixed;
+}
+
+#vendors-table td {
+    overflow: hidden;
+    word-break: break-word;
+    text-align: left;
+}
 
 @media (min-width: 768px) {
     .container-fluid > .navbar-collapse, .container-fluid > .navbar-header, .container > .navbar-collapse, .container > .navbar-header {


### PR DESCRIPTION
**Description**
- Renamed NamespacePrefix fields to NamespacePrefixes to correctly denote the multiple namespace prefixes.
- Refactored EditVendor and VendorOverview mappings to expect a comma-separated list of multiple namespace prefixes. Added a string extension method to create a string by joining an input list of strings using a delimiter.
- Added an HtmlHelperExtension for a textarea input block. Replaced the input blocks on AddVendor and EditVendor screens with the textarea input block. Added the add namespace prefix input-group to AddVendor and EditVendor screens. Added help text to the form inputs.
- Added javascript logic to handle the interactions between the textarea input and add namespace prefix input group to the AddVendor and EditVendor screens.
- Refactored the AddVendorCommand and EditVendorCommand Execute actions to accomodate taking in multiple namespace prefixes for a vendor.Added unit tests for AddVendor and EditVendor commands keeping in mind the multiple namespace prefixes flow.
- Refactored the styling for Vendor table to allow mutliple namespaces to be dispayed in the table cells for different vendor rows.