### PR TITLE
[AA-1535] Migrate Admin App Web, Database and Installer builds from TeamCity

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -41,5 +41,5 @@ jobs:
           View        = "${{ github.event.inputs.view-type }}"
         }
         $arguments.Password = (ConvertTo-SecureString -String "${{ secrets.ARTIFACTS_API_KEY }}" -AsPlainText -Force)
-        $arguments.Packages = @('EdFi.Suite3.ODS.AdminApp.Database', 'EdFi.Suite3.ODS.AdminApp.Web', 'EdFi.Suite3.ODS.Admin.Api')
+        $arguments.Packages = @('EdFi.Suite3.ODS.AdminApp.Database', 'EdFi.Suite3.ODS.AdminApp.Web', 'EdFi.Suite3.ODS.Admin.Api', 'EdFi.Suite3.Installer.AdminApp')
         eng\promote-packages.ps1 @arguments

--- a/.github/workflows/publish-installer.yml
+++ b/.github/workflows/publish-installer.yml
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+name: Pack and Publish Installer
+
+on:
+  workflow_dispatch:
+
+env:
+  ADMIN_APP_VERSION: '2.4'
+  ARTIFACTS_API_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
+  ARTIFACTS_FEED_URL: ${{ secrets.AZURE_ARTIFACTS_FEED_URL }}
+  VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: '{"endpointCredentials": [{"endpoint": "${{ secrets.AZURE_ARTIFACTS_FEED_URL }}","password": "${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}"}]}'
+
+jobs:
+  pack:
+
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@9211491ffb35dd6a6657ca4f45d43dfe6e97c829 # v2.0.0
+      with:
+        dotnet-version: 6.0.x
+    - name: Pack Installer
+      run: |
+        $parameters = @{
+          SemanticVersion = "${{ env.ADMIN_APP_VERSION }}"
+          BuildCounter = "${{ github.run_number }}"
+          NuGetFeed = "${{ env.ARTIFACTS_FEED_URL }}"
+          NuGetApiKey = "${{ env.ARTIFACTS_API_KEY }}"
+        }
+        ./EdFi.Suite3.Installer.AdminApp/build-package.ps1 @parameters
+    - name: Upload Package
+      if: success()
+      uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # v3.0.0
+      with:
+        name: NuGetPackages
+        path: ./EdFi.Suite3.Installer.AdminApp/EdFi.Suite3.Installer.AdminApp.*.nupkg
+        if-no-files-found: error
+        retention-days: 30
+
+  publish-artifacts:
+    needs: pack
+
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+      - name: Get Artifact
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 #v3.0.0
+        with:
+          name: NuGetPackages
+      - name: Install-credential-handler
+        run: iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"
+      - name: Upload Admin App Installer
+        run: |
+          $artifact = (Get-ChildItem -Path $_ -Name -Include EdFi.Suite3.Installer.AdminApp.*.nupkg)
+          $arguments = @{
+            NuGetApiKey = "${{ env.ARTIFACTS_API_KEY }}"
+          }
+          $arguments.PackageFile = $artifact
+          ./build.ps1 Push @arguments

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,10 @@ jobs:
       run: .\build.ps1 -Command PopulateGoogleAnalyticsAppSettings -GoogleAnalyticsMeasurementId ${{env.GA_MEASUREMENT_ID}}
     - name: Pack
       if: success()
-      run: ./build.ps1 -Command PackageApi -Configuration Release -Version ${{ env.ADMIN_API_VERSION }} -BuildCounter ${{ github.run_number }}
+      run: |
+        ./build.ps1 -Command Package -Configuration Release -Version ${{ env.ADMIN_APP_VERSION }} -BuildCounter ${{ github.run_number }}
+        ./build.ps1 -Command PackageDatabase -Configuration Release -Version ${{ env.ADMIN_APP_VERSION }} -BuildCounter ${{ github.run_number }}
+        ./build.ps1 -Command PackageApi -Configuration Release -Version ${{ env.ADMIN_API_VERSION }} -BuildCounter ${{ github.run_number }}
     - name: Upload Package
       if: success()
       uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # v3.0.0
@@ -68,7 +71,23 @@ jobs:
         run: iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"
       - name: Upload Admin API
         run: |
-          $artifact = (Get-ChildItem -Path $_ -Name -Include *.Admin.Api.*.nupkg)
+          $artifact = (Get-ChildItem -Path $_ -Name -Include EdFi.Suite3.ODS.Admin.Api.*.nupkg)
+          $arguments = @{
+            NuGetApiKey = "${{ env.ARTIFACTS_API_KEY }}"
+          }
+          $arguments.PackageFile = $artifact
+          ./build.ps1 Push @arguments
+      - name: Upload Admin App
+        run: |
+          $artifact = (Get-ChildItem -Path $_ -Name -Include EdFi.Suite3.ODS.AdminApp.Web.*.nupkg)
+          $arguments = @{
+            NuGetApiKey = "${{ env.ARTIFACTS_API_KEY }}"
+          }
+          $arguments.PackageFile = $artifact
+          ./build.ps1 Push @arguments
+      - name: Upload Admin Database
+        run: |
+          $artifact = (Get-ChildItem -Path $_ -Name -Include EdFi.Suite3.ODS.AdminApp.Database.*.nupkg)
           $arguments = @{
             NuGetApiKey = "${{ env.ARTIFACTS_API_KEY }}"
           }

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EdFi.Suite3.Installer.AdminApp/EdFi.Suite3.Installer.AdminApp.nuspec
+++ b/EdFi.Suite3.Installer.AdminApp/EdFi.Suite3.Installer.AdminApp.nuspec
@@ -17,7 +17,7 @@
     <file src="uninstall.ps1" />
     <file src="global.json" />
     <file src="Install-EdFiOdsAdminApp.psm1" />
-    <file src="AppCommon/**" />
+    <file src="AppCommon/**" exclude="AppCommon/Utility/*.*" />
     <file src="../LICENSE" />
     <file src="../NOTICES.md" />
     <file src="../eng/key-management.psm1" />

--- a/EdFi.Suite3.Installer.AdminApp/build-package.ps1
+++ b/EdFi.Suite3.Installer.AdminApp/build-package.ps1
@@ -12,9 +12,6 @@ param (
     [string]
     [Parameter(Mandatory=$true)]
     $BuildCounter,
-    
-    [switch]
-    $Publish,
 
     [string]
     $NuGetFeed,
@@ -24,22 +21,25 @@ param (
 )
 
 $ErrorActionPreference = "Stop"
+$OutputDirectory = Resolve-Path $PSScriptRoot
+$PackageDefinitionFile = Resolve-Path "$PSScriptRoot/EdFi.Suite3.Installer.AdminApp.nuspec"
+$Downloads = "$PSScriptRoot/downloads"
+$Version = "$SemanticVersion.$BuildCounter"
 
 Invoke-Expression "$PSScriptRoot/prep-installer-package.ps1 $PSScriptRoot"
 
-$verbose = $PSCmdlet.MyInvocation.BoundParameters["Verbose"]
+function Build-Package {
 
-$appCommonUtilityDirectory = "$PSScriptRoot/AppCommon/Utility"
+    $parameters = @(
+        "pack", $PackageDefinitionFile,
+        "-Version", $Version,
+        "-OutputDirectory", $OutputDirectory,
+        "-Verbosity", "detailed"
+    )
 
-Import-Module "$appCommonUtilityDirectory/create-package.psm1" -Force
-
-$parameters = @{
-    PackageDefinitionFile = Resolve-Path "$PSScriptRoot/EdFi.Suite3.Installer.AdminApp.nuspec"
-    Version = "$SemanticVersion.$BuildCounter"
-    OutputDirectory = Resolve-Path $PSScriptRoot
-    Publish = $Publish
-    Source = $NuGetFeed
-    ApiKey = $NuGetApiKey
-    ToolsPath = "C:/temp/tools"
+    Write-Host @parameters -ForegroundColor Magenta
+    nuget @parameters
 }
-Invoke-CreatePackage @parameters -Verbose:$verbose
+
+Write-Host "Building package"
+Build-Package

--- a/EdFi.Suite3.Installer.AdminApp/prep-installer-package.ps1
+++ b/EdFi.Suite3.Installer.AdminApp/prep-installer-package.ps1
@@ -18,18 +18,25 @@ param (
 $ErrorActionPreference = "Stop"
 
 Push-Location $PackageDirectory
-
-Import-Module -Force "$PSScriptRoot/nuget-helper.psm1"
-
-# Download App Common
-$parameters = @{
-    PackageName = "EdFi.Installer.AppCommon"
-    PackageVersion = $AppCommonVersion
-    ToolsPath = "C:/temp/tools"
-    PackageSource = $PackageSource
+if(-not(Test-Path -Path $Downloads )){
+        mkdir $Downloads
 }
-$appCommonDirectory = Get-NugetPackage @parameters
 
+$PackageName = "EdFi.Installer.AppCommon"
+$PackageVersion = "2.0.0"
+
+$parameters = @(
+    "install", $PackageName,
+    "-source", $NuGetFeed,
+    "-outputDirectory", $Downloads
+    "-version", $PackageVersion
+)
+
+Write-Host "Downloading AppCommon"
+Write-Host -ForegroundColor Magenta "Executing nuget: $parameters"
+nuget $parameters
+
+$appCommonDirectory = Resolve-Path $Downloads/$PackageName.$PackageVersion* | Select-Object -Last 1
 
 # Move AppCommon's modules to a local AppCommon directory
 @(
@@ -42,7 +49,7 @@ $appCommonDirectory = Get-NugetPackage @parameters
         Recurse = $true
         Force = $true
         Path = "$appCommonDirectory/$_"
-        Destination = "$PackageDirectory/AppCommon/$_"
+        Destination = "$PSScriptRoot/AppCommon/$_"
     }
     Copy-Item @parameters
 }

--- a/build.ps1
+++ b/build.ps1
@@ -306,7 +306,7 @@ function GetAdminApiPackageVersion {
 }
 
 function BuildDatabasePackage {
-    $project = "EdFi.Ods.Admin.Web"
+    $project = "EdFi.Ods.AdminApp.Web"
     $mainPath = "$solutionRoot/$project"
     $projectPath = "$mainPath/$project.csproj"
     $nugetSpecPath = "$mainPath/publish/EdFi.Ods.AdminApp.Database.nuspec"
@@ -416,7 +416,7 @@ function Invoke-BuildApiPackage {
 }
 
 function Invoke-BuildDatabasePackage {
-    Invoke-Step { BuildDatabaseScriptPackage }
+    Invoke-Step { BuildDatabasePackage }
 }
 
 function Invoke-PushPackage {


### PR DESCRIPTION
- Create new action to build Admin App installer.
- Add build steps for Admin App Web and Database.
- Including Installer into packages to be promoted to release
- Updating ps script to not depend on globally installed NuGet (matching configuration for Data Import)