### PR TITLE
[AA-1392] Follow-Up: Overzealous API Failure Responses

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.UnitTests/Api/OdsApiFacadeTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.UnitTests/Api/OdsApiFacadeTests.cs
@@ -328,7 +328,11 @@ namespace EdFi.Ods.AdminApp.Management.UnitTests.Api
             var mockRestClient = new Mock<IRestClient>();
             mockRestClient.Setup(x => x.BaseUrl).Returns(new Uri(_connectionInformation.ApiBaseUrl));
             mockRestClient.Setup(x => x.Execute(It.IsAny<RestRequest>())).Returns(new RestResponse
-                { StatusCode = HttpStatusCode.OK, Content = content });
+            {
+                ResponseStatus = ResponseStatus.Completed,
+                StatusCode = HttpStatusCode.OK,
+                Content = content
+            });
 
             var mockTokenRetriever = new Mock<ITokenRetriever>();
             mockTokenRetriever.Setup(x => x.ObtainNewBearerToken()).Returns("Token");
@@ -455,6 +459,7 @@ namespace EdFi.Ods.AdminApp.Management.UnitTests.Api
             mockRestClient.Setup(x => x.BaseUrl).Returns(new Uri(_connectionInformation.ApiBaseUrl));
             mockRestClient.Setup(x => x.Execute(It.IsAny<RestRequest>())).Returns(new RestResponse
             {
+                ResponseStatus = ResponseStatus.Completed,
                 StatusCode = HttpStatusCode.Created
             });
 
@@ -510,7 +515,8 @@ namespace EdFi.Ods.AdminApp.Management.UnitTests.Api
             mockRestClient.Setup(x => x.BaseUrl).Returns(new Uri(_connectionInformation.ApiBaseUrl));
             mockRestClient.Setup(x => x.Execute(It.IsAny<RestRequest>())).Returns(new RestResponse
             {
-                StatusCode = HttpStatusCode.NoContent
+                StatusCode = HttpStatusCode.NoContent,
+                ResponseStatus = ResponseStatus.Completed,
             });
 
             var mockTokenRetriever = new Mock<ITokenRetriever>();

--- a/Application/EdFi.Ods.AdminApp.Management.UnitTests/Api/OdsApiFacadeTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.UnitTests/Api/OdsApiFacadeTests.cs
@@ -247,7 +247,7 @@ namespace EdFi.Ods.AdminApp.Management.UnitTests.Api
 
             // Assert
             result.Success.ShouldBe(false);
-            result.ErrorMessage.ShouldBe(errorMsg);
+            result.ErrorMessage.ShouldContain(errorMsg);
         }
 
         [Test]
@@ -290,7 +290,7 @@ namespace EdFi.Ods.AdminApp.Management.UnitTests.Api
 
             // Assert
             result.Success.ShouldBe(false);
-            result.ErrorMessage.ShouldBe(errorMsg);
+            result.ErrorMessage.ShouldContain(errorMsg);
         }
 
         [Test]
@@ -415,7 +415,7 @@ namespace EdFi.Ods.AdminApp.Management.UnitTests.Api
 
             // Assert
             result.Success.ShouldBe(false);
-            result.ErrorMessage.ShouldBe(errorMsg);
+            result.ErrorMessage.ShouldContain(errorMsg);
         }
 
         [Test]

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
@@ -164,11 +164,8 @@ namespace EdFi.Ods.AdminApp.Management.Api
                 var jsonInput = JsonConvert.SerializeObject(resource);
                 request.AddParameter("application/json; charset=utf-8", jsonInput, ParameterType.RequestBody);
                 var response = _restClient.Execute(request);
-                if (response != null && response.StatusCode != HttpStatusCode.Created &&
-                                        response.StatusCode != HttpStatusCode.OK)
-                {
-                    result.ErrorMessage = response.ErrorMessage ?? $"ODS/API returned status code '{response.StatusCode}'";
-                }
+
+                HandleErrorResponse(response);
 
                 return result;
             }
@@ -185,19 +182,14 @@ namespace EdFi.Ods.AdminApp.Management.Api
         {
             try
             {
-                var result = new OdsApiResult();
                 var request = OdsRequest($"{elementPath}/{id}");
                 request.Method = Method.PUT;
                 var jsonInput = JsonConvert.SerializeObject(resource);
                 request.AddParameter("application/json; charset=utf-8", jsonInput, ParameterType.RequestBody);
                 var response = _restClient.Execute(request);
-                if (response != null && (!response.StatusCode.Equals(HttpStatusCode.Created) ||
-                                         !response.StatusCode.Equals(HttpStatusCode.NoContent)))
-                {
-                    result.ErrorMessage = response.ErrorMessage;
-                }
+                HandleErrorResponse(response);
 
-                return result;
+                return new OdsApiResult();
             }
             catch (Exception ex)
             {

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
@@ -87,7 +87,7 @@ namespace EdFi.Ods.AdminApp.Management.Api
             _logger.Debug(response.ErrorException);
 
             var embeddedError = response.ErrorException?.Message ?? response.ErrorMessage;
-            var contentObj = JsonConvert.DeserializeObject<JObject>(response.Content);
+            var contentObj = JsonConvert.DeserializeObject<JObject>(response.Content) ?? new JObject();
             contentObj.TryGetValue("message", out var contentMessage);
 
             var errorMesssage = !string.IsNullOrEmpty(embeddedError)

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
@@ -49,6 +49,19 @@ namespace EdFi.Ods.AdminApp.Management.Api
             return request;
         }
 
+        private OdsApiResult ExecuteWithDefaultResponse(IRestRequest request)
+        {
+            try
+            {
+                ExecuteRequestAndHandleErrors(request);
+                return new OdsApiResult();
+            }
+            catch (Exception e)
+            {
+                return new OdsApiResult { ErrorMessage = e.Message };
+            }
+        }
+
         private IRestResponse ExecuteRequestAndHandleErrors(IRestRequest request)
         {
             IRestResponse response;
@@ -182,10 +195,7 @@ namespace EdFi.Ods.AdminApp.Management.Api
             {
                 throw new AdminAppException("Failed to serialize resource", ex);
             }
-
-            ExecuteRequestAndHandleErrors(request);
-
-            return new OdsApiResult();
+            return ExecuteWithDefaultResponse(request);
         }
 
         public OdsApiResult PutResource<T>(T resource, string elementPath, string id, bool refreshToken = false)
@@ -203,9 +213,7 @@ namespace EdFi.Ods.AdminApp.Management.Api
                 throw new AdminAppException("Failed to serialize resource", ex);
             }
 
-            ExecuteRequestAndHandleErrors(request);
-
-            return new OdsApiResult();
+            return ExecuteWithDefaultResponse(request);
         }
 
         public IReadOnlyList<string> GetAllDescriptors()
@@ -239,8 +247,7 @@ namespace EdFi.Ods.AdminApp.Management.Api
             var request = OdsRequest(elementPath);
             request.Method = Method.DELETE;
             request.AddUrlSegment("id", id);
-            ExecuteRequestAndHandleErrors(request);
-            return new OdsApiResult();
+            return ExecuteWithDefaultResponse(request);
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
@@ -52,25 +52,20 @@ namespace EdFi.Ods.AdminApp.Management.Api
         private IRestResponse ExecuteRequestAndHandleErrors(IRestRequest request)
         {
             var response = _restClient.Execute(request);
-            HandleErrorResponse(response);
-            return response;
-        }
 
-        private static void HandleErrorResponse(IRestResponse response)
-        {
-            if (!response.IsSuccessful)
-            {
-                _logger.Debug("*** Status:");
-                _logger.Debug(response.StatusCode);
+            if (response.IsSuccessful)
+                return response;
 
-                _logger.Debug("*** Content:");
-                _logger.Debug(response.Content);
+            _logger.Debug("*** Status:");
+            _logger.Debug(response.StatusCode);
 
-                _logger.Debug("*** ErrorException:");
-                _logger.Debug(response.ErrorException);
+            _logger.Debug("*** Content:");
+            _logger.Debug(response.Content);
 
-                throw new OdsApiConnectionException(response.StatusCode, response.ErrorMessage, response.ErrorException?.Message ?? response.ErrorMessage);
-            }
+            _logger.Debug("*** ErrorException:");
+            _logger.Debug(response.ErrorException);
+
+            throw new OdsApiConnectionException(response.StatusCode, response.ErrorMessage, response.ErrorException?.Message ?? response.ErrorMessage);
         }
 
         public IReadOnlyList<T> GetAll<T>(string elementPath, int offset, int limit = 50) where T : class

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
@@ -73,7 +73,12 @@ namespace EdFi.Ods.AdminApp.Management.Api
             _logger.Debug("*** ErrorException:");
             _logger.Debug(response.ErrorException);
 
-            throw new OdsApiConnectionException(response.StatusCode, response.ErrorMessage, response.ErrorException?.Message ?? response.ErrorMessage);
+            var embeddedError = response.ErrorException?.Message ?? response.ErrorMessage;
+            var errorMesssage = !string.IsNullOrEmpty(embeddedError)
+                ? embeddedError
+                : $"ODS API failure with no message. Status Code: {response.StatusCode}";
+
+            throw new OdsApiConnectionException(response.StatusCode, embeddedError, errorMesssage);
         }
 
         public IReadOnlyList<T> GetAll<T>(string elementPath, int offset, int limit = 50) where T : class

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
@@ -74,9 +74,12 @@ namespace EdFi.Ods.AdminApp.Management.Api
             _logger.Debug(response.ErrorException);
 
             var embeddedError = response.ErrorException?.Message ?? response.ErrorMessage;
+            var contentObj = JsonConvert.DeserializeObject<JObject>(response.Content);
+            contentObj.TryGetValue("message", out var contentMessage);
+
             var errorMesssage = !string.IsNullOrEmpty(embeddedError)
                 ? embeddedError
-                : $"ODS API failure with no message. Status Code: {response.StatusCode}";
+                : contentMessage?.ToString() ?? $"ODS API failure with no message. Status Code: {response.StatusCode}";
 
             throw new OdsApiConnectionException(response.StatusCode, embeddedError, errorMesssage);
         }

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
@@ -49,6 +49,13 @@ namespace EdFi.Ods.AdminApp.Management.Api
             return request;
         }
 
+        private IRestResponse ExecuteRequestAndHandleErrors(IRestRequest request)
+        {
+            var response = _restClient.Execute(request);
+            HandleErrorResponse(response);
+            return response;
+        }
+
         private static void HandleErrorResponse(IRestResponse response)
         {
             if (!response.IsSuccessful)
@@ -75,8 +82,7 @@ namespace EdFi.Ods.AdminApp.Management.Api
             var responseList = new List<T>();
             List<T> pageItems;
 
-            var restResponse = _restClient.Execute(request);
-            HandleErrorResponse(restResponse);
+            var restResponse = ExecuteRequestAndHandleErrors(request);
 
             pageItems = JsonConvert.DeserializeObject<List<T>>(restResponse.Content);
             responseList.AddRange(pageItems);
@@ -98,8 +104,7 @@ namespace EdFi.Ods.AdminApp.Management.Api
 
             do
             {
-                var restResponse = _restClient.Execute(request);
-                HandleErrorResponse(restResponse);
+                var restResponse = ExecuteRequestAndHandleErrors(request);
 
                 pageItems = JsonConvert.DeserializeObject<List<T>>(restResponse.Content);
                 responseList.AddRange(pageItems);
@@ -131,8 +136,7 @@ namespace EdFi.Ods.AdminApp.Management.Api
 
             do
             {
-                var restResponse = _restClient.Execute(request);
-                HandleErrorResponse(restResponse);
+                var restResponse = ExecuteRequestAndHandleErrors(request);
 
                 pageItems = JsonConvert.DeserializeObject<List<T>>(restResponse.Content);
                 responseList.AddRange(pageItems);
@@ -149,25 +153,22 @@ namespace EdFi.Ods.AdminApp.Management.Api
         {
             var request = OdsRequest(elementPath);
             request.AddUrlSegment("id", id);
-            var response = _restClient.Execute(request);
-            HandleErrorResponse(response);
+            var response = ExecuteRequestAndHandleErrors(request);
             return JsonConvert.DeserializeObject<T>(response.Content);
         }
 
         public OdsApiResult PostResource<T>(T resource, string elementPath, bool refreshToken = false)
         {
-            var result = new OdsApiResult();
             try
             {
                 var request = OdsRequest(elementPath);
                 request.Method = Method.POST;
                 var jsonInput = JsonConvert.SerializeObject(resource);
                 request.AddParameter("application/json; charset=utf-8", jsonInput, ParameterType.RequestBody);
-                var response = _restClient.Execute(request);
 
-                HandleErrorResponse(response);
+                ExecuteRequestAndHandleErrors(request);
 
-                return result;
+                return new OdsApiResult();
             }
             catch (Exception ex)
             {
@@ -186,8 +187,7 @@ namespace EdFi.Ods.AdminApp.Management.Api
                 request.Method = Method.PUT;
                 var jsonInput = JsonConvert.SerializeObject(resource);
                 request.AddParameter("application/json; charset=utf-8", jsonInput, ParameterType.RequestBody);
-                var response = _restClient.Execute(request);
-                HandleErrorResponse(response);
+                ExecuteRequestAndHandleErrors(request);
 
                 return new OdsApiResult();
             }
@@ -204,8 +204,7 @@ namespace EdFi.Ods.AdminApp.Management.Api
         {
             _restClient.BaseUrl = new Uri(_connectionInformation.DescriptorsUrl);
             var request = OdsRequest("swagger.json");
-            var response = _restClient.Execute(request);
-            HandleErrorResponse(response);
+            var response = ExecuteRequestAndHandleErrors(request);
             var swaggerDocument = JsonConvert.DeserializeObject<JObject>(response.Content);
             var descriptorPaths = swaggerDocument["paths"].ToObject<Dictionary<string, JObject>>();
 
@@ -234,8 +233,7 @@ namespace EdFi.Ods.AdminApp.Management.Api
                 var request = OdsRequest(elementPath);
                 request.Method = Method.DELETE;
                 request.AddUrlSegment("id", id);
-                var restResponse = _restClient.Execute(request);
-                HandleErrorResponse(restResponse);
+                ExecuteRequestAndHandleErrors(request);
                 return new OdsApiResult();
             }
             catch (Exception ex)

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsRestClient.cs
@@ -51,7 +51,7 @@ namespace EdFi.Ods.AdminApp.Management.Api
 
         private static void HandleErrorResponse(IRestResponse response)
         {
-            if (!response.StatusCode.Equals(HttpStatusCode.OK))
+            if (!response.IsSuccessful)
             {
                 _logger.Debug("*** Status:");
                 _logger.Debug(response.StatusCode);


### PR DESCRIPTION
Fixes ODS API Client to treat the `204 No Content` response from some DELETE requests as Success (instead of Failure since it's `!= 200 OK`)

- changes response "success" criteria to use `IsSuccessful` instead of checking specific status codes
- fixes to parse error message from `Content` or use default when response has no `ErrorMessage`
- refactor methods to unify coupled request/response/handling methods
- does _not_ change to use Global Error Handler
  - failures still return a `OdsApiResult` instead of throwing an exception to be handled by middleware