### PR TITLE
[AA-1469] - Docker Deployment For AdminApi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,10 @@ _ReSharper.*
 *.orig
 *.original
 *.log
+*.env
+*.crt
+*.key
+*.pfx
 
 #Packages
 packages/

--- a/Application/EdFi.Ods.Admin.Api/Compose/pgsql/compose-build.yml
+++ b/Application/EdFi.Ods.Admin.Api/Compose/pgsql/compose-build.yml
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+version: "3.8"
+
+services:
+  adminapi:
+    build:
+      context: ../../
+      dockerfile: pgsql.Dockerfile
+    image: adminapi
+    ports:
+      - "8080:80"
+      - "8001:443"
+    environment:
+      ADMIN_POSTGRES_HOST: pb-admin
+      POSTGRES_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+      POSTGRES_USER: "${POSTGRES_USER}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+      DATABASEENGINE: "PostgreSql"
+      API_MODE: ${API_MODE}
+      AUTHORITY: ${AUTHORITY}
+      ISSUER_URL: ${ISSUER_URL}
+      SIGNING_KEY: ${SIGNING_KEY}
+      ADMINAPP_VIRTUAL_NAME: ${ADMINAPP_VIRTUAL_NAME} 
+      API_INTERNAL_URL: ${API_INTERNAL_URL}
+    depends_on:
+      - pb-admin
+    restart: always
+    hostname: adminapi 
+    container_name: adminapi
+
+  db-admin:
+    image: edfialliance/ods-api-db-admin:latest
+    environment:
+      POSTGRES_USER: "${POSTGRES_USER}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+      API_MODE: ${API_MODE}
+    ports:
+      - "5880:5432"
+    volumes:
+      - vol-db-admin:/var/lib/postgresql/data
+    restart: always
+    container_name: ed-fi-db-admin
+
+  pb-admin:
+    image: pgbouncer/pgbouncer@sha256:aa8a38b7b33e5fe70c679053f97a8e55c74d52b00c195f0880845e52b50ce516 #pgbouncer:1.15.0
+    environment:
+      DATABASES: "* = host = db-admin port=5432 user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}"
+      PGBOUNCER_LISTEN_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+    ports:
+      - "5401:${PGBOUNCER_LISTEN_PORT:-6432}"
+    restart: always
+    container_name: ed-fi-pb-admin
+    depends_on:
+      - db-admin
+
+volumes:
+  vol-db-admin:
+    driver: local
+    name: vol-db-admin

--- a/Application/EdFi.Ods.Admin.Api/Compose/pgsql/env.example
+++ b/Application/EdFi.Ods.Admin.Api/Compose/pgsql/env.example
@@ -1,0 +1,17 @@
+API_MODE=<API Mode Eg. SharedInstance, YearSpecific, DistrictSpecific>
+ADMINAPP_VIRTUAL_NAME=<virtual name for the admin app endpoint>
+ODS_VIRTUAL_NAME=<virtual name for the ods endpoint>
+
+# For Authentication
+AUTHORITY=<Authentication Authority Appsetting Eg. https://localhost:443>
+ISSUER_URL=<Authentication IssuerUrl Appsetting Eg. https://localhost:8001>
+SIGNING_KEY=<Authentication Signing Key (Symmetric Security Key) for OpenIddict>
+
+# For Postgres only
+POSTGRES_USER=<default postgres database user>
+POSTGRES_PASSWORD=<password for default postgres user>
+PGBOUNCER_LISTEN_PORT=<port for pg bouncer to listen to>
+
+# The following needs to be set to specify the ODS API endpoint for admin app to internally connect.
+# If user chooses direct connection between ODS API and admin app within docker network, then set the api internal url as follows
+API_INTERNAL_URL = http://${ODS_VIRTUAL_NAME}

--- a/Application/EdFi.Ods.Admin.Api/Docker/mssql/appsettings.template.json
+++ b/Application/EdFi.Ods.Admin.Api/Docker/mssql/appsettings.template.json
@@ -1,0 +1,39 @@
+{
+  "AppSettings": {
+      "DatabaseEngine": "SqlServer",
+      "DefaultOdsInstance": "EdFi ODS",
+      "ProductionApiUrl": "$API_INTERNAL_URL",
+      "ApiExternalUrl": "$API_EXTERNAL_URL",
+      "SecurityMetadataCacheTimeoutMinutes": "10",
+      "ApiStartupType": "$API_MODE",
+      "LocalEducationAgencyTypeValue": "Local Education Agency",
+      "PostSecondaryInstitutionTypeValue": "Post Secondary Institution",
+      "SchoolTypeValue": "School",
+      "PathBase": "$ADMINAPP_VIRTUAL_NAME",
+      "GoogleAnalyticsMeasurementId": "",
+      "ProductRegistrationUrl": "https://edfi-tools-analytics.azurewebsites.net/data/v1/"
+  },
+  "Authentication": {
+      "Authority": "$AUTHORITY",
+      "IssuerUrl": "$ISSUER_URL",
+      "SigningKey": "$SIGNING_KEY",
+      "AllowRegistration": true
+  },
+  "EnableSwagger": true,
+  "ConnectionStrings": {
+    "Admin": "Data Source=$SQLSERVER_ADMIN_DATASOURCE;Initial Catalog=EdFi_Admin;User Id=$SQLSERVER_USER;Password=$SQLSERVER_PASSWORD; Integrated Security=False;",
+    "Security": "Data Source=$SQLSERVER_ADMIN_DATASOURCE;Initial Catalog=EdFi_Security;User Id=$SQLSERVER_USER;Password=$SQLSERVER_PASSWORD; Integrated Security=False;",
+    "ProductionOds": "Data Source=$SQLSERVER_ODS_DATASOURCE;Initial Catalog=EdFi_{0}; User Id=$SQLSERVER_USER;Password=$SQLSERVER_PASSWORD; Integrated Security=False;"
+  },
+  "Log4NetCore": {
+      "Log4NetConfigFileName": "./log4net.config"
+  },
+  "Logging": {
+      "LogLevel": {
+          "Default": "Information",
+          "Microsoft": "Warning",
+          "Microsoft.Hosting.Lifetime": "Information"
+      }
+  },
+  "AllowedHosts": "*"
+}

--- a/Application/EdFi.Ods.Admin.Api/Docker/mssql/env.example
+++ b/Application/EdFi.Ods.Admin.Api/Docker/mssql/env.example
@@ -1,0 +1,19 @@
+API_MODE=<API Mode Eg. SharedInstance, YearSpecific, DistrictSpecific>
+
+ODS_VIRTUAL_NAME=<virtual name for the ods endpoint>
+ADMINAPP_VIRTUAL_NAME=<virtual name for the admin app endpoint>
+
+# For Authentication
+AUTHORITY=<Authentication Authority Appsetting Eg. https://localhost:443>
+ISSUER_URL=<Authentication IssuerUrl Appsetting Eg. https://localhost:8001>
+SIGNING_KEY=<Authentication Signing Key (Symmetric Security Key) for OpenIddict>
+
+# For SQL Server only
+SQLSERVER_ODS_DATASOURCE=<DNS or IP Address of the SQL Server Instance, i.e. sql.somedns.org or 10.1.5.9,1433
+SQLSERVER_ADMIN_DATASOURCE=<DNS or IP Address of the SQL Server Instance that contains the Admin/Security/Master databases, i.e. sql.somedns.org or 10.1.5.9,1433>
+SQLSERVER_USER=<SQL Username with access to SQL Server Ed-Fi databases, edfiadmin>
+SQLSERVER_PASSWORD=<SQL Password for the SQLSERVER_USER with access to SQL Server Ed-Fi databases, password123!>
+
+# The following needs to be set to specify the ODS API endpoint for admin app to internally connect.
+# If user chooses direct connection between ODS API and admin app within docker network, then set the api internal url as follows
+API_INTERNAL_URL = http://${ODS_VIRTUAL_NAME}

--- a/Application/EdFi.Ods.Admin.Api/Docker/mssql/log4net.config
+++ b/Application/EdFi.Ods.Admin.Api/Docker/mssql/log4net.config
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<log4net>
+    <appender name="TraceAppender" type="log4net.Appender.TraceAppender">
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <appender name="FileAppender" type="log4net.Appender.RollingFileAppender">
+        <file value="Ed-Fi-ODS-AdminAPI-Log.txt" />
+        <appendToFile value="true" />
+        <rollingStyle value="Size" />
+        <maxSizeRollBackups value="10" />
+        <maximumFileSize value="15MB" />
+        <staticLogFileName value="true" />
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>  
+    <root>
+        <level value="DEBUG" />
+        <appender-ref ref="TraceAppender" />
+        <appender-ref ref="FileAppender" />
+    </root>  
+</log4net>

--- a/Application/EdFi.Ods.Admin.Api/Docker/mssql/run.sh
+++ b/Application/EdFi.Ods.Admin.Api/Docker/mssql/run.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+set -e
+set -x
+
+envsubst < /app/AdminApi/appsettings.template.json > /app/AdminApi/temp.json
+
+measurementId=`jq -r '.AppSettings.GoogleAnalyticsMeasurementId' /app/AdminApi/appsettings.json`
+
+tmp=$(mktemp)
+jq --arg variable "$measurementId" '.AppSettings.GoogleAnalyticsMeasurementId = $variable' /app/AdminApi/temp.json > "$tmp" && mv "$tmp" /app/AdminApi/temp.json
+
+mv /app/AdminApi/temp.json /app/AdminApi/appsettings.json
+
+dotnet EdFi.Ods.Admin.Api.dll

--- a/Application/EdFi.Ods.Admin.Api/Docker/pgsql/appsettings.template.json
+++ b/Application/EdFi.Ods.Admin.Api/Docker/pgsql/appsettings.template.json
@@ -1,0 +1,39 @@
+{
+  "AppSettings": {
+      "DatabaseEngine": "PostgreSQL",
+      "DefaultOdsInstance": "EdFi ODS",
+      "ProductionApiUrl": "$API_INTERNAL_URL",
+      "ApiExternalUrl": "$API_EXTERNAL_URL",
+      "SecurityMetadataCacheTimeoutMinutes": "10",
+      "ApiStartupType": "$API_MODE",
+      "LocalEducationAgencyTypeValue": "Local Education Agency",
+      "PostSecondaryInstitutionTypeValue": "Post Secondary Institution",
+      "SchoolTypeValue": "School",
+      "PathBase": "$ADMINAPP_VIRTUAL_NAME",
+      "GoogleAnalyticsMeasurementId": "",
+      "ProductRegistrationUrl": "https://edfi-tools-analytics.azurewebsites.net/data/v1/"
+  },
+  "Authentication": {
+    "Authority": "$AUTHORITY",
+    "IssuerUrl": "$ISSUER_URL",
+    "SigningKey": "$SIGNING_KEY",
+    "AllowRegistration": true
+  },
+  "EnableSwagger": true,
+  "ConnectionStrings": {
+    "Admin": "host=${ADMIN_POSTGRES_HOST};port=${POSTGRES_PORT};username=${POSTGRES_USER};password=${POSTGRES_PASSWORD};database=EdFi_Admin;pooling=false",
+    "Security": "host=${ADMIN_POSTGRES_HOST};port=${POSTGRES_PORT};username=${POSTGRES_USER};password=${POSTGRES_PASSWORD};database=EdFi_Security;pooling=false",
+    "ProductionOds": "host=${ODS_POSTGRES_HOST};port=${POSTGRES_PORT};username=${POSTGRES_USER};password=${POSTGRES_PASSWORD};database=EdFi_Ods;pooling=false"
+  },
+  "Log4NetCore": {
+      "Log4NetConfigFileName": "./log4net.config"
+  },
+  "Logging": {
+      "LogLevel": {
+          "Default": "Information",
+          "Microsoft": "Warning",
+          "Microsoft.Hosting.Lifetime": "Information"
+      }
+  },
+  "AllowedHosts": "*"
+}

--- a/Application/EdFi.Ods.Admin.Api/Docker/pgsql/env.example
+++ b/Application/EdFi.Ods.Admin.Api/Docker/pgsql/env.example
@@ -1,0 +1,20 @@
+API_MODE=<API Mode Eg. SharedInstance, YearSpecific, DistrictSpecific>
+ODS_VIRTUAL_NAME=<virtual name for the ods endpoint>
+ADMINAPP_VIRTUAL_NAME=<virtual name for the admin app endpoint>
+
+# For Authentication
+AUTHORITY=<Authentication Authority Appsetting Eg. https://localhost:443>
+ISSUER_URL=<Authentication IssuerUrl Appsetting Eg. https://localhost:8001>
+SIGNING_KEY=<Authentication Signing Key (Symmetric Security Key) for OpenIddict>
+
+# For Postgres only
+POSTGRES_USER=<default postgres database user>
+POSTGRES_PASSWORD=<password for default postgres user>
+POSTGRES_PORT=<port for postgres server Eg. 5432>
+ADMIN_POSTGRES_HOST=<DNS or IP Address of the Postgres Server, i.e. sql.somedns.org Eg. 172.25.32.1
+ODS_POSTGRES_HOST=<DNS or IP Address of the Postgres Server, i.e. sql.somedns.org Eg. 172.25.32.1
+ODS_WAIT_POSTGRES_HOSTS=<DNS or IP Address of the different ODS Postgres Servers, i.e. sql.somedns.org Eg. 172.25.32.1
+
+# The following needs to be set to specify the ODS API endpoint for admin app to internally connect.
+# If user chooses direct connection between ODS API and admin app within docker network, then set the api internal url as follows
+API_INTERNAL_URL = http://${ODS_VIRTUAL_NAME}

--- a/Application/EdFi.Ods.Admin.Api/Docker/pgsql/log4net.config
+++ b/Application/EdFi.Ods.Admin.Api/Docker/pgsql/log4net.config
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<log4net>
+    <appender name="TraceAppender" type="log4net.Appender.TraceAppender">
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>
+    <appender name="FileAppender" type="log4net.Appender.RollingFileAppender">
+        <file value="Ed-Fi-ODS-AdminAPI-Log.txt" />
+        <appendToFile value="true" />
+        <rollingStyle value="Size" />
+        <maxSizeRollBackups value="10" />
+        <maximumFileSize value="15MB" />
+        <staticLogFileName value="true" />
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        </layout>
+    </appender>  
+    <root>
+        <level value="DEBUG" />
+        <appender-ref ref="TraceAppender" />
+        <appender-ref ref="FileAppender" />
+    </root>  
+</log4net>

--- a/Application/EdFi.Ods.Admin.Api/Docker/pgsql/run.sh
+++ b/Application/EdFi.Ods.Admin.Api/Docker/pgsql/run.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+set -e
+set -x
+
+envsubst < /app/AdminApi/appsettings.template.json > /app/AdminApi/temp.json
+
+measurementId=`jq -r '.AppSettings.GoogleAnalyticsMeasurementId' /app/AdminApi/appsettings.json`
+
+tmp=$(mktemp)
+jq --arg variable "$measurementId" '.AppSettings.GoogleAnalyticsMeasurementId = $variable' /app/AdminApi/temp.json > "$tmp" && mv "$tmp" /app/AdminApi/temp.json
+
+mv /app/AdminApi/temp.json /app/AdminApi/appsettings.json
+
+if [[ -z "$ODS_WAIT_POSTGRES_HOSTS" ]]; then
+  # if there are no hosts to wait then fallback to $ODS_POSTGRES_HOST
+  export ODS_WAIT_POSTGRES_HOSTS=$ODS_POSTGRES_HOST
+fi
+
+export ODS_WAIT_POSTGRES_HOSTS_ARR=($ODS_WAIT_POSTGRES_HOSTS) 
+for HOST in ${ODS_WAIT_POSTGRES_HOSTS_ARR[@]}
+do
+  until PGPASSWORD=$POSTGRES_PASSWORD psql -h $HOST -p $POSTGRES_PORT -U $POSTGRES_USER -c '\q';
+  do
+    >&2 echo "ODS Postgres '$HOST' is unavailable - sleeping"
+    sleep 10
+  done
+done
+
+until PGPASSWORD=$POSTGRES_PASSWORD psql -h $ADMIN_POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USER -c '\q';
+do
+  >&2 echo "Admin Postgres is unavailable - sleeping"
+  sleep 10
+done
+
+>&2 echo "Postgres is up - executing command"
+exec $cmd
+
+dotnet EdFi.Ods.Admin.Api.dll

--- a/Application/EdFi.Ods.Admin.Api/Docker/ssl/generate-certificate.sh
+++ b/Application/EdFi.Ods.Admin.Api/Docker/ssl/generate-certificate.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+set -e
+set -x
+
+PARENT="localhost"
+openssl req -x509 -newkey rsa:4096 -sha256 -days 365 -nodes -keyout $PARENT.key -out $PARENT.crt -subj "//CN=${PARENT}" -extensions v3_ca -extensions v3_req -config openssl.config
+openssl x509 -noout -text -in $PARENT.crt
+winpty openssl pkcs12 -export -out $PARENT.pfx -inkey $PARENT.key -in $PARENT.crt

--- a/Application/EdFi.Ods.Admin.Api/Docker/ssl/openssl.config
+++ b/Application/EdFi.Ods.Admin.Api/Docker/ssl/openssl.config
@@ -1,0 +1,21 @@
+[req]
+default_bits = 4096
+distinguished_name = req
+x509_extension = v3_ca
+req_extensions = v3_req
+
+[v3_req]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1 = localhost
+DNS.2 = 127.0.0.1
+
+[ v3_ca ]
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid:always,issuer
+basicConstraints = critical, CA:TRUE, pathlen:0
+keyUsage = critical, cRLSign, keyCertSign
+extendedKeyUsage = serverAuth, clientAuth

--- a/Application/EdFi.Ods.Admin.Api/EdFi.Ods.Admin.Api.nuspec
+++ b/Application/EdFi.Ods.Admin.Api/EdFi.Ods.Admin.Api.nuspec
@@ -12,6 +12,6 @@
     <license type="expression">Apache-2.0</license>
   </metadata>
   <files>
-       <file src="**" exclude="E2E Tests/**;**/*.sql" />
+       <file src="**" exclude="E2E Tests/**;Docker/**;Compose/**;**/*.sql" />
   </files>
 </package>

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityExtensions.cs
@@ -57,12 +57,13 @@ public static class SecurityExtensions
 
         //Application Security
         var issuer = configuration.GetValue<string>("Authentication:IssuerUrl");
+        var authority = configuration.GetValue<string>("Authentication:Authority");
         services.AddAuthentication(opt =>
         {
             opt.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
             opt.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
         }).AddJwtBearer(opt => {
-            opt.Authority = issuer;
+            opt.Authority = authority;
             opt.SaveToken = true;
             opt.TokenValidationParameters = new TokenValidationParameters
             {

--- a/Application/EdFi.Ods.Admin.Api/Program.cs
+++ b/Application/EdFi.Ods.Admin.Api/Program.cs
@@ -16,6 +16,12 @@ _logger.Info("Starting Admin API");
 
 var app = builder.Build();
 
+var pathBase = app.Configuration.GetValue<string>("AppSettings:PathBase");
+if (!string.IsNullOrEmpty(pathBase))
+{
+    app.UsePathBase("/" + pathBase.Trim('/'));
+}
+
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {

--- a/Application/EdFi.Ods.Admin.Api/appsettings.json
+++ b/Application/EdFi.Ods.Admin.Api/appsettings.json
@@ -14,6 +14,7 @@
         "ProductRegistrationUrl": "https://edfi-tools-analytics.azurewebsites.net/data/v1/"
     },
     "Authentication": {
+        "Authority": "",
         "IssuerUrl": "",
         "SigningKey": "",
         "AllowRegistration": false

--- a/Application/EdFi.Ods.Admin.Api/mssql.Dockerfile
+++ b/Application/EdFi.Ods.Admin.Api/mssql.Dockerfile
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+#tag 6.0-alpine 
+FROM mcr.microsoft.com/dotnet/aspnet@sha256:5d7911e8485a58ac50eefa09e2cea8f3d59268fd7f1501f72324e37e29d9d6ee
+LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
+ENV VERSION="1.0.4"
+ENV ASPNETCORE_URLS="https://+;http://+"
+ENV ASPNETCORE_Kestrel__Certificates__Default__Path=/app/AdminApi/Certificates/localhost.pfx
+# Please set the certificate password during docker run
+# Example:
+# ASPNETCORE_Kestrel__Certificates__Default__Password="test123"
+
+# Alpine image does not contain Globalization Cultures library so we need to install ICU library to get for LINQ expression to work
+# Disable the globaliztion invariant mode (set in base image)
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
+
+WORKDIR /app
+
+RUN apk --no-cache add curl unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.21 postgresql-client=~13.7-r0 jq=~1.6 icu=~67.1 gcompat && \
+    wget -O /app/AdminApi.zip https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.ODS.Admin.Api/versions/${VERSION}/content && \
+    unzip /app/AdminApi.zip -d /app/AdminApi && \
+    rm -f /app/AdminApi.zip
+
+COPY ./Docker/mssql/appsettings.template.json /app/AdminApi/appsettings.template.json
+COPY ./Docker/mssql/run.sh /app/AdminApi/run.sh
+COPY ./Docker/mssql/log4net.config /app/AdminApi/log4net.config
+COPY ./Docker/ssl/localhost.pfx /app/AdminApi/Certificates/localhost.pfx
+
+RUN dos2unix /app/AdminApi/*.json && \
+    dos2unix /app/AdminApi/*.sh && \
+    dos2unix /app/AdminApi/log4net.config && \
+    dos2unix /app/AdminApi/Certificates/localhost.pfx && \
+    chmod 700 /app/AdminApi/*.sh -- **
+
+EXPOSE 443
+
+WORKDIR /app/AdminApi
+ENTRYPOINT [ "/app/AdminApi/run.sh" ]

--- a/Application/EdFi.Ods.Admin.Api/pgsql.Dockerfile
+++ b/Application/EdFi.Ods.Admin.Api/pgsql.Dockerfile
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+#tag 6.0-alpine 
+FROM mcr.microsoft.com/dotnet/aspnet@sha256:5d7911e8485a58ac50eefa09e2cea8f3d59268fd7f1501f72324e37e29d9d6ee
+LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
+ENV VERSION="1.0.4"
+ENV ASPNETCORE_URLS="https://+;http://+"
+ENV ASPNETCORE_Kestrel__Certificates__Default__Path=/app/AdminApi/Certificates/localhost.pfx
+# Please set the certificate password during docker run
+# Example:
+# ASPNETCORE_Kestrel__Certificates__Default__Password="test123"
+
+# Alpine image does not contain Globalization Cultures library so we need to install ICU library to get for LINQ expression to work
+# Disable the globaliztion invariant mode (set in base image)
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
+
+WORKDIR /app
+
+RUN apk --no-cache add curl unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.21 postgresql-client=~13.7-r0 jq=~1.6 icu=~67.1 gcompat && \
+    wget -O /app/AdminApi.zip https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.ODS.Admin.Api/versions/${VERSION}/content && \
+    unzip /app/AdminApi.zip -d /app/AdminApi && \
+    rm -f /app/AdminApi.zip
+
+COPY ./Docker/pgsql/appsettings.template.json /app/AdminApi/appsettings.template.json
+COPY ./Docker/pgsql/run.sh /app/AdminApi/run.sh
+COPY ./Docker/pgsql/log4net.config /app/AdminApi/log4net.config
+COPY ./Docker/ssl/localhost.pfx /app/AdminApi/Certificates/localhost.pfx
+
+RUN dos2unix /app/AdminApi/*.json && \
+    dos2unix /app/AdminApi/*.sh && \
+    dos2unix /app/AdminApi/log4net.config && \
+    dos2unix /app/AdminApi/Certificates/localhost.pfx && \
+    chmod 700 /app/AdminApi/*.sh -- **
+
+EXPOSE 443
+
+WORKDIR /app/AdminApi
+ENTRYPOINT [ "/app/AdminApi/run.sh" ]

--- a/BuildAdminApiDockerDevelopment.ps1
+++ b/BuildAdminApiDockerDevelopment.ps1
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+<#
+    .SYNOPSIS
+        Script for running the build operation and copy over the latest files to an existing AdminApi docker container for testing.
+
+    .DESCRIPTION
+        Script for facilitating the local docker testing with latest changes. Developer can set the required appsettings values and trigger
+        the build. Once the build done, the apsettings.json will be updated with values provided and
+        latest files will be copied over to an existing AdminApi docker container folder.
+
+    .EXAMPLE
+        .\BuildAdminApiDockerDevelopment.ps1
+#>
+
+$p = @{
+        ProductionApiUrl = "http://api"
+        ApiExternalUrl = "https://localhost:5001"
+        ApiStartupType = "SharedInstance"
+        DatabaseEngine = "PostgreSql"
+        PathBase = "adminapp"
+        IssuerUrl = "https://localhost:8001"
+        SigningKey = ""
+        AdminDB = "host=db-admin;port=5432;username=username;password=root@321;database=EdFi_Admin;pooling=false"
+        SecurityDB = "host=db-admin;port=5432;username=username;password=root@321;database=EdFi_Security;pooling=false"
+        ProductionOdsDB = "host=db-ods;port=5432;username=username;password=password;database=EdFi_{0};pooling=false"
+    }
+
+.\build.ps1 -APIVersion 1.0.6 -Configuration Release -DockerEnvValues $p -Command BuildAndDeployToAdminApiDockerContainer

--- a/BuildDockerDevelopment.ps1
+++ b/BuildDockerDevelopment.ps1
@@ -31,4 +31,4 @@ $p = @{
         ProductionOdsDB = "host=db-ods;port=5432;username=username;password=password;database=EdFi_{0};Application Name=EdFi.Ods.AdminApp;"
     }
 
-.\build.ps1 -Version 2.1.1 -Configuration Release -DockerEnvValues $p -Command BuildAndDeployToDockerContainer
+.\build.ps1 -Version 2.1.1 -Configuration Release -DockerEnvValues $p -Command BuildAndDeployToAdminAppDockerContainer


### PR DESCRIPTION
**Description**
- Added 'Authority' authentication appsetting. This is to allow different configurations for IssuerUrl and Authority appsettings for authentication.
- Added Docker configuration files and script for Admin Api container against SQL Server.
- Added Docker configuration files and script for Admin Api container against Postgres.
- Added generate-certificate.sh to create self-signed SSL certificates which can be used when testing the containers.
- Added docker compose file and corresponding env.example for Postgres flow.
- Added AdminApi relatted container functions for testing in build.ps1. Renamed AdminApp related container functions to avoid confusion. Added BuildAdminApiDockerDevelopment.ps1 to facilitate quick dev testing inside AdminApi docker container.