### PR TITLE
Use playwright traces

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -83,12 +83,12 @@ jobs:
         .\send-test-results.ps1 -PersonalAccessToken ${{ env.JIRA_ACCESS_TOKEN }} -ProjectId ${{ env.PROJECT_ID }} -AdminAppVersion '${{ env.ADMIN_APP_VERSION }}' -ResultsFilePath '${{ env.RESULTS_FILE }}' -ConfigParams $parameters
       shell: pwsh
       working-directory: main
-    - name: Upload execution screenshots
+    - name: Upload execution traces
       if: failure()
       uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
       with:
-        name: playwright-execution-screenshots
-        path: main/Application/EdFi.Ods.AdminApp.E2E.Tests/screenshots
+        name: playwright-execution-traces
+        path: main/Application/EdFi.Ods.AdminApp.E2E.Tests/traces
     - name: Clean ODS
       if: always()
       run: ./shared-instance-env-clean.ps1

--- a/Application/EdFi.Ods.AdminApp.E2E.Tests/.env.example
+++ b/Application/EdFi.Ods.AdminApp.E2E.Tests/.env.example
@@ -3,4 +3,4 @@ email="user@ed-fi-test.org"
 password="Pass.1234"
 API_URL = "https://localhost/api/data/v3"
 HEADLESS = true
-RECORD = false
+TRACE = false

--- a/Application/EdFi.Ods.AdminApp.E2E.Tests/.gitignore
+++ b/Application/EdFi.Ods.AdminApp.E2E.Tests/.gitignore
@@ -1,9 +1,8 @@
 node_modules/
 
 screenshots/
-videos/
 state/
-logs/
+traces/
 reports/
 
 .env

--- a/Application/EdFi.Ods.AdminApp.E2E.Tests/features/management/functions.ts
+++ b/Application/EdFi.Ods.AdminApp.E2E.Tests/features/management/functions.ts
@@ -1,11 +1,12 @@
-import { mkdir, writeFile } from "fs/promises";
-import { currentScenarioName, page } from "./setup";
+import { mkdir } from "fs/promises";
+import { context, currentScenarioName, page } from "./setup";
 
-export function saveLog(error: string): void {
-    const logFolder = "./logs";
-    mkdir(logFolder).catch(() => {});
-    const content = `${new Date().toISOString()}\n${error}`;
-    writeFile(`${logFolder}/ERROR ${currentScenarioName}.txt`, content).catch();
+export async function saveTrace() {
+    const traceFolder = "./traces";
+    mkdir(traceFolder).catch(() => {});
+    if (process.env.TRACE) {
+        await context.tracing.stop({ path: `./traces/${currentScenarioName} - trace.zip` });
+    }
 }
 
 export async function takeScreenshot(name: string): Promise<void> {

--- a/Application/EdFi.Ods.AdminApp.E2E.Tests/features/management/setup.ts
+++ b/Application/EdFi.Ods.AdminApp.E2E.Tests/features/management/setup.ts
@@ -14,13 +14,12 @@ export let models: ModelResolver;
 export let currentScenarioName: string;
 
 Before(async (scenario) => {
-    context = process.env.RECORD
-        ? await browser.newContext({
-              recordVideo: { dir: "./videos" },
-              acceptDownloads: true,
-              ignoreHTTPSErrors: true,
-          })
-        : await browser.newContext({ acceptDownloads: true, ignoreHTTPSErrors: true });
+    context = await browser.newContext({ acceptDownloads: true, ignoreHTTPSErrors: true });
+
+    if (process.env.TRACE) {
+        await context.tracing.start({ screenshots: true, snapshots: true });
+    }
+
     page = await context.newPage();
     models = new ModelResolver(page);
     setScenarioName(scenario.pickle.name);

--- a/Application/EdFi.Ods.AdminApp.E2E.Tests/features/management/teardown.ts
+++ b/Application/EdFi.Ods.AdminApp.E2E.Tests/features/management/teardown.ts
@@ -1,14 +1,9 @@
 import { After, AfterAll } from "@cucumber/cucumber";
-import { saveLog, takeScreenshot } from "./functions";
+import { saveTrace } from "./functions";
 import { page, browser } from "./setup";
 
-After(async (scenario) => {
-    if (scenario.result?.status.toString() === "FAILED") {
-        await takeScreenshot("FAIL");
-        if (scenario.result?.message) {
-            saveLog(scenario.result.message);
-        }
-    }
+After(async () => {
+    await saveTrace();
 });
 
 AfterAll(() => {


### PR DESCRIPTION
- Using playwright traces rather than videos and screenshots for troubleshooting.
- Results can be executed from the command line or uploaded to https://trace.playwright.dev/
- Uploading traces when there's a failure executing the tests in GitHub Action