### PR TITLE
[AA-1423] - Upgrade to dotnet 6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.x
+        dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore
       working-directory: ./Application

--- a/Application/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="Moq" Version="4.14.5" />
   </ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests/EdFi.Ods.AdminApp.Management.Azure.IntegrationTests.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Shouldly" Version="3.0.2" />
-    <PackageReference Include="Moq" Version="4.14.5" />
+    <PackageReference Include="Shouldly" Version="4.0.3" />
+    <PackageReference Include="Moq" Version="4.17.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.Azure.UnitTests/EdFi.Ods.AdminApp.Management.Azure.UnitTests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Azure.UnitTests/EdFi.Ods.AdminApp.Management.Azure.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.Azure.UnitTests/EdFi.Ods.AdminApp.Management.Azure.UnitTests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Azure.UnitTests/EdFi.Ods.AdminApp.Management.Azure.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.Azure.UnitTests/EdFi.Ods.AdminApp.Management.Azure.UnitTests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Azure.UnitTests/EdFi.Ods.AdminApp.Management.Azure.UnitTests.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="Moq" Version="4.14.5" />
   </ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.Azure.UnitTests/EdFi.Ods.AdminApp.Management.Azure.UnitTests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Azure.UnitTests/EdFi.Ods.AdminApp.Management.Azure.UnitTests.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Shouldly" Version="3.0.2" />
-    <PackageReference Include="Moq" Version="4.14.5" />
+    <PackageReference Include="Shouldly" Version="4.0.3" />
+    <PackageReference Include="Moq" Version="4.17.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.Azure/EdFi.Ods.AdminApp.Management.Azure.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Azure/EdFi.Ods.AdminApp.Management.Azure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.Azure/EdFi.Ods.AdminApp.Management.Azure.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Azure/EdFi.Ods.AdminApp.Management.Azure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.Azure/EdFi.Ods.AdminApp.Management.Azure.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Azure/EdFi.Ods.AdminApp.Management.Azure.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="3.10.0-preview" />
     <PackageReference Include="Microsoft.Azure.Management.WebSites" Version="1.3.2-preview" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.13.7" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.OnPrem/EdFi.Ods.AdminApp.Management.OnPrem.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.OnPrem/EdFi.Ods.AdminApp.Management.OnPrem.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.OnPrem/EdFi.Ods.AdminApp.Management.OnPrem.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.OnPrem/EdFi.Ods.AdminApp.Management.OnPrem.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
@@ -12,8 +12,8 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
         <PackageReference Include="Moq" Version="4.14.5" />
-        <PackageReference Include="NUnit" Version="3.12.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+        <PackageReference Include="NUnit" Version="3.13.3" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
         <PackageReference Include="Respawn" Version="3.3.0" />
         <PackageReference Include="Shouldly" Version="3.0.2" />
     </ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/EdFi.Ods.AdminApp.Management.Tests.csproj
@@ -10,12 +10,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-        <PackageReference Include="Moq" Version="4.14.5" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="Moq" Version="4.17.2" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
         <PackageReference Include="Respawn" Version="3.3.0" />
-        <PackageReference Include="Shouldly" Version="3.0.2" />
+        <PackageReference Include="Shouldly" Version="4.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.UnitTests/Automapper/AdminManagementMappingProfileTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.UnitTests/Automapper/AdminManagementMappingProfileTests.cs
@@ -216,8 +216,10 @@ namespace EdFi.Ods.AdminApp.Management.UnitTests.Automapper
                     EducationOrganizationCategory = LocalEducationAgencyCategoryType
                 };
 
+                var edfiSchool = new EdFiSchool(Id, Name, SchoolId, new List<EdFiEducationOrganizationAddress>(),
+                    new List<EdFiEducationOrganizationCategory>(), new List<EdFiSchoolGradeLevel>());
                 // Act
-                var result = _mapper.Map<EdFiSchool>(school);
+                var result = _mapper.Map(school, edfiSchool);
 
                 // Assert
                 result.ShouldNotBeNull();
@@ -302,8 +304,10 @@ namespace EdFi.Ods.AdminApp.Management.UnitTests.Automapper
                     EducationOrganizationCategory = LocalEducationAgencyCategoryType
                 };
 
+                var edfiLea = new EdFiLocalEducationAgency(Id, new List<EdFiEducationOrganizationAddress>(),
+                    new List<EdFiEducationOrganizationCategory>(), LeaId, nameOfInstitution: Name, localEducationAgencyCategoryDescriptor: LocalEducationAgencyCategoryType);
                 // Act
-                var result = _mapper.Map<EdFiLocalEducationAgency>(lea);
+                var result = _mapper.Map(lea, edfiLea);
 
                 // Assert
                 result.ShouldNotBeNull();

--- a/Application/EdFi.Ods.AdminApp.Management.UnitTests/EdFi.Ods.AdminApp.Management.UnitTests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.UnitTests/EdFi.Ods.AdminApp.Management.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Copyright>Copyright © 2019 Ed-Fi Alliance</Copyright>
   </PropertyGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.UnitTests/EdFi.Ods.AdminApp.Management.UnitTests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.UnitTests/EdFi.Ods.AdminApp.Management.UnitTests.csproj
@@ -9,8 +9,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Moq" Version="4.14.5" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
   </ItemGroup>
 

--- a/Application/EdFi.Ods.AdminApp.Management.UnitTests/EdFi.Ods.AdminApp.Management.UnitTests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.UnitTests/EdFi.Ods.AdminApp.Management.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Copyright>Copyright © 2019 Ed-Fi Alliance</Copyright>
   </PropertyGroup>

--- a/Application/EdFi.Ods.AdminApp.Management.UnitTests/EdFi.Ods.AdminApp.Management.UnitTests.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management.UnitTests/EdFi.Ods.AdminApp.Management.UnitTests.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.14.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Shouldly" Version="3.0.2" />
+    <PackageReference Include="Shouldly" Version="4.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management/Database/EntityFrameworkCoreDatabaseModelBuilderExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/EntityFrameworkCoreDatabaseModelBuilderExtensions.cs
@@ -23,7 +23,11 @@ namespace EdFi.Ods.AdminApp.Management.Database
                 entity.SetTableName(entity.GetTableName().ToLowerInvariant());
 
                 foreach (var property in entity.GetProperties())
-                    property.SetColumnName(property.GetColumnName(StoreObjectIdentifier.Table(entity.GetTableName(), null)).ToLowerInvariant());
+                {
+                    var tableId = StoreObjectIdentifier.Table(entity.GetTableName());
+                    var columnName = property.GetColumnName(tableId) ?? property.GetDefaultColumnName(tableId);
+                    property.SetColumnName(columnName.ToLowerInvariant());
+                }
 
                 foreach (var key in entity.GetKeys())
                     key.SetName(key.GetName().ToLowerInvariant());

--- a/Application/EdFi.Ods.AdminApp.Management/Database/EntityFrameworkCoreDatabaseModelBuilderExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/EntityFrameworkCoreDatabaseModelBuilderExtensions.cs
@@ -5,6 +5,7 @@
 
 using System;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace EdFi.Ods.AdminApp.Management.Database
 {
@@ -22,7 +23,7 @@ namespace EdFi.Ods.AdminApp.Management.Database
                 entity.SetTableName(entity.GetTableName().ToLowerInvariant());
 
                 foreach (var property in entity.GetProperties())
-                    property.SetColumnName(property.GetColumnName().ToLowerInvariant());
+                    property.SetColumnName(property.GetColumnName(StoreObjectIdentifier.Table(entity.GetTableName(), null)).ToLowerInvariant());
 
                 foreach (var key in entity.GetKeys())
                     key.SetName(key.GetName().ToLowerInvariant());
@@ -31,7 +32,7 @@ namespace EdFi.Ods.AdminApp.Management.Database
                     key.SetConstraintName(key.GetConstraintName().ToLowerInvariant());
 
                 foreach (var index in entity.GetIndexes())
-                    index.SetName(index.GetName().ToLowerInvariant());
+                    index.SetDatabaseName(index.GetDatabaseName().ToLowerInvariant());
             }
         }
     }

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -21,13 +21,13 @@
 
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="Flurl" Version="2.8.2" />
-    <PackageReference Include="log4net" Version="2.0.12" />
+    <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="3.1.9" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.15" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.10" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Npgsql" Version="5.0.10" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="RestSharp" Version="106.12.0" />
   </ItemGroup>
 

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -11,22 +11,22 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="11.0.1" />
-    <PackageReference Include="Dapper" Version="2.0.30" />
-    <PackageReference Include="dbup-core" Version="4.2.0" />
-    <PackageReference Include="dbup-postgresql" Version="4.2.0" />
-    <PackageReference Include="dbup-sqlserver" Version="4.2.0" />
+    <PackageReference Include="Dapper" Version="2.0.123" />
+    <PackageReference Include="dbup-core" Version="4.5.0" />
+    <PackageReference Include="dbup-postgresql" Version="4.5.0" />
+    <PackageReference Include="dbup-sqlserver" Version="4.5.0" />
 
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.3.43" />
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.3.43" />
 
-    <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="Flurl" Version="2.8.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.3" />
+    <PackageReference Include="Flurl" Version="3.0.4" />
     <PackageReference Include="log4net" Version="2.0.13" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="3.1.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.15" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.10" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="6.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.3" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="RestSharp" Version="106.12.0" />
   </ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="10.0.0" />
+    <PackageReference Include="AutoMapper" Version="11.0.1" />
     <PackageReference Include="Dapper" Version="2.0.30" />
     <PackageReference Include="dbup-core" Version="4.2.0" />
     <PackageReference Include="dbup-postgresql" Version="4.2.0" />
@@ -24,10 +24,10 @@
     <PackageReference Include="log4net" Version="2.0.12" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="3.1.9" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.9" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.15" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.10" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Npgsql" Version="4.1.5" />
+    <PackageReference Include="Npgsql" Version="5.0.10" />
     <PackageReference Include="RestSharp" Version="106.12.0" />
   </ItemGroup>
 

--- a/Application/EdFi.Ods.AdminApp.Management/GetOdsStatusQuery.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/GetOdsStatusQuery.cs
@@ -3,10 +3,12 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Data.Entity.Core;
 using System.Data.SqlClient;
 using System.Linq;
 using EdFi.Admin.DataAccess.Contexts;
 using EdFi.Admin.DataAccess.Models;
+using Npgsql;
 
 namespace EdFi.Ods.AdminApp.Management
 {
@@ -32,6 +34,15 @@ namespace EdFi.Ods.AdminApp.Management
                 //Login failed likely means we haven't yet completed initial setup
                 //so we'll return InstanceNotRegistered below
                 if (!s.Message.StartsWith("Login failed"))
+                {
+                    throw;
+                }
+            }
+            catch (EntityCommandExecutionException s)
+            {
+                //Similarly check for the corresponding exception from NpgSql
+                var inner = s.InnerException as PostgresException;
+                if (inner == null || !(inner.Message.Contains("relation") && inner.Message.Contains("does not exist")))
                 {
                     throw;
                 }

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -25,23 +25,22 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="3.1.1" />
-    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="3.1.1" />
-    <PackageReference Include="AutoMapper" Version="10.0.0" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
-    <PackageReference Include="CsvHelper" Version="15.0.6" />
+    <PackageReference Include="CsvHelper" Version="27.2.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.2" />
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="6.0.2" />
+    <PackageReference Include="AutoMapper" Version="11.0.1" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
     <PackageReference Include="EdFi.Admin.LearningStandards.Core" Version="1.1.0" />
     <PackageReference Include="EdFi.Suite3.LoadTools" Version="5.3.6" />
-    <PackageReference Include="FluentValidation" Version="9.2.2" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="9.2.0" />
-    <PackageReference Include="GoogleAnalyticsTracker.Simple" Version="6.0.5" />
-    <PackageReference Include="Hangfire" Version="1.7.14" />
-    <PackageReference Include="Hangfire.PostgreSql" Version="1.7.1" />
-    <PackageReference Include="HtmlTags" Version="8.0.0" />
-    <PackageReference Include="log4net" Version="2.0.12" />
-    <PackageReference Include="Npgsql" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="3.1.5" />
+    <PackageReference Include="FluentValidation" Version="10.4.0" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="10.4.0" />
+    <PackageReference Include="GoogleAnalyticsTracker.Simple" Version="7.0.1" />
+    <PackageReference Include="Hangfire" Version="1.7.28" />
+    <PackageReference Include="Hangfire.PostgreSql" Version="1.9.7" />
+    <PackageReference Include="HtmlTags" Version="8.1.1" />
+    <PackageReference Include="log4net" Version="2.0.13" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="6.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="AutoMapper" Version="11.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
     <PackageReference Include="EdFi.Admin.LearningStandards.Core" Version="1.1.0" />
-    <PackageReference Include="EdFi.Suite3.LoadTools" Version="5.3.6" />
+    <PackageReference Include="EdFi.Suite3.LoadTools" Version="5.4.12" />
     <PackageReference Include="FluentValidation" Version="10.4.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.4.0" />
     <PackageReference Include="GoogleAnalyticsTracker.Simple" Version="7.0.1" />

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/ValidationExtensions.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/ValidationExtensions.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using EdFi.Common.Utils.Extensions;
 using FluentValidation;
 using FluentValidation.Results;
-using FluentValidation.Validators;
 using log4net;
 
 namespace EdFi.Ods.AdminApp.Web.Infrastructure
@@ -18,7 +17,7 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure
     {
         private static readonly ILog _logger = LogManager.GetLogger(typeof(ValidationExtensions));
 
-        public static IRuleBuilderInitial<T, TProperty> SafeCustom<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, Action<TProperty, CustomContext> action)
+        public static IRuleBuilderOptionsConditions<T, TProperty> SafeCustom<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, Action<TProperty, ValidationContext<T>> action)
         {
             return ruleBuilder.Custom((command, context) =>
             {
@@ -35,7 +34,7 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure
             });
         }
 
-        public static IRuleBuilderInitial<T, TProperty> SafeCustomAsync<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, Func<TProperty, CustomContext, Task> action)
+        public static IRuleBuilderOptionsConditions<T, TProperty> SafeCustomAsync<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, Func<TProperty, ValidationContext<T>, Task> action)
         {
             return ruleBuilder.CustomAsync( async (command, context, cancellationToken) =>
             {
@@ -52,7 +51,7 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure
             });
         }
 
-        public static void AddFailures(this CustomContext context, ValidationResult result)
+        public static void AddFailures<T>(this ValidationContext<T> context, ValidationResult result)
         {
             result.Errors.Select(x => x.ErrorMessage).ForEach(context.AddFailure);
         }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Application/AddApplicationModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Application/AddApplicationModel.cs
@@ -10,7 +10,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using EdFi.Ods.AdminApp.Management;
 using EdFi.Ods.AdminApp.Web.Helpers;
-using FluentValidation.Validators;
 
 namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.Application
 {
@@ -58,6 +57,8 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.Application
 
             RuleFor(m => m.ApplicationName)
                 .Must(BeWithinApplicationNameMaxLength)
+                .WithMessage("The Application Name {ApplicationName} would be too long for Admin App to set up necessary Application records." +
+                " Consider shortening the name by {ExtraCharactersInName} character(s).")
                 .When(x => x.ApplicationName != null);
 
             RuleFor(m => m.ClaimSetName)
@@ -71,7 +72,7 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.Application
             RuleFor(m => m.VendorId).NotEmpty();
         }
 
-        private bool BeWithinApplicationNameMaxLength(AddApplicationModel model, string applicationName, PropertyValidatorContext context)
+        private bool BeWithinApplicationNameMaxLength<T>(AddApplicationModel model, string applicationName, ValidationContext<T> context)
         {            
             var extraCharactersInName = applicationName.Length - ApplicationExtensions.MaximumApplicationNameLength;
             if (extraCharactersInName <= 0)
@@ -79,9 +80,8 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.Application
                 return true;
             }
 
-            context.Rule.MessageBuilder = c
-                => $"The Application Name {applicationName} would be too long for Admin App to set up necessary Application records." +
-                   $" Consider shortening the name by {extraCharactersInName} character(s).";
+            context.MessageFormatter.AppendArgument("ApplicationName", applicationName);
+            context.MessageFormatter.AppendArgument("ExtraCharactersInName", extraCharactersInName);
 
             return false;
         }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Application/EditApplicationModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Application/EditApplicationModel.cs
@@ -3,14 +3,12 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-using EdFi.Ods.AdminApp.Management;
 using EdFi.Ods.AdminApp.Management.Api.Models;
 using EdFi.Ods.AdminApp.Management.Database.Commands;
 using FluentValidation;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using EdFi.Ods.AdminApp.Web.Helpers;
-using FluentValidation.Validators;
 
 namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.Application
 {
@@ -48,6 +46,8 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.Application
             RuleFor(m => m.ApplicationName).NotEmpty();
             RuleFor(m => m.ApplicationName)
                 .Must(BeWithinApplicationNameMaxLength)
+                .WithMessage("The Application Name {ApplicationName} would be too long for Admin App to set up necessary Application records." +
+                             " Consider shortening the name by {ExtraCharactersInName} character(s).")
                 .When(x => x.ApplicationName != null);
 
             RuleFor(m => m.ClaimSetName)
@@ -61,7 +61,7 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.Application
             RuleFor(m => m.VendorId).NotEmpty();
         }
 
-        private bool BeWithinApplicationNameMaxLength(EditApplicationModel model, string applicationName, PropertyValidatorContext context)
+        private bool BeWithinApplicationNameMaxLength<T>(EditApplicationModel model, string applicationName, ValidationContext<T> context)
         {            
             var extraCharactersInName = applicationName.Length - ApplicationExtensions.MaximumApplicationNameLength;
             if (extraCharactersInName <= 0)
@@ -69,9 +69,9 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.Application
                 return true;
             }
 
-            context.Rule.MessageBuilder = c
-                => $"The Application Name {applicationName} would be too long for Admin App to set up necessary Application records." +
-                   $" Consider shortening the name by {extraCharactersInName} character(s).";
+            context.MessageFormatter.AppendArgument("ApplicationName", applicationName);
+            context.MessageFormatter.AppendArgument("ExtraCharactersInName", extraCharactersInName);
+
 
             return false;
         }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Home/ErrorModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/Home/ErrorModel.cs
@@ -14,7 +14,7 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.Home
     {
         public string Message { get; }
         public string StackTrace { get; }
-        public HttpStatusCode? StatusCode { get; }
+        public new HttpStatusCode? StatusCode { get; }
 
         public bool IsStackTraceRelevant { get; }
         public bool AllowFeedback { get; }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/OdsInstances/BulkRegisterOdsInstancesModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/OdsInstances/BulkRegisterOdsInstancesModel.cs
@@ -13,7 +13,6 @@ using EdFi.Ods.AdminApp.Web.Helpers;
 using EdFi.Ods.AdminApp.Web.Infrastructure;
 using FluentValidation;
 using log4net;
-using FluentValidation.Validators;
 using EdFi.Ods.AdminApp.Management.Instances;
 
 namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstances
@@ -121,7 +120,7 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstances
                 .Where(g => g.Count() > 1).Select(x => x.Key).ToList();
         }
 
-        private void HaveValidHeaders(BulkRegisterOdsInstancesModel model, CustomContext context)
+        private void HaveValidHeaders<T>(BulkRegisterOdsInstancesModel model, ValidationContext<T> context)
         {
             var missingHeaders = model.MissingHeaders();
 
@@ -134,7 +133,7 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.OdsInstances
             context.AddFailure($"Missing Headers: {string.Join(",", model.MissingHeaders())}");
         }
 
-        private void HaveUniqueRecords(BulkRegisterOdsInstancesModel model, CustomContext context)
+        private void HaveUniqueRecords<T>(BulkRegisterOdsInstancesModel model, ValidationContext<T> context)
         {
             GetDuplicates(model.DataRecords().ToList(), out var duplicateNumericSuffixes, out var duplicateDescriptions);
 

--- a/EdFi.Suite3.Installer.AdminApp/global.json
+++ b/EdFi.Suite3.Installer.AdminApp/global.json
@@ -1,5 +1,6 @@
 {
     "sdk": {
-        "version": "3.1.301"
+        "version": "6.0.102",
+        "rollForward": "latestMajor"
     }
 }

--- a/build.ps1
+++ b/build.ps1
@@ -154,7 +154,7 @@ function InitializeNuGet {
 }
 
 function Restore {
-    Invoke-Execute { &$script:nugetExe restore $solution }
+    Invoke-Execute { dotnet restore $solution }
 }
 
 function AssemblyInfo {

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -19,11 +19,11 @@ For debugging on Azure, see [CloudODS Debugging](cloudods-debugging.md)
 
 ## Development Pre-Requisites
 
-* [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1)
+* [.NET Core 6.0 SDK](https://dotnet.microsoft.com/download/dotnet/6.0)
 * Either:
-  * [Visual Studio 2019](https://visualstudio.microsoft.com/downloads), or
-  * [Visual Studio 2019 Build
-    Tools](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019)
+  * [Visual Studio 2022](https://visualstudio.microsoft.com/downloads), or
+  * [Visual Studio 2022 Build
+    Tools](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022)
     (install the ".NET Build Tools" component)
 * Clone [this
   repository](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-AdminApp) locally
@@ -43,7 +43,7 @@ longer than 256 characters:
 
 The PowerShell script `build.ps1` in the root directory contains functions for
 running standard build operations at the command line . This script assumes that
-.NET Core 3.1 SDK or newer is installed. Other dependencies tools are downloaded
+.NET 6.0 SDK or newer is installed. Other dependencies tools are downloaded
 as needed (nuget, nunit).
 
 Available commands:


### PR DESCRIPTION
**Description**
**Upgrades/Migration**
- Updated the target framework to netstandard 2.1 for the Management projects.
- Updated the target framework to net6.0 for Azure.IntegrationTests and Management.Tests projects since they have a dependency on AdminApp.Web project.
- Updated the target framework to net6.0 for the EdFi.Ods.AdminApp.Web project.
- Upgraded nuget packages on AdminApp.Web to the versions compatible with net6.0.
- Upgraded nuget packages on AdminApp.Management to the versions compatible with netstandard2.1.Upgraded NUnit nuget packages on the Management projects to the versions compatible with net6.0/netstandard2.1.
- Updated global.json sdk version to net6.0.
- Updated github action workflow to use .net 6.0.x instead of .net core 3.1.x.Updated developer docs to refer to .net 6.0 instead of .net core 3.1.

**Refactoring Work after package upgrades**
- Refactored ViewModels and ValidationExtensions to use ValidationContext<T> instead of Custom Context and IRuleBuilderOptionsConditions instead of IRuleBuilderInitial after the version upgrade to FluentValidation packages.
- Refactored to add configuration details as init-only properties instead of using setters (which are now removed) after upgrading to the latest CsvHelper version.
- Refactored to resolve warnings after nuget package upgrades.