### PR TITLE
[ODST-194] Run playwright tests in action

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  setup-ods:
+  run-e2e-tests:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,6 +33,22 @@ jobs:
       run: |
         chmod +x ./main/Application/EdFi.Ods.AdminApp.E2E.Tests/ct-setup/inspect.sh
         ./main/Application/EdFi.Ods.AdminApp.E2E.Tests/ct-setup/inspect.sh
+    - name: Setup node
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+    - name: Install dependencies
+      run: npm ci
+      working-directory: main/Application/EdFi.Ods.AdminApp.E2E.Tests
+    - name: Install OS dependencies
+      run: npx playwright install-deps
+      working-directory: main/Application/EdFi.Ods.AdminApp.E2E.Tests
+    - name: Set environment
+      run: mv .env.example .env
+      working-directory: main/Application/EdFi.Ods.AdminApp.E2E.Tests
+    - name: Run tests
+      run: npm test
+      working-directory: main/Application/EdFi.Ods.AdminApp.E2E.Tests
     - name: Clean ODS
       if: ${{ always() }}
       run: ./shared-instance-env-clean.ps1

--- a/Application/EdFi.Ods.AdminApp.E2E.Tests/.env.example
+++ b/Application/EdFi.Ods.AdminApp.E2E.Tests/.env.example
@@ -1,6 +1,6 @@
-URL="/"
-email="user@user.com"
+URL="https://localhost/adminapp"
+email="user@ed-fi-test.org"
 password="pass"
-API_URL = "URL/api/data/v3"
+API_URL = "https://localhost/api/data/v3"
 HEADLESS = true
-RECORD = true
+RECORD = false

--- a/Application/EdFi.Ods.AdminApp.E2E.Tests/cucumber.js
+++ b/Application/EdFi.Ods.AdminApp.E2E.Tests/cucumber.js
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+module.exports = {
+    default: [
+      "--require-module ts-node/register",
+      "--require features/**/*.ts",
+      "--publish-quiet",
+    ].join(" "),
+  };

--- a/Application/EdFi.Ods.AdminApp.E2E.Tests/package.json
+++ b/Application/EdFi.Ods.AdminApp.E2E.Tests/package.json
@@ -23,13 +23,12 @@
   "name": "playwright-admin-app-tests",
   "scripts": {
     "lint": "npx eslint --ext .ts ./ --fix",
-    "cucumber": "cucumber-js --require features/**/*.ts --require-module ts-node/register --publish-quiet",
-    "test": "npm run cucumber -- features/**/*.feature",
+    "test": "cucumber-js -- features/**/*.feature",
     "report": "npm run test -- --format json:reports/report.json",
     "sanity-test": "npm run test -- --tags @Sanity",
     "test-wip": "npm run test -- --tags @WIP",
     "publish": "npm run test -- --publish",
-    "test-login": "npm run cucumber -- features/login.feature --fail-fast"
+    "test-login": "cucumber-js -- features/login.feature --fail-fast"
   },
   "version": "1.0.0"
 }


### PR DESCRIPTION
**This should be merged after https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-AdminApp/pull/248 is merged**

Run playwright tests against the ODS instance created.

- The purpose of these task is not for the tests to pass, just to run. The new tests will be added in a future ticket.
- The results are currently not saved since this will be covered in a future ticket.

Needs https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Docker/pull/102 to be merged to fix issue with case of folder names