### PR TITLE
[AA-1462] Admin API Authentication

### DIFF
--- a/Application/EdFi.Ods.Admin.Api/EdFi.Ods.Admin.Api.csproj
+++ b/Application/EdFi.Ods.Admin.Api/EdFi.Ods.Admin.Api.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="FluentValidation" Version="10.4.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.4.0" />
     <PackageReference Include="log4net" Version="2.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="6.1.0" />
     <PackageReference Include="OpenIddict.AspNetCore" Version="3.1.1" />
     <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="3.1.1" />

--- a/Application/EdFi.Ods.Admin.Api/EdFi.Ods.Admin.Api.csproj
+++ b/Application/EdFi.Ods.Admin.Api/EdFi.Ods.Admin.Api.csproj
@@ -11,6 +11,8 @@
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.4.0" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="6.1.0" />
+    <PackageReference Include="OpenIddict.AspNetCore" Version="3.1.1" />
+    <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="3.1.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>
 

--- a/Application/EdFi.Ods.Admin.Api/Features/Connect/ConnectController.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/Connect/ConnectController.cs
@@ -11,16 +11,22 @@ using OpenIddict.Server.AspNetCore;
 
 namespace EdFi.Ods.Admin.Api.Features.Connect;
 
+[AllowAnonymous]
 public class ConnectController : Controller
 {
     private readonly ITokenService _tokenService;
+    private readonly IRegisterService _registerService;
 
-    public ConnectController(ITokenService tokenService)
+    public ConnectController(ITokenService tokenService, IRegisterService registerService)
     {
         _tokenService = tokenService;
+        _registerService = registerService;
     }
 
-    [AllowAnonymous]
+    [HttpPost("/connect/register")]
+    [Consumes("application/x-www-form-urlencoded"), Produces("application/json")]
+    public Task<IResult> Register([FromForm] RegisterService.Request request) => _registerService.Handle(request);
+
     [HttpPost("/connect/token")]
     [Consumes("application/x-www-form-urlencoded"), Produces("application/json")]
     public async Task<ActionResult> Token()

--- a/Application/EdFi.Ods.Admin.Api/Features/Connect/ConnectController.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/Connect/ConnectController.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.Ods.Admin.Api.Infrastructure.Security;
 using FluentValidation;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Authorization;
@@ -27,7 +28,7 @@ public class ConnectController : Controller
     [Consumes("application/x-www-form-urlencoded"), Produces("application/json")]
     public Task<IResult> Register([FromForm] RegisterService.Request request) => _registerService.Handle(request);
 
-    [HttpPost("/connect/token")]
+    [HttpPost(SecurityConstants.TokenEndpointUri)]
     [Consumes("application/x-www-form-urlencoded"), Produces("application/json")]
     public async Task<ActionResult> Token()
     {

--- a/Application/EdFi.Ods.Admin.Api/Features/Connect/ConnectController.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/Connect/ConnectController.cs
@@ -1,0 +1,36 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using FluentValidation;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using OpenIddict.Server.AspNetCore;
+
+namespace EdFi.Ods.Admin.Api.Features.Connect;
+
+public class ConnectController : Controller
+{
+    private readonly ITokenService _tokenService;
+
+    public ConnectController(ITokenService tokenService)
+    {
+        _tokenService = tokenService;
+    }
+
+    [AllowAnonymous]
+    [HttpPost("/connect/token")]
+    [Consumes("application/x-www-form-urlencoded"), Produces("application/json")]
+    public async Task<ActionResult> Token()
+    {
+        var request = HttpContext.GetOpenIddictServerRequest();
+        if (request == null)
+            throw new ValidationException("Failed to parse token request");
+
+        var principal = await _tokenService.Handle(request);
+
+        return SignIn(principal, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+    }
+}

--- a/Application/EdFi.Ods.Admin.Api/Features/Connect/RegisterService.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/Connect/RegisterService.cs
@@ -1,0 +1,70 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using FluentValidation;
+using FluentValidation.Results;
+using OpenIddict.Abstractions;
+
+namespace EdFi.Ods.Admin.Api.Features.Connect;
+
+public interface IRegisterService
+{
+    Task<IResult> Handle(RegisterService.Request request);
+}
+
+public class RegisterService : IRegisterService
+{
+    private readonly Validator _validator;
+    private readonly IOpenIddictApplicationManager _applicationManager;
+
+    public RegisterService(Validator validator, IOpenIddictApplicationManager applicationManager)
+    {
+        _validator = validator;
+        _applicationManager = applicationManager;
+    }
+
+    public async Task<IResult> Handle(Request request)
+    {
+        await _validator.GuardAsync(request);
+
+        var existingApp = await _applicationManager.FindByClientIdAsync(request.ClientId!);
+        if (existingApp != null)
+            throw new ValidationException(new[] { new ValidationFailure(nameof(request.ClientId), $"ClientId {request.ClientId} already exists") });
+
+        var application = new OpenIddictApplicationDescriptor
+        {
+            ClientId = request.ClientId,
+            ClientSecret = request.ClientSecret,
+            DisplayName = request.DisplayName,
+            Permissions =
+            {
+                OpenIddictConstants.Permissions.Endpoints.Token,
+                OpenIddictConstants.Permissions.GrantTypes.ClientCredentials,
+
+                OpenIddictConstants.Permissions.Prefixes.Scope + "api"
+            },
+        };
+
+        await _applicationManager.CreateAsync(application);
+        return AdminApiResponse.Ok($"Registered client {request.ClientId} successfully.");
+    }
+
+    public class Validator : AbstractValidator<Request>
+    {
+        public Validator()
+        {
+            RuleFor(m => m.ClientId).NotEmpty();
+            RuleFor(m => m.ClientSecret).NotEmpty();
+            RuleFor(m => m.DisplayName).NotEmpty();
+        }
+    }
+
+    public class Request
+    {
+        public string? ClientId { get; set; }
+        public string? ClientSecret { get; set; }
+        public string? DisplayName { get; set; }
+    }
+}

--- a/Application/EdFi.Ods.Admin.Api/Features/Connect/RegisterService.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/Connect/RegisterService.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.Ods.Admin.Api.Infrastructure.Security;
 using FluentValidation;
 using FluentValidation.Results;
 using OpenIddict.Abstractions;
@@ -46,8 +47,7 @@ public class RegisterService : IRegisterService
             {
                 OpenIddictConstants.Permissions.Endpoints.Token,
                 OpenIddictConstants.Permissions.GrantTypes.ClientCredentials,
-
-                OpenIddictConstants.Permissions.Prefixes.Scope + "api"
+                OpenIddictConstants.Permissions.Prefixes.Scope + SecurityConstants.ApiFullAccessScope
             },
         };
 

--- a/Application/EdFi.Ods.Admin.Api/Features/Connect/TokenService.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/Connect/TokenService.cs
@@ -5,6 +5,7 @@
 
 using System.Security.Authentication;
 using System.Security.Claims;
+using EdFi.Ods.Admin.Api.Infrastructure.Security;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using OpenIddict.Abstractions;
 
@@ -44,7 +45,7 @@ public class TokenService : ITokenService
         var identity = new ClaimsIdentity(JwtBearerDefaults.AuthenticationScheme);
         identity.AddClaim(OpenIddictConstants.Claims.Subject, request.ClientId!, OpenIddictConstants.Destinations.AccessToken);
         identity.AddClaim(OpenIddictConstants.Claims.Name, displayName!, OpenIddictConstants.Destinations.AccessToken);
-        identity.AddClaim(OpenIddictConstants.Claims.Scope, "edfi_admin_api/full_access", OpenIddictConstants.Destinations.AccessToken);
+        identity.AddClaim(OpenIddictConstants.Claims.Scope, SecurityConstants.ApiFullAccessScope, OpenIddictConstants.Destinations.AccessToken);
 
         return new ClaimsPrincipal(identity);
     }

--- a/Application/EdFi.Ods.Admin.Api/Features/Connect/TokenService.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/Connect/TokenService.cs
@@ -1,0 +1,51 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Security.Authentication;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using OpenIddict.Abstractions;
+
+namespace EdFi.Ods.Admin.Api.Features.Connect;
+
+public interface ITokenService
+{
+    Task<ClaimsPrincipal> Handle(OpenIddictRequest request);
+}
+
+public class TokenService : ITokenService
+{
+    private readonly IOpenIddictApplicationManager _applicationManager;
+
+    public TokenService(IOpenIddictApplicationManager applicationManager)
+    {
+        _applicationManager = applicationManager;
+    }
+
+    public async Task<ClaimsPrincipal> Handle(OpenIddictRequest request)
+    {
+        if (!request.IsClientCredentialsGrantType())
+        {
+            throw new NotImplementedException("The specified grant type is not implemented");
+        }
+
+        var application = await _applicationManager.FindByClientIdAsync(request.ClientId!) ??
+            throw new NotFoundException<string?>("Admin API Client", request.ClientId);
+
+        if (!await _applicationManager.ValidateClientSecretAsync(application, request.ClientSecret!))
+        {
+            throw new AuthenticationException("Invalid Admin API Client key and secret");
+        }
+
+        var displayName = await _applicationManager.GetDisplayNameAsync(application);
+
+        var identity = new ClaimsIdentity(JwtBearerDefaults.AuthenticationScheme);
+        identity.AddClaim(OpenIddictConstants.Claims.Subject, request.ClientId!);
+        identity.AddClaim(OpenIddictConstants.Claims.Name, displayName!);
+        identity.AddClaim(OpenIddictConstants.Claims.Scope, "edfi_admin_api/full_access");
+
+        return new ClaimsPrincipal(identity);
+    }
+}

--- a/Application/EdFi.Ods.Admin.Api/Features/Connect/TokenService.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/Connect/TokenService.cs
@@ -42,9 +42,9 @@ public class TokenService : ITokenService
         var displayName = await _applicationManager.GetDisplayNameAsync(application);
 
         var identity = new ClaimsIdentity(JwtBearerDefaults.AuthenticationScheme);
-        identity.AddClaim(OpenIddictConstants.Claims.Subject, request.ClientId!);
-        identity.AddClaim(OpenIddictConstants.Claims.Name, displayName!);
-        identity.AddClaim(OpenIddictConstants.Claims.Scope, "edfi_admin_api/full_access");
+        identity.AddClaim(OpenIddictConstants.Claims.Subject, request.ClientId!, OpenIddictConstants.Destinations.AccessToken);
+        identity.AddClaim(OpenIddictConstants.Claims.Name, displayName!, OpenIddictConstants.Destinations.AccessToken);
+        identity.AddClaim(OpenIddictConstants.Claims.Scope, "edfi_admin_api/full_access", OpenIddictConstants.Destinations.AccessToken);
 
         return new ClaimsPrincipal(identity);
     }

--- a/Application/EdFi.Ods.Admin.Api/Features/Vendors/VendorFeatures.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/Vendors/VendorFeatures.cs
@@ -11,11 +11,11 @@ public class VendorFeatures : IFeature
 {
     public void MapEndpoints(IEndpointRouteBuilder endpoints)
     {
-        endpoints.MapGet("/vendors", GetVendors);
-        endpoints.MapGet("/vendors/{id}", GetVendor);
-        endpoints.MapPost("/vendors", AddVendor);
-        endpoints.MapPut("/vendors", UpdateVendor);
-        endpoints.MapDelete("/vendors/{id}", DeleteVendor);
+        endpoints.MapGet("/vendors", GetVendors).RequireAuthorization();
+        endpoints.MapGet("/vendors/{id}", GetVendor).RequireAuthorization();
+        endpoints.MapPost("/vendors", AddVendor).RequireAuthorization();
+        endpoints.MapPut("/vendors", UpdateVendor).RequireAuthorization();
+        endpoints.MapDelete("/vendors/{id}", DeleteVendor).RequireAuthorization();
     }
 
     internal Task<IResult> GetVendors(AdminAppDbContext dbContext)

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiDbContext.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiDbContext.cs
@@ -1,0 +1,35 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Ods.Admin.Api.Infrastructure.Security;
+using EdFi.Ods.AdminApp.Management.Database;
+using Microsoft.EntityFrameworkCore;
+
+namespace EdFi.Ods.Admin.Api.Infrastructure;
+
+public class AdminApiDbContext : DbContext
+{
+    private readonly IConfiguration _configuration;
+
+    public AdminApiDbContext(DbContextOptions<AdminApiDbContext> options, IConfiguration configuration)
+        : base(options)
+    {
+        _configuration = configuration;
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        var engine = _configuration.GetValue<string>("AppSettings:DatabaseEngine");
+
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.HasDefaultSchema("adminapi");
+        modelBuilder.ApplyDatabaseServerSpecificConventions(engine);
+
+        modelBuilder.Entity<ApiApplication>().ToTable("Applications").HasKey(a => a.Id);
+        modelBuilder.Entity<ApiScope>().ToTable("Scopes").HasKey(s => s.Id);
+        modelBuilder.Entity<ApiAuthorization>().ToTable("Authorizations").HasKey(a => a.Id);
+        modelBuilder.Entity<ApiToken>().ToTable("Tokens").HasKey(t => t.Id);
+    }
+}

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiDbContext.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiDbContext.cs
@@ -21,15 +21,15 @@ public class AdminApiDbContext : DbContext
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        var engine = _configuration.GetValue<string>("AppSettings:DatabaseEngine");
-
         base.OnModelCreating(modelBuilder);
         modelBuilder.HasDefaultSchema("adminapi");
-        modelBuilder.ApplyDatabaseServerSpecificConventions(engine);
 
         modelBuilder.Entity<ApiApplication>().ToTable("Applications").HasKey(a => a.Id);
         modelBuilder.Entity<ApiScope>().ToTable("Scopes").HasKey(s => s.Id);
         modelBuilder.Entity<ApiAuthorization>().ToTable("Authorizations").HasKey(a => a.Id);
         modelBuilder.Entity<ApiToken>().ToTable("Tokens").HasKey(t => t.Id);
+
+        var engine = _configuration.GetValue<string>("AppSettings:DatabaseEngine");
+        modelBuilder.ApplyDatabaseServerSpecificConventions(engine);
     }
 }

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityConstants.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityConstants.cs
@@ -1,0 +1,12 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.Ods.Admin.Api.Infrastructure.Security;
+
+public class SecurityConstants
+{
+    public const string TokenEndpointUri = "/connect/token";
+    public const string ApiFullAccessScope = "edfi_admin_api/full_access";
+}

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityExtensions.cs
@@ -56,8 +56,8 @@ public static class SecurityExtensions
             opt.SaveToken = true;
             opt.TokenValidationParameters = new TokenValidationParameters
             {
+                ValidateAudience = false,
                 ValidIssuer = issuer,
-                ValidAudience = issuer,
             };
         });
         services.AddAuthorization(opt =>

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityExtensions.cs
@@ -7,6 +7,7 @@ using EdFi.Ods.Admin.Api.Features.Connect;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.IdentityModel.Tokens;
+using OpenIddict.Abstractions;
 
 namespace EdFi.Ods.Admin.Api.Infrastructure.Security;
 
@@ -25,12 +26,12 @@ public static class SecurityExtensions
             {
                 opt.AllowClientCredentialsFlow();
 
-                opt.SetTokenEndpointUris("/connect/token");
+                opt.SetTokenEndpointUris(SecurityConstants.TokenEndpointUri);
 
                 opt.AddEphemeralEncryptionKey();
                 opt.AddEphemeralSigningKey();
 
-                opt.RegisterScopes("edfi_admin_api/full_access");
+                opt.RegisterScopes();
                 opt.UseAspNetCore().EnableTokenEndpointPassthrough();
             })
             .AddValidation(options =>
@@ -54,7 +55,7 @@ public static class SecurityExtensions
         services.AddAuthorization(opt =>
         {
             opt.DefaultPolicy = new AuthorizationPolicyBuilder()
-                .RequireClaim("scope", "edfi_adminapi/full_access")
+                .RequireClaim(OpenIddictConstants.Claims.Scope, SecurityConstants.ApiFullAccessScope)
                 .Build();
         });
 

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityExtensions.cs
@@ -29,12 +29,10 @@ public static class SecurityExtensions
 
                 opt.SetTokenEndpointUris(SecurityConstants.TokenEndpointUri);
 
-                if (webHostEnvironment.IsDevelopment())
-                {
-                    opt.AddEphemeralEncryptionKey();
-                    opt.AddEphemeralSigningKey();
-                }
-                else
+                opt.AddEphemeralEncryptionKey();
+                opt.AddEphemeralSigningKey();
+
+                if (!webHostEnvironment.IsDevelopment())
                 {
                     var encryptionKey = configuration.GetValue<string>("AppSettings:EncryptionKey");
                     var signingKey = configuration.GetValue<string>("Authentication:SigningKey");

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityExtensions.cs
@@ -50,8 +50,11 @@ public static class SecurityExtensions
 
         //Application Security
         var issuer = configuration.GetValue<string>("Authentication:IssuerUrl");
-        services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme).AddJwtBearer(opt =>
+        services.AddAuthentication(opt =>
         {
+            opt.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+            opt.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+        }).AddJwtBearer(opt => {
             opt.Authority = issuer;
             opt.SaveToken = true;
             opt.TokenValidationParameters = new TokenValidationParameters

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityExtensions.cs
@@ -32,10 +32,15 @@ public static class SecurityExtensions
                 opt.AddEphemeralEncryptionKey();
                 opt.AddEphemeralSigningKey();
 
-                if (!webHostEnvironment.IsDevelopment())
+                if (!webHostEnvironment.IsDevelopment()) //Keys below will override Ephemeral / Dev Keys
                 {
                     var encryptionKey = configuration.GetValue<string>("AppSettings:EncryptionKey");
                     var signingKey = configuration.GetValue<string>("Authentication:SigningKey");
+
+                    if (string.IsNullOrWhiteSpace(encryptionKey) || string.IsNullOrWhiteSpace(signingKey))
+                    {
+                        throw new Exception("Invalid Configuration: AppSettings:EncryptionKey and Authentication:SigningKey are required.");
+                    }
 
                     opt.AddEncryptionKey(new SymmetricSecurityKey(Convert.FromBase64String(encryptionKey)));
                     opt.AddSigningKey(new SymmetricSecurityKey(Convert.FromBase64String(signingKey)));

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityExtensions.cs
@@ -41,7 +41,7 @@ public static class SecurityExtensions
                     opt.AddSigningKey(new SymmetricSecurityKey(Convert.FromBase64String(signingKey)));
                 }
 
-                opt.RegisterScopes();
+                opt.RegisterScopes(SecurityConstants.ApiFullAccessScope);
                 opt.UseAspNetCore().EnableTokenEndpointPassthrough();
             })
             .AddValidation(options =>

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityExtensions.cs
@@ -36,7 +36,11 @@ public static class SecurityExtensions
                 }
                 else
                 {
-                    //TBD
+                    var encryptionKey = configuration.GetValue<string>("AppSettings:EncryptionKey");
+                    var signingKey = configuration.GetValue<string>("Authentication:SigningKey");
+
+                    opt.AddEncryptionKey(new SymmetricSecurityKey(Convert.FromBase64String(encryptionKey)));
+                    opt.AddSigningKey(new SymmetricSecurityKey(Convert.FromBase64String(signingKey)));
                 }
 
                 opt.RegisterScopes();

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityExtensions.cs
@@ -13,7 +13,8 @@ namespace EdFi.Ods.Admin.Api.Infrastructure.Security;
 
 public static class SecurityExtensions
 {
-    public static void AddSecurityUsingOpenIddict(this IServiceCollection services, IConfiguration configuration)
+    public static void AddSecurityUsingOpenIddict(this IServiceCollection services,
+        IConfiguration configuration, IWebHostEnvironment webHostEnvironment)
     {
         //OpenIddict Server
         services.AddOpenIddict()
@@ -28,8 +29,15 @@ public static class SecurityExtensions
 
                 opt.SetTokenEndpointUris(SecurityConstants.TokenEndpointUri);
 
-                opt.AddEphemeralEncryptionKey();
-                opt.AddEphemeralSigningKey();
+                if (webHostEnvironment.IsDevelopment())
+                {
+                    opt.AddEphemeralEncryptionKey();
+                    opt.AddEphemeralSigningKey();
+                }
+                else
+                {
+                    //TBD
+                }
 
                 opt.RegisterScopes();
                 opt.UseAspNetCore().EnableTokenEndpointPassthrough();

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityExtensions.cs
@@ -1,0 +1,66 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.Ods.Admin.Api.Features.Connect;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.IdentityModel.Tokens;
+
+namespace EdFi.Ods.Admin.Api.Infrastructure.Security;
+
+public static class SecurityExtensions
+{
+    public static void AddSecurityUsingOpenIddict(this IServiceCollection services, IConfiguration configuration)
+    {
+        //OpenIddict Server
+        services.AddOpenIddict()
+            .AddCore(opt =>
+            {
+                opt.UseEntityFrameworkCore().UseDbContext<AdminApiDbContext>()
+                    .ReplaceDefaultEntities<ApiApplication, ApiAuthorization, ApiScope, ApiToken, int>();
+            })
+            .AddServer(opt =>
+            {
+                opt.AllowClientCredentialsFlow();
+
+                opt.SetTokenEndpointUris("/connect/token");
+
+                opt.AddEphemeralEncryptionKey();
+                opt.AddEphemeralSigningKey();
+
+                opt.RegisterScopes("edfi_admin_api/full_access");
+                opt.UseAspNetCore().EnableTokenEndpointPassthrough();
+            })
+            .AddValidation(options =>
+            {
+                options.UseLocalServer();
+                options.UseAspNetCore();
+            });
+
+        //Application Security
+        var issuer = configuration.GetValue<string>("Authentication:IssuerUrl");
+        services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme).AddJwtBearer(opt =>
+        {
+            opt.Authority = issuer;
+            opt.SaveToken = true;
+            opt.TokenValidationParameters = new TokenValidationParameters
+            {
+                ValidIssuer = issuer,
+                ValidAudience = issuer,
+            };
+        });
+        services.AddAuthorization(opt =>
+        {
+            opt.DefaultPolicy = new AuthorizationPolicyBuilder()
+                .RequireClaim("scope", "edfi_adminapi/full_access")
+                .Build();
+        });
+
+        //Security Endpoints
+        services.AddTransient<ITokenService, TokenService>();
+        services.AddTransient<IRegisterService, RegisterService>();
+        services.AddControllers();
+    }
+}

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityModels.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityModels.cs
@@ -1,0 +1,24 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using OpenIddict.EntityFrameworkCore.Models;
+
+namespace EdFi.Ods.Admin.Api.Infrastructure.Security;
+
+public class ApiApplication : OpenIddictEntityFrameworkCoreApplication<int, ApiAuthorization, ApiToken>
+{
+}
+
+public class ApiScope : OpenIddictEntityFrameworkCoreScope<int>
+{
+}
+
+public class ApiAuthorization : OpenIddictEntityFrameworkCoreAuthorization<int, ApiApplication, ApiToken>
+{
+}
+
+public class ApiToken : OpenIddictEntityFrameworkCoreToken<int, ApiApplication, ApiAuthorization>
+{
+}

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/TokenEndpointBodyDescriptionFilter.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/TokenEndpointBodyDescriptionFilter.cs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace EdFi.Ods.Admin.Api.Infrastructure.Security;
+
+/// <summary>
+/// Swashbuckle OperationFilter to manually specify the Request Body for the Token endpoint,
+/// which pulls the request from HttpContext as per OpenIddict convention.
+/// </summary>
+public class TokenEndpointBodyDescriptionFilter : IOperationFilter
+{
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        var descriptor = context.ApiDescription.ActionDescriptor as ControllerActionDescriptor;
+        if (descriptor?.ControllerName != "Connect" || descriptor.ActionName != "Token")
+            return;
+
+        operation.Description = (operation.Description ?? "") + "\nExecute using \"Authorize\" above, not \"Try It Out\" here.";
+        operation.RequestBody ??= new OpenApiRequestBody();
+        operation.RequestBody.Content = new Dictionary<string, OpenApiMediaType>
+        {
+            { "application/x-www-form-urlencoded", BuildTokenRequestBodyDescription() }
+        };
+    }
+
+    private OpenApiMediaType BuildTokenRequestBodyDescription() => new OpenApiMediaType
+    {
+        Schema = new OpenApiSchema
+        {
+            Type = "object",
+            Properties = new Dictionary<string, OpenApiSchema>
+            {
+                { "client_id", new OpenApiSchema { Type = "string "} },
+                { "client_name", new OpenApiSchema { Type = "string "} },
+                { "grant_type", new OpenApiSchema { Type = "string "} },
+            }
+        }
+    };
+}

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/TokenEndpointBodyDescriptionFilter.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/TokenEndpointBodyDescriptionFilter.cs
@@ -21,7 +21,7 @@ public class TokenEndpointBodyDescriptionFilter : IOperationFilter
         if (descriptor?.ControllerName != "Connect" || descriptor.ActionName != "Token")
             return;
 
-        operation.Description = (operation.Description ?? "") + "\nExecute using \"Authorize\" above, not \"Try It Out\" here.";
+        operation.Description = (operation.Description ?? "") + "\nTo authenticate Swagger requests, execute using \"Authorize\" above, not \"Try It Out\" here.";
         operation.RequestBody ??= new OpenApiRequestBody();
         operation.RequestBody.Content = new Dictionary<string, OpenApiMediaType>
         {

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/TokenEndpointBodyDescriptionFilter.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/TokenEndpointBodyDescriptionFilter.cs
@@ -37,7 +37,7 @@ public class TokenEndpointBodyDescriptionFilter : IOperationFilter
             Properties = new Dictionary<string, OpenApiSchema>
             {
                 { "client_id", new OpenApiSchema { Type = "string "} },
-                { "client_name", new OpenApiSchema { Type = "string "} },
+                { "client_secret", new OpenApiSchema { Type = "string "} },
                 { "grant_type", new OpenApiSchema { Type = "string "} },
             }
         }

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -33,7 +33,7 @@ public static class WebApplicationBuilderExtensions
                         .GetCustomAttribute<System.ComponentModel.DataAnnotations.DisplayAttribute>()?.GetName();
             });
 
-        // Services
+        //Databases
         var databaseEngine = webApplicationBuilder.Configuration["AppSettings:DatabaseEngine"];
         webApplicationBuilder.AddDatabases(databaseEngine);
 

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -36,6 +36,27 @@ public static class WebApplicationBuilderExtensions
         // Services
         var databaseEngine = webApplicationBuilder.Configuration["AppSettings:DatabaseEngine"];
         webApplicationBuilder.AddDatabases(databaseEngine);
+
+        //OpenIddict Auth
+        webApplicationBuilder.Services.AddOpenIddict()
+            .AddCore(opt => opt.UseEntityFrameworkCore().UseDbContext<AdminAppDbContext>())
+            .AddServer(opt =>
+            {
+                opt.AllowClientCredentialsFlow();
+
+                opt.SetTokenEndpointUris("/connect/token");
+
+                opt.AddEphemeralEncryptionKey();
+                opt.AddEphemeralSigningKey();
+
+                opt.RegisterScopes("edfi_admin_api/full_access");
+                opt.UseAspNetCore().EnableTokenEndpointPassthrough();
+            })
+            .AddValidation(options =>
+            {
+                options.UseLocalServer();
+                options.UseAspNetCore();
+            });
     }
 
     private static void AddDatabases(this WebApplicationBuilder webApplicationBuilder, string databaseEngine)

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -30,7 +30,7 @@ public static class WebApplicationBuilderExtensions
                     {
                         ClientCredentials = new OpenApiOAuthFlow
                         {
-                            TokenUrl = new Uri($"{issuer}/connect/token"),
+                            TokenUrl = new Uri($"{issuer}{SecurityConstants.TokenEndpointUri}"),
                         },
                     },
                     In = ParameterLocation.Header,

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -21,6 +21,7 @@ public static class WebApplicationBuilderExtensions
         webApplicationBuilder.Services.AddSwaggerGen(opt =>
         {
             opt.CustomSchemaIds(x => x.FullName);
+            opt.OperationFilter<TokenEndpointBodyDescriptionFilter>();
             opt.AddSecurityDefinition(
                 "oauth",
                 new OpenApiSecurityScheme

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using EdFi.Admin.DataAccess.Contexts;
+using EdFi.Ods.Admin.Api.Infrastructure.Security;
 using EdFi.Ods.AdminApp.Management.Database;
 using EdFi.Security.DataAccess.Contexts;
 using FluentValidation.AspNetCore;
@@ -56,7 +57,11 @@ public static class WebApplicationBuilderExtensions
         else if (DatabaseEngineEnum.Parse(databaseEngine).Equals(DatabaseEngineEnum.SqlServer))
         {
             webApplicationBuilder.Services.AddDbContext<AdminAppDbContext>(
-                options => options.UseSqlServer(adminConnectionString));
+                options =>
+                {
+                    options.UseSqlServer(adminConnectionString);
+                    options.UseOpenIddict<ApiApplication, ApiAuthorization, ApiScope, ApiToken, int>();
+                });
 
             webApplicationBuilder.Services.AddScoped<ISecurityContext>(
                 sp => new SqlServerSecurityContext(securityConnectionString));

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using EdFi.Admin.DataAccess.Contexts;
+using EdFi.Ods.Admin.Api.Features.Connect;
 using EdFi.Ods.Admin.Api.Infrastructure.Security;
 using EdFi.Ods.AdminApp.Management.Database;
 using EdFi.Security.DataAccess.Contexts;
@@ -61,6 +62,9 @@ public static class WebApplicationBuilderExtensions
                 options.UseLocalServer();
                 options.UseAspNetCore();
             });
+
+        webApplicationBuilder.Services.AddTransient<ITokenService, TokenService>();
+        webApplicationBuilder.Services.AddControllers();
     }
 
     private static void AddDatabases(this WebApplicationBuilder webApplicationBuilder, string databaseEngine)

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -85,6 +85,7 @@ public static class WebApplicationBuilderExtensions
         });
 		
 		webApplicationBuilder.Services.AddTransient<ITokenService, TokenService>();
+        webApplicationBuilder.Services.AddTransient<IRegisterService, RegisterService>();
         webApplicationBuilder.Services.AddControllers();
     }
 

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -86,6 +86,13 @@ public static class WebApplicationBuilderExtensions
             webApplicationBuilder.Services.AddDbContext<AdminAppDbContext>(
                 options => options.UseNpgsql(adminConnectionString));
 
+            webApplicationBuilder.Services.AddDbContext<AdminApiDbContext>(
+                options =>
+                {
+                    options.UseNpgsql(adminConnectionString);
+                    options.UseOpenIddict<ApiApplication, ApiAuthorization, ApiScope, ApiToken, int>();
+                });
+
             webApplicationBuilder.Services.AddScoped<ISecurityContext>(
                 sp => new PostgresSecurityContext(securityConnectionString));
 

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -39,7 +39,11 @@ public static class WebApplicationBuilderExtensions
 
         //OpenIddict Auth
         webApplicationBuilder.Services.AddOpenIddict()
-            .AddCore(opt => opt.UseEntityFrameworkCore().UseDbContext<AdminAppDbContext>())
+            .AddCore(opt =>
+            {
+                opt.UseEntityFrameworkCore().UseDbContext<AdminApiDbContext>()
+                    .ReplaceDefaultEntities<ApiApplication, ApiAuthorization, ApiScope, ApiToken, int>();
+            })
             .AddServer(opt =>
             {
                 opt.AllowClientCredentialsFlow();
@@ -78,6 +82,9 @@ public static class WebApplicationBuilderExtensions
         else if (DatabaseEngineEnum.Parse(databaseEngine).Equals(DatabaseEngineEnum.SqlServer))
         {
             webApplicationBuilder.Services.AddDbContext<AdminAppDbContext>(
+                options => options.UseSqlServer(adminConnectionString));
+
+            webApplicationBuilder.Services.AddDbContext<AdminApiDbContext>(
                 options =>
                 {
                     options.UseSqlServer(adminConnectionString);

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -16,7 +16,7 @@ public static class WebApplicationBuilderExtensions
         // Add services to the container.
         // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
         webApplicationBuilder.Services.AddEndpointsApiExplorer();
-        webApplicationBuilder.Services.AddSwaggerGen();
+        webApplicationBuilder.Services.AddSwaggerGen(opt => opt.CustomSchemaIds(x => x.FullName));
 
         // Logging
         var loggingOptions = webApplicationBuilder.Configuration.GetSection("Log4NetCore").Get<Log4NetProviderOptions>();

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -72,7 +72,7 @@ public static class WebApplicationBuilderExtensions
         var databaseEngine = webApplicationBuilder.Configuration["AppSettings:DatabaseEngine"];
         webApplicationBuilder.AddDatabases(databaseEngine);
 
-        webApplicationBuilder.Services.AddSecurityUsingOpenIddict(webApplicationBuilder.Configuration);
+        webApplicationBuilder.Services.AddSecurityUsingOpenIddict(webApplicationBuilder.Configuration, webApplicationBuilder.Environment);
     }
 
     private static void AddDatabases(this WebApplicationBuilder webApplicationBuilder, string databaseEngine)

--- a/Application/EdFi.Ods.Admin.Api/Program.cs
+++ b/Application/EdFi.Ods.Admin.Api/Program.cs
@@ -28,6 +28,9 @@ else
 
 app.UseHttpsRedirection();
 
+app.UseAuthentication();
+app.UseAuthorization();
+
 app.UseRouting();
 app.MapFeatureEndpoints();
 app.MapControllers();

--- a/Application/EdFi.Ods.Admin.Api/Program.cs
+++ b/Application/EdFi.Ods.Admin.Api/Program.cs
@@ -30,6 +30,7 @@ app.UseHttpsRedirection();
 
 app.UseRouting();
 app.MapFeatureEndpoints();
+app.MapControllers();
 
 if (app.Configuration.GetValue<bool>("EnableSwagger"))
 {

--- a/Application/EdFi.Ods.Admin.Api/Program.cs
+++ b/Application/EdFi.Ods.Admin.Api/Program.cs
@@ -28,10 +28,10 @@ else
 
 app.UseHttpsRedirection();
 
+//The ordering here is meaningful: Routing -> Auth -> Endpoints
+app.UseRouting();
 app.UseAuthentication();
 app.UseAuthorization();
-
-app.UseRouting();
 app.MapFeatureEndpoints();
 app.MapControllers();
 

--- a/Application/EdFi.Ods.Admin.Api/Properties/launchSettings.json
+++ b/Application/EdFi.Ods.Admin.Api/Properties/launchSettings.json
@@ -16,7 +16,8 @@
       "launchUrl": "swagger",
       "applicationUrl": "https://localhost:7214;http://localhost:5214",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "AUTHENTICATION__ISSUERURL": "https://localhost:7214"
       }
     },
     "IIS Express": {
@@ -24,7 +25,8 @@
       "launchBrowser": true,
       "launchUrl": "swagger",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "AUTHENTICATION__ISSUERURL": "https://localhost:44370"
       }
     }
   }

--- a/Application/EdFi.Ods.Admin.Api/appsettings.Development.json
+++ b/Application/EdFi.Ods.Admin.Api/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "Authentication": {
+    "AllowRegistration": true
+  },
   "EnableSwagger": true,
   "Logging": {
     "LogLevel": {

--- a/Application/EdFi.Ods.Admin.Api/appsettings.json
+++ b/Application/EdFi.Ods.Admin.Api/appsettings.json
@@ -16,6 +16,7 @@
     },
     "Authentication":{
         "IssuerUrl": "",
+        "SigningKey": "",
         "AllowRegistration": false
     },
     "EnableSwagger": false,

--- a/Application/EdFi.Ods.Admin.Api/appsettings.json
+++ b/Application/EdFi.Ods.Admin.Api/appsettings.json
@@ -14,6 +14,9 @@
         "EncryptionKey": "",
         "ProductRegistrationUrl": "https://edfi-tools-analytics.azurewebsites.net/data/v1/"
     },
+    "Authentication":{
+        "IssuerUrl": ""
+    },
     "EnableSwagger": false,
     "ConnectionStrings": {
         "Admin": "Data Source=.\\;Initial Catalog=EdFi_Admin;Integrated Security=True",

--- a/Application/EdFi.Ods.Admin.Api/appsettings.json
+++ b/Application/EdFi.Ods.Admin.Api/appsettings.json
@@ -15,7 +15,8 @@
         "ProductRegistrationUrl": "https://edfi-tools-analytics.azurewebsites.net/data/v1/"
     },
     "Authentication":{
-        "IssuerUrl": ""
+        "IssuerUrl": "",
+        "AllowRegistration": false
     },
     "EnableSwagger": false,
     "ConnectionStrings": {

--- a/Application/EdFi.Ods.AdminApp.Web/Artifacts/MsSql/Structure/Admin/202205080900-CreateAdminApiSchema.sql
+++ b/Application/EdFi.Ods.AdminApp.Web/Artifacts/MsSql/Structure/Admin/202205080900-CreateAdminApiSchema.sql
@@ -1,0 +1,9 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = 'adminapi')
+BEGIN
+EXEC( 'CREATE SCHEMA adminapi' );
+END

--- a/Application/EdFi.Ods.AdminApp.Web/Artifacts/MsSql/Structure/Admin/202205090900-AddApiAuthTables.sql
+++ b/Application/EdFi.Ods.AdminApp.Web/Artifacts/MsSql/Structure/Admin/202205090900-AddApiAuthTables.sql
@@ -1,0 +1,64 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+CREATE TABLE adminapi.Applications (
+    [Id] int identity NOT NULL,
+    [ConcurrencyToken] NVARCHAR(128) NULL,
+    [ClientId] NVARCHAR(256) NULL,
+    [ClientSecret] NVARCHAR(256) NULL,
+    [Type] NVARCHAR(256) NULL,
+    [ConsentType] NVARCHAR(256) NULL,
+    [Permissions] NVARCHAR(MAX) NULL,
+    [Properties] NVARCHAR(MAX) NULL,
+    [Requirements] NVARCHAR(MAX) NULL,
+    [DisplayName] NVARCHAR(256) NULL,
+    [DisplayNames] NVARCHAR(MAX) NULL,
+    [RedirectUris] NVARCHAR(MAX) NULL,
+    [PostLogoutRedirectUris] NVARCHAR(MAX) NULL,
+    CONSTRAINT PK_Applications PRIMARY KEY (Id)
+);
+
+CREATE TABLE adminapi.Scopes (
+    [Id] int identity NOT NULL,
+    [Name] NVARCHAR(256) NULL,
+    [ConcurrencyToken] NVARCHAR(128) NULL,
+    [Description] NVARCHAR(MAX) NULL,
+    [Descriptions] NVARCHAR(MAX) NULL,
+    [DisplayName] NVARCHAR(256) NULL,
+    [DisplayNames] NVARCHAR(MAX) NULL,
+    [Properties] NVARCHAR(MAX) NULL,
+    [Resources] NVARCHAR(MAX) NULL,
+    CONSTRAINT PK_Scopes PRIMARY KEY (Id)
+);
+
+CREATE TABLE adminapi.Authorizations (
+    [Id] int identity NOT NULL,
+    [ConcurrencyToken] NVARCHAR(128) NULL,
+    [ApplicationId] int NOT NULL,
+    [Scopes] NVARCHAR(MAX) NULL,
+    [Subject] NVARCHAR(256) NULL,
+    [Status] NVARCHAR(256) NULL,
+    [Properties] NVARCHAR(MAX) NULL,
+    [CreationDate] DATETIME NULL,
+    CONSTRAINT PK_Authorizations PRIMARY KEY (Id),
+    CONSTRAINT FK_AuthorizationsId_ApplicationId FOREIGN KEY (ApplicationId) REFERENCES adminapi.Applications (Id) ON DELETE NO ACTION,
+);
+
+CREATE TABLE adminapi.Tokens (
+    [Id] int identity NOT NULL,
+    [ConcurrencyToken] NVARCHAR(128) NULL,
+    [ApplicationId] int NULL,
+    [AuthorizationId] int NULL,
+    [Type] NVARCHAR(256) NULL,
+    [CreationDate] DATETIME NULL,
+    [ExpirationDate] DATETIME NULL,
+    [RedemptionDate] DATETIME NULL,
+    [Payload] NVARCHAR(MAX) NULL,
+    [Properties] NVARCHAR(MAX) NULL,
+    [Subject] NVARCHAR(256) NULL,
+    [Status] NVARCHAR(256) NULL,
+    [ReferenceId] NVARCHAR(256) NULL,
+    CONSTRAINT PK_Tokens PRIMARY KEY (Id)
+);

--- a/Application/EdFi.Ods.AdminApp.Web/Artifacts/PgSql/Structure/Admin/202205080900-CreateAdminApiSchema.sql
+++ b/Application/EdFi.Ods.AdminApp.Web/Artifacts/PgSql/Structure/Admin/202205080900-CreateAdminApiSchema.sql
@@ -1,0 +1,6 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+CREATE SCHEMA IF NOT EXISTS adminapi;

--- a/Application/EdFi.Ods.AdminApp.Web/Artifacts/PgSql/Structure/Admin/202205090900-AddApiAuthTables.sql
+++ b/Application/EdFi.Ods.AdminApp.Web/Artifacts/PgSql/Structure/Admin/202205090900-AddApiAuthTables.sql
@@ -1,0 +1,64 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+CREATE TABLE adminapi.Applications (
+    Id INT NOT NULL GENERATED ALWAYS AS IDENTITY,
+    ConcurrencyToken VARCHAR(128) NULL,
+    ClientId VARCHAR(256) NULL,
+    ClientSecret VARCHAR(256) NULL,
+    Type VARCHAR(256) NULL,
+    ConsentType VARCHAR(256) NULL,
+    Permissions VARCHAR NULL,
+    Properties VARCHAR NULL,
+    Requirements VARCHAR NULL,
+    DisplayName VARCHAR(256) NULL,
+    DisplayNames VARCHAR NULL,
+    RedirectUris VARCHAR NULL,
+    PostLogoutRedirectUris VARCHAR NULL,
+    CONSTRAINT PK_Applications PRIMARY KEY (Id)
+);
+
+CREATE TABLE adminapi.Scopes (
+    Id INT NOT NULL GENERATED ALWAYS AS IDENTITY,
+    Name VARCHAR(256) NULL,
+    ConcurrencyToken VARCHAR(128) NULL,
+    Description VARCHAR NULL,
+    Descriptions VARCHAR NULL,
+    DisplayName VARCHAR(256) NULL,
+    DisplayNames VARCHAR NULL,
+    Properties VARCHAR NULL,
+    Resources VARCHAR NULL,
+    CONSTRAINT PK_Scopes PRIMARY KEY (Id)
+);
+
+CREATE TABLE adminapi.Authorizations (
+    Id INT NOT NULL GENERATED ALWAYS AS IDENTITY,
+    ConcurrencyToken VARCHAR(128) NULL,
+    ApplicationId int NOT NULL,
+    Scopes VARCHAR NULL,
+    Subject VARCHAR(256) NULL,
+    Status VARCHAR(256) NULL,
+    Properties VARCHAR NULL,
+    CreationDate TIMESTAMP NULL,
+    CONSTRAINT PK_Authorizations PRIMARY KEY (Id),
+    CONSTRAINT FK_AuthorizationsId_ApplicationId FOREIGN KEY (ApplicationId) REFERENCES adminapi.Applications (Id) ON DELETE RESTRICT
+);
+
+CREATE TABLE adminapi.Tokens (
+    Id INT NOT NULL GENERATED ALWAYS AS IDENTITY,
+    ConcurrencyToken VARCHAR(128) NULL,
+    ApplicationId int NULL,
+    AuthorizationId int NULL,
+    Type VARCHAR(256) NULL,
+    CreationDate TIMESTAMP NULL,
+    ExpirationDate TIMESTAMP NULL,
+    RedemptionDate TIMESTAMP NULL,
+    Payload VARCHAR NULL,
+    Properties VARCHAR NULL,
+    Subject VARCHAR(256) NULL,
+    Status VARCHAR(256) NULL,
+    ReferenceId VARCHAR(256) NULL,
+    CONSTRAINT PK_Tokens PRIMARY KEY (Id)
+);


### PR DESCRIPTION
Introduce authentication and authorization to Admin API using the [OpenIddict](https://documentation.openiddict.com/index.html) library.

- follows "client credential" flow to serve auth tokens for use by other applications
  - supports a single "full access" scope that is granted and required on all endpoints
- registration is disabled by default in prod, but overridden when no Applications are registered
- when testing, you can [disable token encryption](https://documentation.openiddict.com/configuration/token-formats.html#disabling-jwt-access-token-encryption) to validate contents in service such as [jwt.io](https://jwt.io/)

**Remarks**

- OpenIddict endpoints do not return responses in the same format as the rest of AdminAPI, which can be expected as it's its own 'server' context
- registers `/connect/` endpoints as traditional MVC Controllers in order to support `form-urlencoded` requests (per OAuth2) and to work around odd `jwt` serialization issue
  - Controller registration is "obscured" away in `SecurityExtensions` to discourage other controllers
- uses custom entity types (in separate schema) for naming + in case we move away from OpenIddict in the future
- OpenIddict gleans request from `HttpContext`, so the `/connect/token` endpoint does not include a body. The schema is added manually to swagger, although the "Try It Out" button does not work (as noted in description). The "Authorize" button and Postman work as expected

