### PR TITLE
[AA-1549] Include Scope in API Auth Requests

### DIFF
--- a/Application/EdFi.Ods.Admin.Api/ActionFilters/OperationResponsesDocumentFilter.cs
+++ b/Application/EdFi.Ods.Admin.Api/ActionFilters/OperationResponsesDocumentFilter.cs
@@ -17,6 +17,7 @@ namespace EdFi.Ods.Admin.Api.ActionFilters
             // Responses
             var getOkResponse = new OpenApiResponse() { Description = "The requested resource was successfully retrieved." };
             var unAuthorizedResponse = new OpenApiResponse() { Description = "Unauthorized. The request requires authentication" };
+            var forbiddenResponse = new OpenApiResponse() { Description = "Forbidden. The request is authenticated, but not authorized to access this resource" };
             var unhandledErrorResponse = new OpenApiResponse() { Description = "An unhandled error occurred on the server. See the response body for details." };
             var deleteSuccessResponse = new OpenApiResponse() { Description = "The resource was successfully deleted." };
             var resourceNotFoundResponse = new OpenApiResponse() { Description = "The resource could not be found." };
@@ -32,6 +33,7 @@ namespace EdFi.Ods.Admin.Api.ActionFilters
                     // Add appropriate responses
                     operation.Value.Responses.Clear();
                     operation.Value.Responses.Add(StatusCodes.Status401Unauthorized.ToString(), unAuthorizedResponse);
+                    operation.Value.Responses.Add(StatusCodes.Status403Forbidden.ToString(), forbiddenResponse);
                     operation.Value.Responses.Add(StatusCodes.Status500InternalServerError.ToString(), unhandledErrorResponse);
                     switch (operation.Key)
                     {

--- a/Application/EdFi.Ods.Admin.Api/E2E Tests/Admin API E2E.postman_collection.json
+++ b/Application/EdFi.Ods.Admin.Api/E2E Tests/Admin API E2E.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "d1e11b5e-30eb-46a6-9be1-9b32fb6982c6",
+		"_postman_id": "726d1780-411c-40f3-bc09-6ce719b27f77",
 		"name": "Admin API E2E",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "20720204"
@@ -279,6 +279,11 @@
 									"key": "grant_type",
 									"value": "client_credentials",
 									"type": "text"
+								},
+								{
+									"key": "scope",
+									"value": "edfi_admin_api/full_access",
+									"type": "text"
 								}
 							]
 						},
@@ -401,6 +406,87 @@
 									"key": "grant_type",
 									"value": "authorization_code",
 									"type": "text"
+								},
+								{
+									"key": "scope",
+									"value": "edfi_admin_api/full_access",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{API_URL}}/connect/token",
+							"host": [
+								"{{API_URL}}"
+							],
+							"path": [
+								"connect",
+								"token"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Token - Invalid Scope",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is Bad Request\", function () {\r",
+									"    pm.response.to.have.status(400);\r",
+									"});\r",
+									"\r",
+									"const response = pm.response.json();\r",
+									"\r",
+									"pm.test(\"Response includes error message\", function () {\r",
+									"    pm.expect(response).to.have.property(\"error\");\r",
+									"    pm.expect(response).to.have.property(\"error_description\");\r",
+									"    pm.expect(response).to.have.property(\"error_uri\");\r",
+									"\r",
+									"    pm.expect(response[\"error_description\"]).to.contain(\"scope\");\r",
+									"});\r",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "client_id",
+									"value": "{{RegisteredClientId}}",
+									"type": "text"
+								},
+								{
+									"key": "client_secret",
+									"value": "{{$guid}}",
+									"type": "text"
+								},
+								{
+									"key": "grant_type",
+									"value": "client_credentials",
+									"type": "text"
+								},
+								{
+									"key": "scope",
+									"value": "NOT_REAL/SCOPE",
+									"type": "text"
 								}
 							]
 						},
@@ -474,6 +560,11 @@
 								{
 									"key": "grant_type",
 									"value": "client_credentials",
+									"type": "text"
+								},
+								{
+									"key": "scope",
+									"value": "edfi_admin_api/full_access",
 									"type": "text"
 								}
 							]
@@ -2371,7 +2462,8 @@
 					"        urlencoded: [",
 					"            {key: 'client_id', value: pm.variables.get(\"ClientId\")},",
 					"            {key: 'client_secret', value: pm.variables.get(\"ClientSecret\")},",
-					"            {key: 'grant_type', value: \"client_credentials\"}",
+					"            {key: 'grant_type', value: \"client_credentials\"},",
+					"            {key: 'scope', value: \"edfi_admin_api/full_access\"}",
 					"        ]",
 					"    }",
 					"},",

--- a/Application/EdFi.Ods.Admin.Api/Features/Connect/RegisterService.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/Connect/RegisterService.cs
@@ -50,7 +50,7 @@ public class RegisterService : IRegisterService
             {
                 OpenIddictConstants.Permissions.Endpoints.Token,
                 OpenIddictConstants.Permissions.GrantTypes.ClientCredentials,
-                OpenIddictConstants.Permissions.Prefixes.Scope + SecurityConstants.ApiFullAccessScope
+                OpenIddictConstants.Permissions.Prefixes.Scope + SecurityConstants.Scopes.AdminApiFullAccess
             },
         };
 

--- a/Application/EdFi.Ods.Admin.Api/Features/Connect/TokenService.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/Connect/TokenService.cs
@@ -41,13 +41,16 @@ public class TokenService : ITokenService
             throw new AuthenticationException("Invalid Admin API Client key and secret");
         }
 
+        var requestedScopes = request.GetScopes();
         var displayName = await _applicationManager.GetDisplayNameAsync(application);
 
         var identity = new ClaimsIdentity(JwtBearerDefaults.AuthenticationScheme);
         identity.AddClaim(OpenIddictConstants.Claims.Subject, request.ClientId!, OpenIddictConstants.Destinations.AccessToken);
         identity.AddClaim(OpenIddictConstants.Claims.Name, displayName!, OpenIddictConstants.Destinations.AccessToken);
-        identity.AddClaim(OpenIddictConstants.Claims.Scope, SecurityConstants.Scopes.AdminApiFullAccess, OpenIddictConstants.Destinations.AccessToken);
 
-        return new ClaimsPrincipal(identity);
+        var principal = new ClaimsPrincipal(identity);
+        principal.SetScopes(requestedScopes);
+
+        return principal;
     }
 }

--- a/Application/EdFi.Ods.Admin.Api/Features/Connect/TokenService.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/Connect/TokenService.cs
@@ -46,7 +46,7 @@ public class TokenService : ITokenService
         var identity = new ClaimsIdentity(JwtBearerDefaults.AuthenticationScheme);
         identity.AddClaim(OpenIddictConstants.Claims.Subject, request.ClientId!, OpenIddictConstants.Destinations.AccessToken);
         identity.AddClaim(OpenIddictConstants.Claims.Name, displayName!, OpenIddictConstants.Destinations.AccessToken);
-        identity.AddClaim(OpenIddictConstants.Claims.Scope, SecurityConstants.ApiFullAccessScope, OpenIddictConstants.Destinations.AccessToken);
+        identity.AddClaim(OpenIddictConstants.Claims.Scope, SecurityConstants.Scopes.AdminApiFullAccess, OpenIddictConstants.Destinations.AccessToken);
 
         return new ClaimsPrincipal(identity);
     }

--- a/Application/EdFi.Ods.Admin.Api/Features/Connect/TokenService.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/Connect/TokenService.cs
@@ -42,6 +42,15 @@ public class TokenService : ITokenService
         }
 
         var requestedScopes = request.GetScopes();
+        var appScopes = (await _applicationManager.GetPermissionsAsync(application))
+            .Where(p => p.StartsWith(OpenIddictConstants.Permissions.Prefixes.Scope))
+            .Select(p => p.Substring(OpenIddictConstants.Permissions.Prefixes.Scope.Length))
+            .ToList();
+
+        var missingScopes = requestedScopes.Where(s => !appScopes.Contains(s)).ToList();
+        if(missingScopes.Any())
+            throw new AuthenticationException($"Client is not allowed access to requested scope(s): {string.Join(", " , missingScopes)}");
+
         var displayName = await _applicationManager.GetDisplayNameAsync(application);
 
         var identity = new ClaimsIdentity(JwtBearerDefaults.AuthenticationScheme);

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityConstants.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityConstants.cs
@@ -5,8 +5,12 @@
 
 namespace EdFi.Ods.Admin.Api.Infrastructure.Security;
 
-public class SecurityConstants
+public static class SecurityConstants
 {
     public const string TokenEndpointUri = "/connect/token";
-    public const string ApiFullAccessScope = "edfi_admin_api/full_access";
+
+    public static class Scopes
+    {
+        public const string AdminApiFullAccess = "edfi_admin_api/full_access";
+    }
 }

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/SecurityExtensions.cs
@@ -45,7 +45,7 @@ public static class SecurityExtensions
                     opt.AddSigningKey(signingKey);
                 }
 
-                opt.RegisterScopes(SecurityConstants.ApiFullAccessScope);
+                opt.RegisterScopes(SecurityConstants.Scopes.AdminApiFullAccess);
                 opt.UseAspNetCore().EnableTokenEndpointPassthrough();
             })
             .AddValidation(options =>
@@ -75,7 +75,7 @@ public static class SecurityExtensions
         services.AddAuthorization(opt =>
         {
             opt.DefaultPolicy = new AuthorizationPolicyBuilder()
-                .RequireClaim(OpenIddictConstants.Claims.Scope, SecurityConstants.ApiFullAccessScope)
+                .RequireClaim(OpenIddictConstants.Claims.Scope, SecurityConstants.Scopes.AdminApiFullAccess)
                 .Build();
         });
 

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/TokenEndpointBodyDescriptionFilter.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/Security/TokenEndpointBodyDescriptionFilter.cs
@@ -38,6 +38,7 @@ public class TokenEndpointBodyDescriptionFilter : IOperationFilter
                 { "client_id", new OpenApiSchema { Type = "string "} },
                 { "client_secret", new OpenApiSchema { Type = "string "} },
                 { "grant_type", new OpenApiSchema { Type = "string "} },
+                { "scope", new OpenApiSchema { Type = "string"} },
             }
         }
     };

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -76,6 +76,10 @@ public static class WebApplicationBuilderExtensions
                         ClientCredentials = new OpenApiOAuthFlow
                         {
                             TokenUrl = new Uri($"{issuer}{SecurityConstants.TokenEndpointUri}"),
+                            Scopes = new Dictionary<string, string>
+                            {
+                                { SecurityConstants.Scopes.AdminApiFullAccess, "Unrestricted access to all Admin API endpoints" },
+                            }
                         },
                     },
                     In = ParameterLocation.Header,

--- a/Application/EdFi.Ods.Admin.Api/Properties/launchSettings.json
+++ b/Application/EdFi.Ods.Admin.Api/Properties/launchSettings.json
@@ -17,6 +17,7 @@
       "applicationUrl": "https://localhost:7214;http://localhost:5214",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
+        "AUTHENTICATION__AUTHORITY": "https://localhost:7214",
         "AUTHENTICATION__ISSUERURL": "https://localhost:7214"
       }
     },
@@ -28,6 +29,7 @@
       "applicationUrl": "https://localhost:7214;http://localhost:5214",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Production",
+        "AUTHENTICATION__AUTHORITY": "https://localhost:7214",
         "AUTHENTICATION__ISSUERURL": "https://localhost:7214",
         "AUTHENTICATION__SIGNINGKEY": "dGhlKndlYnNpdGVfSVNf8J+Glw==",
         "AUTHENTICATION__ALLOWREGISTRATION": "true",
@@ -40,6 +42,7 @@
       "launchUrl": "swagger",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
+        "AUTHENTICATION__AUTHORITY": "https://localhost:44370",
         "AUTHENTICATION__ISSUERURL": "https://localhost:44370"
       }
     }


### PR DESCRIPTION
Future-proof the Admin API authentication endpoint (`/connect/token`) by including desired scopes in the request. This will allow us to introduce new scopes and issue tokens which only contain some of them without making changes to that endpoint's shape.

- no change in token contents / security requirement
- reading and setting requested scopes added to token service
- when token is not granted the required scope, .NET returns a 403 Forbidden
- swagger updated to list valid scopes + include in documentation for `connect/token` endpoint
- E2E tests updated to both include scope in token requests + cover test for requesting invalid scope
- manually tested requesting a scope which a client does not have access to, which is blocked by both OpenIddict validation + explicitly in `TokenService`

Asides:

- fixed missing `Authority` config in launch profiles
- updated swagger to list 403 response on all endpoints
- renamed constant to set up for eventual additional scopes