### PR TITLE
[AA-1542] Updating artifact retention dates

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -66,12 +66,14 @@ jobs:
       with:
         name: playwright-results
         path: main/Application/EdFi.Ods.AdminApp.E2E.Tests/reports/playwright-results.xml
+        retention-days: 10
     - name: Upload execution traces
       if: failure()
       uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # v3.0.0
       with:
         name: playwright-execution-traces
         path: main/Application/EdFi.Ods.AdminApp.E2E.Tests/traces
+        retention-days: 10
     - name: Clean ODS
       if: always()
       run: ./shared-instance-env-clean.ps1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,7 @@ jobs:
         name: NuGetPackages
         path: ./*.nupkg
         if-no-files-found: error
+        retention-days: 30
 
   publish-artifacts:
     needs: pack

--- a/Application/EdFi.Ods.AdminApp.E2E.Tests/features/firstTimeSetup.feature
+++ b/Application/EdFi.Ods.AdminApp.E2E.Tests/features/firstTimeSetup.feature
@@ -12,7 +12,7 @@ Feature: First Time Setup
 
     #AA-1429
     @FTS
-    Scenario: First Time Setup Successful
+    Scenario: Setup Successful
         Given it's on the "First Time Setup" page
         When clicking Continue
         Then first time setup is successful


### PR DESCRIPTION
Updating retention days for artifacts.

E2E Artifacts:
Artifacts from test results and test error logs are saved for 10 days.
Artifact for NuGet packages are saved for 30 days.