### PR TITLE
[AA-1517] claim set import not retaining the authorization strategy overrides

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/ClaimSetFileImportCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/ClaimSetFileImportCommand.cs
@@ -1,10 +1,11 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Collections.Generic;
 using System.Linq;
+using EdFi.Ods.AdminApp.Management.ClaimSetEditor.Extensions;
 using EdFi.Ods.AdminApp.Management.Database.Queries;
 
 namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
@@ -14,12 +15,17 @@ namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
         private readonly AddClaimSetCommand _addClaimSetCommand;
         private readonly EditResourceOnClaimSetCommand _editResourceOnClaimSetCommand;
         private readonly GetResourceClaimsQuery _getResourceClaimsQuery;
+        private readonly OverrideDefaultAuthorizationStrategyCommand _overrideDefaultAuthorizationStrategyCommand;
 
-        public ClaimSetFileImportCommand(AddClaimSetCommand addClaimSetCommand, EditResourceOnClaimSetCommand editResourceOnClaimSetCommand, GetResourceClaimsQuery getResourceClaimsQuery)
+        public ClaimSetFileImportCommand(AddClaimSetCommand addClaimSetCommand,
+            EditResourceOnClaimSetCommand editResourceOnClaimSetCommand,
+            GetResourceClaimsQuery getResourceClaimsQuery,
+            OverrideDefaultAuthorizationStrategyCommand overrideDefaultAuthorizationStrategyCommand)
         {
             _addClaimSetCommand = addClaimSetCommand;
             _editResourceOnClaimSetCommand = editResourceOnClaimSetCommand;
             _getResourceClaimsQuery = getResourceClaimsQuery;
+            _overrideDefaultAuthorizationStrategyCommand = overrideDefaultAuthorizationStrategyCommand;
         }
 
         public void Execute(SharingModel model)
@@ -47,6 +53,7 @@ namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
                             resource.Read = r.Read;
                             resource.Update = r.Update;
                             resource.Delete = r.Delete;
+                            resource.AuthStrategyOverridesForCRUD = r.AuthStrategyOverridesForCRUD;
                         }
                         return resource;
                     }).ToList();
@@ -60,6 +67,25 @@ namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
                     };
 
                     _editResourceOnClaimSetCommand.Execute(editResourceModel);
+
+                    if (resource.AuthStrategyOverridesForCRUD != null && resource.AuthStrategyOverridesForCRUD.Any())
+                    {
+                        var overrideAuthStrategyModel = new OverrideAuthorizationStrategyModel
+                        {
+                            ClaimSetId = claimSetId,
+                            ResourceClaimId = resource.Id,
+                            AuthorizationStrategyForCreate = AuthStrategyOverrideForAction(resource.AuthStrategyOverridesForCRUD.Create()),
+                            AuthorizationStrategyForRead = AuthStrategyOverrideForAction(resource.AuthStrategyOverridesForCRUD.Read()),
+                            AuthorizationStrategyForUpdate = AuthStrategyOverrideForAction(resource.AuthStrategyOverridesForCRUD.Update()),
+                            AuthorizationStrategyForDelete = AuthStrategyOverrideForAction(resource.AuthStrategyOverridesForCRUD.Delete())
+                        };
+                        _overrideDefaultAuthorizationStrategyCommand.Execute(overrideAuthStrategyModel);
+                    }
+                }
+
+                static int AuthStrategyOverrideForAction(AuthorizationStrategy authorizationStrategy)
+                {
+                    return authorizationStrategy != null ? authorizationStrategy.AuthStrategyId : 0;
                 }
             }
         }
@@ -87,5 +113,15 @@ namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
     {
         public int ClaimSetId { get; set; }
         public ResourceClaim ResourceClaim { get; set;  }
+    }
+
+    public class OverrideAuthorizationStrategyModel : IOverrideDefaultAuthorizationStrategyModel
+    {
+        public int ClaimSetId { get; set; }
+        public int ResourceClaimId { get; set; }
+        public int AuthorizationStrategyForCreate { get; set; }
+        public int AuthorizationStrategyForRead { get; set; }
+        public int AuthorizationStrategyForUpdate { get; set; }
+        public int AuthorizationStrategyForDelete { get; set; }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/Extensions/AuthorizationStrategiesExtension.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/Extensions/AuthorizationStrategiesExtension.cs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor.Extensions
+{
+    public static class AuthorizationStrategiesExtension
+    {
+        public static AuthorizationStrategy Create(this AuthorizationStrategy[] authorizationStrategies)
+        {
+            return authorizationStrategies[0];
+        }
+
+        public static AuthorizationStrategy Read(this AuthorizationStrategy[] authorizationStrategies)
+        {
+            return authorizationStrategies[1];
+        }
+
+        public static AuthorizationStrategy Update(this AuthorizationStrategy[] authorizationStrategies)
+        {
+            return authorizationStrategies[2];
+        }
+
+        public static AuthorizationStrategy Delete(this AuthorizationStrategy[] authorizationStrategies)
+        {
+            return authorizationStrategies[3];
+        }
+
+        public static AuthorizationStrategy[] AddAuthorizationStrategyOverrides(this AuthorizationStrategy[] authorizationStrategies,
+            Security.DataAccess.Models.Action action, AuthorizationStrategy strategy)
+        {
+            if (action.ActionName == Action.Create.Value)
+                authorizationStrategies[0] = strategy;
+            else if (action.ActionName == Action.Read.Value)
+                authorizationStrategies[1] = strategy;
+            else if (action.ActionName == Action.Update.Value)
+                authorizationStrategies[2] = strategy;
+            else if (action.ActionName == Action.Delete.Value)
+                authorizationStrategies[3] = strategy;
+
+            return authorizationStrategies;
+        }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/GetResourcesByClaimSetIdQuery.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/GetResourcesByClaimSetIdQuery.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Data.Entity;
 using System.Linq;
 using AutoMapper;
+using EdFi.Ods.AdminApp.Management.ClaimSetEditor.Extensions;
 using EdFi.Security.DataAccess.Contexts;
 using EdFi.Security.DataAccess.Models;
 
@@ -213,37 +214,20 @@ namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
                     if(resourceClaim.AuthorizationStrategyOverride != null)
                     {
                         authStrategy = _mapper.Map<AuthorizationStrategy>(resourceClaim.AuthorizationStrategyOverride);
-                    }                        
+                    }
                 }
 
                 if (resultDictionary.ContainsKey(resourceClaim.ResourceClaim.ResourceClaimId))
                 {
-                    resultDictionary[resourceClaim.ResourceClaim.ResourceClaimId] = AddToOverrideDictionary(
-                        resultDictionary[resourceClaim.ResourceClaim.ResourceClaimId], resourceClaim.Action,
+                    resultDictionary[resourceClaim.ResourceClaim.ResourceClaimId].AddAuthorizationStrategyOverrides(resourceClaim.Action,
                         authStrategy);
                 }
                 else
                 {
                     var actions = new AuthorizationStrategy[]{null, null, null, null};
-                    actions = AddToOverrideDictionary(actions, resourceClaim.Action, authStrategy);                                
-                    resultDictionary[resourceClaim.ResourceClaim.ResourceClaimId] = actions;
-                }
-
-                AuthorizationStrategy[] AddToOverrideDictionary(AuthorizationStrategy[] actions, Security.DataAccess.Models.Action action, AuthorizationStrategy strategy)
-                {
-                    if (action.ActionName == Action.Create.Value)
-                        actions[0] = strategy;
-                    else if (action.ActionName == Action.Read.Value)
-                        actions[1] = strategy;
-                    else if (action.ActionName == Action.Update.Value)
-                        actions[2] = strategy;
-                    else if (action.ActionName == Action.Delete.Value)
-                        actions[3] = strategy;
-
-                    return actions;
+                    resultDictionary[resourceClaim.ResourceClaim.ResourceClaimId] = actions.AddAuthorizationStrategyOverrides(resourceClaim.Action, authStrategy);
                 }
             }
-            
             return resultDictionary;
         }
 

--- a/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_AuthStrategiesModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_AuthStrategiesModal.cshtml
@@ -1,10 +1,11 @@
-﻿@*
+@*
 SPDX-License-Identifier: Apache-2.0
 Licensed to the Ed-Fi Alliance under one or more agreements.
 The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 See the LICENSE and NOTICES files in the project root for more information.
 *@
 
+@using EdFi.Ods.AdminApp.Management.ClaimSetEditor.Extensions
 @using EdFi.Ods.AdminApp.Web.Helpers
 @using EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
 @using Newtonsoft.Json;
@@ -63,14 +64,26 @@ See the LICENSE and NOTICES files in the project root for more information.
                     <tbody>
                     @if (Model.ResourceClaim != null)
                     {
+                         var authStrategyOverridesForRead = Model.ResourceClaim.AuthStrategyOverridesForCRUD.Read();
+                         var defaultAuthStrategyForRead = Model.ResourceClaim.DefaultAuthStrategiesForCRUD.Read();
+
+                         var authStrategyOverridesForCreate = Model.ResourceClaim.AuthStrategyOverridesForCRUD.Create();
+                         var defaultAuthStrategyForCreate = Model.ResourceClaim.DefaultAuthStrategiesForCRUD.Create();
+
+                         var authStrategyOverridesForUpdate = Model.ResourceClaim.AuthStrategyOverridesForCRUD.Update();
+                         var defaultAuthStrategyForUpdate = Model.ResourceClaim.DefaultAuthStrategiesForCRUD.Update();
+
+                         var authStrategyOverridesForDelete = Model.ResourceClaim.AuthStrategyOverridesForCRUD.Delete();
+                         var defaultAuthStrategyForDelete = Model.ResourceClaim.DefaultAuthStrategiesForCRUD.Delete();
+
                         <tr class="parent-resource-claim">
                             <td class="icon-cell"></td>
                             <td data-resource-id='@Model.ResourceClaim.Id' class="resource-label">@Model.ResourceClaim.Name</td>
                             <td class="read-action-cell" data-existing-action='@Model.ResourceClaim.Read'>
-                                @if (Model.ResourceClaim.AuthStrategyOverridesForCRUD[1] != null)
+                                @if (authStrategyOverridesForRead != null)
                                 {
-                                    <span data-is-inherited="@Model.ResourceClaim.AuthStrategyOverridesForCRUD[1].IsInheritedFromParent" data-default-strategy='@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[1].DisplayName'>@Model.ResourceClaim.AuthStrategyOverridesForCRUD[1].DisplayName</span>
-                                    if (Model.ResourceClaim.AuthStrategyOverridesForCRUD[1].IsInheritedFromParent)
+                                    <span data-is-inherited="@authStrategyOverridesForRead.IsInheritedFromParent" data-default-strategy='@defaultAuthStrategyForRead.DisplayName'>@authStrategyOverridesForRead.DisplayName</span>
+                                    if (authStrategyOverridesForRead.IsInheritedFromParent)
                                     {
                                         <span class="overridden-strategy inherited-override">(Overridden)</span>
                                     }
@@ -79,10 +92,10 @@ See the LICENSE and NOTICES files in the project root for more information.
                                         <span class="overridden-strategy">(Overridden)</span>
                                     }
                                 }
-                                else if (Model.ResourceClaim.DefaultAuthStrategiesForCRUD[1] != null)
+                                else if (defaultAuthStrategyForRead != null)
                                 {
-                                    <span data-is-inherited="@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[1].IsInheritedFromParent" data-default-strategy='@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[1].DisplayName'>@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[1].DisplayName</span>
-                                    if (Model.ResourceClaim.DefaultAuthStrategiesForCRUD[1].IsInheritedFromParent)
+                                    <span data-is-inherited="@defaultAuthStrategyForRead.IsInheritedFromParent" data-default-strategy='@defaultAuthStrategyForRead.DisplayName'>@defaultAuthStrategyForRead.DisplayName</span>
+                                    if (defaultAuthStrategyForRead.IsInheritedFromParent)
                                     {
                                         <span class="default-strategy inherited-strategy">(Default)</span>
                                     }
@@ -93,10 +106,10 @@ See the LICENSE and NOTICES files in the project root for more information.
                                 }
                             </td>
                             <td class="create-action-cell" data-existing-action='@Model.ResourceClaim.Create'>
-                                @if (Model.ResourceClaim.AuthStrategyOverridesForCRUD[0] != null)
+                                @if (authStrategyOverridesForCreate != null)
                                 {
-                                    <span data-is-inherited="@Model.ResourceClaim.AuthStrategyOverridesForCRUD[0].IsInheritedFromParent" data-default-strategy='@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[0].DisplayName'>@Model.ResourceClaim.AuthStrategyOverridesForCRUD[0].DisplayName</span>
-                                    if (Model.ResourceClaim.AuthStrategyOverridesForCRUD[0].IsInheritedFromParent)
+                                    <span data-is-inherited="@authStrategyOverridesForCreate.IsInheritedFromParent" data-default-strategy='@defaultAuthStrategyForCreate.DisplayName'>@authStrategyOverridesForCreate.DisplayName</span>
+                                    if (authStrategyOverridesForCreate.IsInheritedFromParent)
                                     {
                                         <span class="overridden-strategy inherited-override">(Overridden)</span>
                                     }
@@ -105,10 +118,10 @@ See the LICENSE and NOTICES files in the project root for more information.
                                         <span class="overridden-strategy">(Overridden)</span>
                                     }
                                 }
-                                else if (Model.ResourceClaim.DefaultAuthStrategiesForCRUD[0] != null)
+                                else if (defaultAuthStrategyForCreate != null)
                                 {
-                                    <span data-is-inherited="@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[0].IsInheritedFromParent" data-default-strategy='@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[0].DisplayName'>@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[0].DisplayName</span>
-                                    if (Model.ResourceClaim.DefaultAuthStrategiesForCRUD[0].IsInheritedFromParent)
+                                    <span data-is-inherited="@defaultAuthStrategyForCreate.IsInheritedFromParent" data-default-strategy='@defaultAuthStrategyForCreate.DisplayName'>@defaultAuthStrategyForCreate.DisplayName</span>
+                                    if (defaultAuthStrategyForCreate.IsInheritedFromParent)
                                     {
                                         <span class="default-strategy inherited-strategy">(Default)</span>
                                     }
@@ -119,10 +132,10 @@ See the LICENSE and NOTICES files in the project root for more information.
                                 }
                             </td>
                             <td class="update-action-cell" data-existing-action='@Model.ResourceClaim.Update'>
-                                @if (Model.ResourceClaim.AuthStrategyOverridesForCRUD[2] != null)
+                                @if (authStrategyOverridesForUpdate != null)
                                 {
-                                    <span data-is-inherited="@Model.ResourceClaim.AuthStrategyOverridesForCRUD[2].IsInheritedFromParent" data-default-strategy='@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[2].DisplayName'>@Model.ResourceClaim.AuthStrategyOverridesForCRUD[2].DisplayName</span>
-                                    if (Model.ResourceClaim.AuthStrategyOverridesForCRUD[2].IsInheritedFromParent)
+                                    <span data-is-inherited="@authStrategyOverridesForUpdate.IsInheritedFromParent" data-default-strategy='@defaultAuthStrategyForUpdate.DisplayName'>@authStrategyOverridesForUpdate.DisplayName</span>
+                                    if (authStrategyOverridesForUpdate.IsInheritedFromParent)
                                     {
                                         <span class="overridden-strategy inherited-override">(Overridden)</span>
                                     }
@@ -131,10 +144,10 @@ See the LICENSE and NOTICES files in the project root for more information.
                                         <span class="overridden-strategy">(Overridden)</span>
                                     }
                                 }
-                                else if (Model.ResourceClaim.DefaultAuthStrategiesForCRUD[2] != null)
+                                else if (defaultAuthStrategyForUpdate != null)
                                 {
-                                    <span data-is-inherited="@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[2].IsInheritedFromParent" data-default-strategy='@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[2].DisplayName'>@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[2].DisplayName</span>
-                                    if (Model.ResourceClaim.DefaultAuthStrategiesForCRUD[2].IsInheritedFromParent)
+                                    <span data-is-inherited="@defaultAuthStrategyForUpdate.IsInheritedFromParent" data-default-strategy='@defaultAuthStrategyForUpdate.DisplayName'>@defaultAuthStrategyForUpdate.DisplayName</span>
+                                    if (defaultAuthStrategyForUpdate.IsInheritedFromParent)
                                     {
                                         <span class="default-strategy inherited-strategy">(Default)</span>
                                     }
@@ -145,10 +158,10 @@ See the LICENSE and NOTICES files in the project root for more information.
                                 }
                             </td>
                             <td class="delete-action-cell" data-existing-action='@Model.ResourceClaim.Delete'>
-                                @if (Model.ResourceClaim.AuthStrategyOverridesForCRUD[3] != null)
+                                @if (authStrategyOverridesForDelete != null)
                                 {
-                                    <span data-is-inherited="@Model.ResourceClaim.AuthStrategyOverridesForCRUD[3].IsInheritedFromParent" data-default-strategy='@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[3].DisplayName'>@Model.ResourceClaim.AuthStrategyOverridesForCRUD[3].DisplayName</span>
-                                    if (Model.ResourceClaim.AuthStrategyOverridesForCRUD[3].IsInheritedFromParent)
+                                    <span data-is-inherited="@authStrategyOverridesForDelete.IsInheritedFromParent" data-default-strategy='@defaultAuthStrategyForDelete.DisplayName'>@authStrategyOverridesForDelete.DisplayName</span>
+                                    if (authStrategyOverridesForDelete.IsInheritedFromParent)
                                     {
                                         <span class="overridden-strategy inherited-override">(Overridden)</span>
                                     }
@@ -157,10 +170,10 @@ See the LICENSE and NOTICES files in the project root for more information.
                                         <span class="overridden-strategy">(Overridden)</span>
                                     }
                                 }
-                                else if (Model.ResourceClaim.DefaultAuthStrategiesForCRUD[3] != null)
+                                else if (defaultAuthStrategyForDelete != null)
                                 {
-                                    <span data-is-inherited="@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[3].IsInheritedFromParent" data-default-strategy='@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[3].DisplayName'>@Model.ResourceClaim.DefaultAuthStrategiesForCRUD[3].DisplayName</span>
-                                    if (Model.ResourceClaim.DefaultAuthStrategiesForCRUD[3].IsInheritedFromParent)
+                                    <span data-is-inherited="@defaultAuthStrategyForDelete.IsInheritedFromParent" data-default-strategy='@defaultAuthStrategyForDelete.DisplayName'>@defaultAuthStrategyForDelete.DisplayName</span>
+                                    if (defaultAuthStrategyForDelete.IsInheritedFromParent)
                                     {
                                         <span class="default-strategy inherited-strategy">(Default)</span>
                                     }


### PR DESCRIPTION
@pmcvtm 
Please help review and merge changes.
The code changes are similar to AA-1506. Modified test methods on creating/ setting up the Claim set resource claims, since the existing (old) ResourceClaims table accepts duplicates. 
Thanks,