### PR TITLE
[AA-1358] - Add support for Docker Health checks

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -25,6 +25,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="3.1.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="3.1.1" />
     <PackageReference Include="AutoMapper" Version="10.0.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />

--- a/Application/EdFi.Ods.AdminApp.Web/HealthCheckServiceExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/HealthCheckServiceExtensions.cs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EdFi.Ods.AdminApp.Web
+{
+    public static class HealthCheckServiceExtensions
+    {
+        public static IServiceCollection AddHealthCheck(this IServiceCollection services, string connectionString, bool isSqlServer)
+        {
+            var hcBuilder = services.AddHealthChecks();
+            if (isSqlServer)
+            {
+                hcBuilder.AddSqlServer(connectionString);
+            }
+            else
+            {
+                hcBuilder.AddNpgSql(connectionString);
+            }
+
+            return services;        
+        }
+    }
+}
+

--- a/Application/EdFi.Ods.AdminApp.Web/HealthCheckServiceExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/HealthCheckServiceExtensions.cs
@@ -21,8 +21,7 @@ namespace EdFi.Ods.AdminApp.Web
                 hcBuilder.AddNpgSql(connectionString);
             }
 
-            return services;        
+            return services;
         }
     }
 }
-

--- a/Application/EdFi.Ods.AdminApp.Web/Startup.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Startup.cs
@@ -33,7 +33,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Authorization;
-using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 

--- a/Application/EdFi.Ods.AdminApp.Web/Startup.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Startup.cs
@@ -150,7 +150,7 @@ namespace EdFi.Ods.AdminApp.Web
             var databaseEngine = Configuration["AppSettings:DatabaseEngine"];
 
             if (IsSqlServer(databaseEngine))
-                    options.UseSqlServer(connectionString);
+                options.UseSqlServer(connectionString);
             else
                 options.UseNpgsql(connectionString);
         }

--- a/Application/EdFi.Ods.AdminApp.Web/Startup.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Startup.cs
@@ -33,6 +33,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Authorization;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
@@ -138,6 +139,8 @@ namespace EdFi.Ods.AdminApp.Web
             HangFireInstance.EnableWithoutSchemaMigration();
             services.AddHangfireServer();
 
+            services.AddHealthCheck(Configuration.GetConnectionString("Admin"), IsSqlServer(databaseEngine));
+
             CommonConfigurationInstaller.ConfigureLearningStandards(services);
         }
 
@@ -146,11 +149,13 @@ namespace EdFi.Ods.AdminApp.Web
             var connectionString = Configuration.GetConnectionString("Admin");
             var databaseEngine = Configuration["AppSettings:DatabaseEngine"];
 
-            if ("SqlServer".Equals(databaseEngine, StringComparison.InvariantCultureIgnoreCase))
-                options.UseSqlServer(connectionString);
+            if (IsSqlServer(databaseEngine))
+                    options.UseSqlServer(connectionString);
             else
                 options.UseNpgsql(connectionString);
         }
+
+        private static bool IsSqlServer(string databaseEngine) => "SqlServer".Equals(databaseEngine, StringComparison.InvariantCultureIgnoreCase);
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
@@ -213,6 +218,8 @@ namespace EdFi.Ods.AdminApp.Web
                                 "This notification will NOT be reported to the Production registration endpoint.");
                         });
                 }
+
+                endpoints.MapHealthChecks("/health");
             });
         }
 


### PR DESCRIPTION
**Description**
- Added AspNetCoreHealthCheck packages to perform the database probes needed for Postgres and SQLServer admin database during the docker healthcheck.
- Added HealthCheckServiceExtensions class to add the database health check depending on the database engine being used. Added IsSqlServer method to Startup to check for the database engine and refactored using Staertup.cs using this check. Called MapHealthChecks on the endpoint builder with the health check endpoint.