### PR TITLE
[AA-1530] Adding documentation for E2E Tests

### DIFF
--- a/.github/workflows/e2e-reports.yml
+++ b/.github/workflows/e2e-reports.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Extract Artifact
       run: Expand-Archive "${{ env.RESULTS_FILE }}.zip"
     - name: Send report to Zephyr
-      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: github.event.workflow_run.head_branch == 'main'
       run: |
         $parameters = @{
             cycleName = '${{ env.CYCLE_NAME }}'

--- a/Application/EdFi.Ods.AdminApp.E2E.Tests/.env.example
+++ b/Application/EdFi.Ods.AdminApp.E2E.Tests/.env.example
@@ -3,3 +3,4 @@ email="user@ed-fi-test.org"
 password="Pass.1234"
 HEADLESS = true
 TRACE = true
+VIDEO = false

--- a/Application/EdFi.Ods.AdminApp.E2E.Tests/ARCHITECTURE.md
+++ b/Application/EdFi.Ods.AdminApp.E2E.Tests/ARCHITECTURE.md
@@ -45,20 +45,25 @@ This is an example of the architecture for two of the features
 
 ```mermaid 
 classDiagram
-  direction RL
+  
   adminAppPage <|-- vendorsPage
   adminAppPage <|-- applicationsPage
-  
-  applicationsPage <-- applications
-  vendorsPage <-- vendors
-  
-  sharedSteps <-- applicationsFeature
-  vendors <-- vendorsFeature
-  sharedSteps <-- vendorsFeature
-  applications <-- applicationsFeature
 
-  vendorsPage <-- sharedSteps
-  applicationsPage <-- sharedSteps
+  vendorsPage --* modelResolver
+  applicationsPage --* modelResolver
+  
+  modelResolver <-- applications: calls
+  modelResolver <-- vendors: calls
+  modelResolver <-- sharedSteps: calls
+  
+  sharedSteps -- applicationsFeature
+  vendors -- vendorsFeature
+  sharedSteps -- vendorsFeature
+  applications -- applicationsFeature
+
+
+  modelResolver: -adminAppPage[] aaPages
+  modelResolver: getPage()
   
   adminAppPage: selectors
   applicationsPage: selectors

--- a/Application/EdFi.Ods.AdminApp.E2E.Tests/ARCHITECTURE.md
+++ b/Application/EdFi.Ods.AdminApp.E2E.Tests/ARCHITECTURE.md
@@ -38,3 +38,34 @@ All assertions should be executed in the implementation of the Gherkin functions
 ## Locators
 
 To interact with the browser, we recommend to use Playwright's [Locator](https://playwright.dev/docs/locators) functionality 
+
+# Class Description
+
+This is an example of the architecture for two of the features
+
+```mermaid 
+classDiagram
+  direction RL
+  adminAppPage <|-- vendorsPage
+  adminAppPage <|-- applicationsPage
+  
+  applicationsPage <-- applications
+  vendorsPage <-- vendors
+  
+  sharedSteps <-- applicationsFeature
+  vendors <-- vendorsFeature
+  sharedSteps <-- vendorsFeature
+  applications <-- applicationsFeature
+  
+  adminAppPage: selectors
+  applicationsPage: selectors
+  vendorsPage: selectors
+  
+  adminAppPage: actions()
+  applicationsPage: actions()
+  vendorsPage: actions()
+  
+  vendors: stepDefinitions()
+  sharedSteps: stepDefinitions()
+  applications: stepDefinitions()
+```

--- a/Application/EdFi.Ods.AdminApp.E2E.Tests/ARCHITECTURE.md
+++ b/Application/EdFi.Ods.AdminApp.E2E.Tests/ARCHITECTURE.md
@@ -13,7 +13,7 @@ The modelResolver class has an array of [adminAppPages](#admin-app-page) and a g
 https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-AdminApp/blob/b51b07e8c48686820f3022bcdc7ae741af69406e/Application/EdFi.Ods.AdminApp.E2E.Tests/features/models/modelResolver.ts#L29-L36
 
 > **Warning**
-> This does not prevent from instantiating a class and using it in a test. This can lead to unexpected behavior.
+> This does not prevent from instantiating a class and using it in a test. Not using the modelResolver can lead to unexpected behavior.
 
 
 ## Admin App Page
@@ -56,6 +56,9 @@ classDiagram
   vendors <-- vendorsFeature
   sharedSteps <-- vendorsFeature
   applications <-- applicationsFeature
+
+  vendorsPage <-- sharedSteps
+  applicationsPage <-- sharedSteps
   
   adminAppPage: selectors
   applicationsPage: selectors

--- a/Application/EdFi.Ods.AdminApp.E2E.Tests/ARCHITECTURE.md
+++ b/Application/EdFi.Ods.AdminApp.E2E.Tests/ARCHITECTURE.md
@@ -1,0 +1,40 @@
+# Admin App E2E Architecture Description
+
+This project uses a BDD structure, using [Gherkin](https://cucumber.io/docs/gherkin/reference/) syntax. The `.feature` classes reference a Typescript class with the definition of the step.
+
+Each definition class references a page using [Page Object Model](#page-object-model). These page objects do not need to be instantiated directly, instead, it should be included into the [modelResolver.ts](./features/models/modelResolver.ts) class using the [Instantiation Pattern](#instantiation-pattern). Then, the modelResolver can be imported into the class an used to call methods of the specific page.
+
+## Instantiation Pattern
+
+To avoid having multiple instances of the same page, there's a class called [modelResolver.ts](./features/models/modelResolver.ts). This class follows the [Singleton pattern](http://wiki.c2.com/?SingletonPattern) and it's instantiated exclusively in the [Before hook](https://cucumber.io/docs/cucumber/api/#hook) to have only one instance per test execution.
+
+The modelResolver class has an array of [adminAppPages](#admin-app-page) and a getter per Page. In the get method, it will try to find the expected Page in the array, if it is not found, it will instantiate the class and push it in the array, to guarantee that there are not multiple instantiations per page.
+
+https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-AdminApp/blob/b51b07e8c48686820f3022bcdc7ae741af69406e/Application/EdFi.Ods.AdminApp.E2E.Tests/features/models/modelResolver.ts#L29-L36
+
+> **Warning**
+> This does not prevent from instantiating a class and using it in a test. This can lead to unexpected behavior.
+
+
+## Admin App Page
+
+The [adminAppPage.ts](./features/models/adminAppPage.ts) is the parent class of the other page objects. Every page object should inherit from adminAppPage. This has URL validations, an abstract method to define the page path and common functionalities for all pages to make use of and avoid code duplication.
+
+## Page Object Model
+
+[Page Object Model](https://martinfowler.com/bliki/PageObject.html) is a pattern where the classes are divided into Pages. Each page consist of two sections:
+
+1. Selectors: Identification for buttons, titles and sections. This uses CSS classes, text or XPATH when necessary. Following: [Playwright Selectors](https://playwright.dev/docs/selectors#text-selector)
+
+2. Page Actions: These methods execute actions and can return results, but it does not perform assertions.
+
+## Assertions
+
+> **Warning**
+> Page Objects should not perform assertions
+
+All assertions should be executed in the implementation of the Gherkin functions. These assertions are done with [nodejs assert](https://nodejs.org/api/assert.html). All assertions should have a custom message to print if the assertion fails, to avoid depending on the built in message.
+
+## Locators
+
+To interact with the browser, we recommend to use Playwright's [Locator](https://playwright.dev/docs/locators) functionality 

--- a/Application/EdFi.Ods.AdminApp.E2E.Tests/README.md
+++ b/Application/EdFi.Ods.AdminApp.E2E.Tests/README.md
@@ -1,5 +1,7 @@
 # Admin App End To End Tests
 
+![e2e tests results](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-AdminApp/actions/workflows/e2e.yml/badge.svg)
+
 The E2E tests are UI Automation tests written in [CucumberJS](https://cucumber.io/) to be executed using [Playwright](https://playwright.dev/) with Typescript
 
 # Execution

--- a/Application/EdFi.Ods.AdminApp.E2E.Tests/README.md
+++ b/Application/EdFi.Ods.AdminApp.E2E.Tests/README.md
@@ -1,8 +1,41 @@
 # Admin App End To End Tests
 
-## Install
+The E2E tests are UI Automation tests written in [CucumberJS]() to be executed using [Playwright]() with Typescript
 
-To get started run `npm install`
+# Execution
+
+## Getting Started
+
+- Install [Node](https://nodejs.org/en/download/).
+- Have a running instance of ODS/API in Shared Instance Mode and Admin App. 
+    - This can be accomplished using [ODS Docker](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Docker) 
+
+## Setup
+
+### Install 
+
+Run `npm install` to get all dependencies
+
+### Environment
+
+Setup a .env file. This should be based on the .env.example file, with details such as:
+    
+- Admin App URL 
+- Username
+- Password
+
+Additionally, there are flags  such as:
+- Headless: Run in Headed or Headless mode (default is Headless)
+- Trace: Save the execution trace of the tests, read more about it here: [Trace Viewer](https://playwright.dev/docs/trace-viewer)
+- Video: Record a video of the execution.
+
+> **Note**
+> The video recordings are ignored from the source code, but those are never automatically deleted from your folder, therefore, be in the lookup for any large amount of videos saved.
+> Additionally, the video feature of playwright does not have an option to set file name, so, all videos will be saved in the folder and you'll need to find them by creation date.
+> When possible, prefer traces over videos since the traces are organized by test and have more information than the video.
+
+
+
 
 ## Run
 

--- a/Application/EdFi.Ods.AdminApp.E2E.Tests/README.md
+++ b/Application/EdFi.Ods.AdminApp.E2E.Tests/README.md
@@ -1,6 +1,6 @@
 # Admin App End To End Tests
 
-The E2E tests are UI Automation tests written in [CucumberJS]() to be executed using [Playwright]() with Typescript
+The E2E tests are UI Automation tests written in [CucumberJS](https://cucumber.io/) to be executed using [Playwright](https://playwright.dev/) with Typescript
 
 # Execution
 
@@ -14,7 +14,11 @@ The E2E tests are UI Automation tests written in [CucumberJS]() to be executed u
 
 ### Install 
 
+Navigate to /Application/EdFi.Ods.AdminApp.E2E.Tests/
+
 Run `npm install` to get all dependencies
+
+After the installation is successful, Playwright must be ready to execute the tests.
 
 ### Environment
 
@@ -35,15 +39,22 @@ Additionally, there are flags  such as:
 > When possible, prefer traces over videos since the traces are organized by test and have more information than the video.
 
 
-
-
 ## Run
 
-Before running, you need to specify the URL, username and password in an .env file. File .env.example is a guide about how to set the variables.
+There are multiple commands to run the tests, that can be found in the script section of [package.json](package.json)
 
-To execute the tests, run `npm test`
+Some of the commands are:
 
-## Debug
+`npm test`: Run all tests, except for the ones that have specific preconditions required, such as registering and first time setup.
+
+`npm run sanity-test`: Run the sanity tests (labeled with @Sanity in the .feature files)
+
+`npm run test-{x}`: Run only the test for a specified feature. For example: `npm run test-vendors` executes the vendor tests only.
+
+`npm run html-report`: Run the tests and generates a report in HTML.
+
+
+# Debug
 
 The preferred method for debug is the integrated playwright inspector.
 
@@ -51,3 +62,15 @@ The preferred method for debug is the integrated playwright inspector.
 $env:PWDEBUG=1
 npm run test
 ```
+
+## Trace Viewer
+
+To see the generated traces, locate the zip files located in /Application/EdFi.Ods.AdminApp.E2E.Tests/traces/. These tests are sorted by Feature and specific test. After the file **trace.zip** corresponding to the desired test is found, you can open it by running:
+
+```
+  npm run trace-viewer -- {Path}
+```
+
+Additionally, you can browse to https://trace.playwright.dev/ and select the trace.zip file to view it in the browser.
+
+More info on debug: https://playwright.dev/docs/debug

--- a/Application/EdFi.Ods.AdminApp.E2E.Tests/README.md
+++ b/Application/EdFi.Ods.AdminApp.E2E.Tests/README.md
@@ -91,4 +91,5 @@ Scenario: WIP Demo Scenario
 
 # More Information
 
-[Architecture](./ARCHITECTURE.md)
+- [Architecture](./ARCHITECTURE.md)
+- [Send results to Zephyr](./reports/reports.md)

--- a/Application/EdFi.Ods.AdminApp.E2E.Tests/README.md
+++ b/Application/EdFi.Ods.AdminApp.E2E.Tests/README.md
@@ -65,12 +65,16 @@ npm run test
 
 ## Trace Viewer
 
-To see the generated traces, locate the zip files located in /Application/EdFi.Ods.AdminApp.E2E.Tests/traces/. These tests are sorted by Feature and specific test. After the file **trace.zip** corresponding to the desired test is found, you can open it by running:
+To see the generated traces, locate the zip files located in /Application/EdFi.Ods.AdminApp.E2E.Tests/traces/. These tests are sorted by Feature and specific test. After finding the **trace.zip** file corresponding to the desired test, you can open it by running:
 
 ```
-  npm run trace-viewer -- {Path}
+  npm run trace-viewer -- {trace.zip path}
 ```
 
 Additionally, you can browse to https://trace.playwright.dev/ and select the trace.zip file to view it in the browser.
 
 More info on debug: https://playwright.dev/docs/debug
+
+# More Information
+
+[Architecture](./ARCHITECTURE.md)

--- a/Application/EdFi.Ods.AdminApp.E2E.Tests/README.md
+++ b/Application/EdFi.Ods.AdminApp.E2E.Tests/README.md
@@ -8,13 +8,13 @@ The E2E tests are UI Automation tests written in [CucumberJS](https://cucumber.i
 
 ## Getting Started
 
-- Install [Node](https://nodejs.org/en/download/).
-- Have a running instance of ODS/API in Shared Instance Mode and Admin App. 
-    - This can be accomplished using [ODS Docker](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Docker) 
+- Install [Node](https://nodejs.org/en/download/) version 18.
+- Have a running instance of ODS/API in Shared Instance Mode and Admin App.
+    - This can be accomplished using [ODS Docker](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Docker)
 
 ## Setup
 
-### Install 
+### Install
 
 Navigate to /Application/EdFi.Ods.AdminApp.E2E.Tests/
 
@@ -25,8 +25,8 @@ After the installation is successful, Playwright must be ready to execute the te
 ### Environment
 
 Setup a .env file. This should be based on the .env.example file, with details such as:
-    
-- Admin App URL 
+
+- Admin App URL
 - Username
 - Password
 
@@ -54,7 +54,6 @@ Some of the commands are:
 `npm run test-{x}`: Run only the test for a specified feature. For example: `npm run test-vendors` executes the vendor tests only.
 
 `npm run html-report`: Run the tests and generates a report in HTML.
-
 
 # Debug
 

--- a/Application/EdFi.Ods.AdminApp.E2E.Tests/README.md
+++ b/Application/EdFi.Ods.AdminApp.E2E.Tests/README.md
@@ -75,6 +75,20 @@ Additionally, you can browse to https://trace.playwright.dev/ and select the tra
 
 More info on debug: https://playwright.dev/docs/debug
 
+# How to Add a new Test Case
+
+1. Add the test definition to the .feature file.
+2. Create the step definition in the /support folder.
+3. Create a new Page Object in the /models folder, that inherits from adminAppPage.
+4. Register the Page Object into the modelResolver.
+5. Add calls to the Page Object methods from the step definition class.
+6. To execute the added test only, add tag @WIP before the scenario definition, and run by executing `npm run test-wip`.
+
+```
+@WIP
+Scenario: WIP Demo Scenario
+```
+
 # More Information
 
 [Architecture](./ARCHITECTURE.md)

--- a/Application/EdFi.Ods.AdminApp.E2E.Tests/features/models/modelResolver.ts
+++ b/Application/EdFi.Ods.AdminApp.E2E.Tests/features/models/modelResolver.ts
@@ -15,7 +15,7 @@ import { VendorsPage } from "./vendorsPage";
 import { ApplicationsPage } from "./applicationsPage";
 
 export class ModelResolver {
-    aaPages: Array<AdminAppPage> = [];
+    private aaPages: Array<AdminAppPage> = [];
 
     public get landingPage(): LandingPage {
         let model = this.getModel<LandingPage>(LandingPage.name);

--- a/Application/EdFi.Ods.AdminApp.E2E.Tests/reports/reports.md
+++ b/Application/EdFi.Ods.AdminApp.E2E.Tests/reports/reports.md
@@ -3,3 +3,34 @@ These reports are generated when running the command
 `npm run report`
 
 Additionally, you can generate reports in other formats as specified here: [Cucumber-JS Formatters](https://github.com/cucumber/cucumber-js/blob/main/docs/formatters.md)
+
+## Send results to Zephyr
+
+To send the results to Zephyr, execute the script [send-test-results.ps1](../../../eng/send-test-results.ps1) specifiying the required parameters
+
+Parameters:
+
+- cycleName: Get the id for the given test cycle, if the name is not found, it will create a new cycle with the given name. Not required if cycleId is specified.
+- cycleId: Test Cycle ID.
+- taskName: Name of the task to be included in Zephyr.
+- folderName: Name of the folder to group the tests.
+- PersonalAccessToken: Token to send the results to zephyr.
+- ProjectId
+- AdminAppVersion: This must be an existing fix version on the Admin App Jira project. If version does not exist, will use value -1 (Unscheduled)
+- ResultsFilePath: Location of results with format JUnit XML.
+
+More information: [How to get IDs](https://support.smartbear.com/zephyr-squad-server/docs/api/how-to/get-ids.html)
+
+Example:
+
+```powershell
+$parameters = @{
+  cycleName = 'Automation Cycle'
+  taskName = "Playwright Automation Task"
+  folderName = "Playwright Automation Run"
+}
+
+.\send-test-results.ps1 -PersonalAccessToken PAT -ProjectId 1 -AdminAppVersion "2.4" -ResultsFilePath "..\playwright-results.xml" -ConfigParams $parameters	
+```
+
+When running the E2E Tests from main, the GitHub Action executes this script automatically.


### PR DESCRIPTION
- Adding instructions to execute the tests.
- Adding diagrams to represent the structure of the tests.
- Adding instructions to send results to Zephyr
- Fixing branch verification when sending reports to Zephyr