### PR TITLE
[AA-1543] Add Versioning to Admin API

### DIFF
--- a/Application/EdFi.Ods.Admin.Api/E2E Tests/Admin API E2E.postman_collection.json
+++ b/Application/EdFi.Ods.Admin.Api/E2E Tests/Admin API E2E.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "d3ec5be6-74d3-4d25-b094-98700ec61c32",
+		"_postman_id": "3af680b2-e64a-45ca-bb94-9829551e4617",
 		"name": "Admin API E2E",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "15734759"
+		"_exporter_id": "20720204"
 	},
 	"item": [
 		{
@@ -663,84 +663,62 @@
 			]
 		},
 		{
-			"name": "Vendors",
+			"name": "v1",
 			"item": [
 				{
 					"name": "Vendors",
-					"event": [
+					"item": [
 						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is Created\", function () {\r",
-									"    pm.response.to.have.status(201);\r",
-									"});\r",
-									"\r",
-									"const response = pm.response.json();\r",
-									"const result = pm.response.json().result;\r",
-									"\r",
-									"pm.test(\"Response matches success format\", function () {\r",
-									"    pm.expect(response.status).to.equal(201);\r",
-									"    pm.expect(response).to.have.property(\"title\");\r",
-									"    pm.expect(response).to.have.property(\"result\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response title is helpful and accurate\", function () {\r",
-									"    pm.expect(response.title.toLowerCase()).to.contain(\"vendor\");\r",
-									"    pm.expect(response.title.toLowerCase()).to.contain(\"created\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response includes location in header\", function () {\r",
-									"    pm.response.to.have.header(\"Location\");\r",
-									"    pm.response.to.be.header(\"Location\", `/vendors/${result.vendorId}`);\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response result includes vendor info\", function () {\r",
-									"    pm.expect(result.company).to.equal(\"Test Company\");\r",
-									"    pm.expect(result.namespacePrefixes).to.equal(\"uri://ed-fi.org\");\r",
-									"    pm.expect(result.contactName).to.equal(\"Test User\");\r",
-									"    pm.expect(result.contactEmailAddress).to.equal(\"test@test-ed-fi.org\");\r",
-									"});\r",
-									"\r",
-									"if(result.vendorId) {\r",
-									"    pm.collectionVariables.set(\"CreatedVendorId\", result.vendorId);\r",
-									"}"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n    \"company\": \"Test Company\",\r\n    \"namespacePrefixes\": \"uri://ed-fi.org\",\r\n    \"contactName\": \"Test User\",\r\n    \"contactEmailAddress\": \"test@test-ed-fi.org\"\r\n}",
-							"options": {
-								"raw": {
-									"language": "json"
+							"name": "Vendors",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is Created\", function () {\r",
+											"    pm.response.to.have.status(201);\r",
+											"});\r",
+											"\r",
+											"const response = pm.response.json();\r",
+											"const result = pm.response.json().result;\r",
+											"\r",
+											"pm.test(\"Response matches success format\", function () {\r",
+											"    pm.expect(response.status).to.equal(201);\r",
+											"    pm.expect(response).to.have.property(\"title\");\r",
+											"    pm.expect(response).to.have.property(\"result\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response title is helpful and accurate\", function () {\r",
+											"    pm.expect(response.title.toLowerCase()).to.contain(\"vendor\");\r",
+											"    pm.expect(response.title.toLowerCase()).to.contain(\"created\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response includes location in header\", function () {\r",
+											"    pm.response.to.have.header(\"Location\");\r",
+											"    pm.response.to.be.header(\"Location\", `/vendors/${result.vendorId}`);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response result includes vendor info\", function () {\r",
+											"    pm.expect(result.company).to.equal(\"Test Company\");\r",
+											"    pm.expect(result.namespacePrefixes).to.equal(\"uri://ed-fi.org\");\r",
+											"    pm.expect(result.contactName).to.equal(\"Test User\");\r",
+											"    pm.expect(result.contactEmailAddress).to.equal(\"test@test-ed-fi.org\");\r",
+											"});\r",
+											"\r",
+											"if(result.vendorId) {\r",
+											"    pm.collectionVariables.set(\"CreatedVendorId\", result.vendorId);\r",
+											"}"
+										],
+										"type": "text/javascript"
+									}
 								}
-							}
-						},
-						"url": {
-							"raw": "{{API_URL}}/vendors",
-							"host": [
-								"{{API_URL}}"
 							],
-							"path": [
-								"vendors"
-							]
-						}
-					},
-					"response": [
-						{
-							"name": "Vendor with multiple namespaces",
-							"originalRequest": {
+							"request": {
 								"method": "POST",
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\r\n    \"company\": {{CompanyName}},\r\n    \"namespacePrefixes\": \"uri://ed-fi.org,uri://academicbenchmarks.com\",\r\n    \"contactName\": {{ContactName}},\r\n    \"contactEmailAddress\": {{ContactEmail}}\r\n}",
+									"raw": "{\r\n    \"company\": \"Test Company\",\r\n    \"namespacePrefixes\": \"uri://ed-fi.org\",\r\n    \"contactName\": \"Test User\",\r\n    \"contactEmailAddress\": \"test@test-ed-fi.org\"\r\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -757,1730 +735,1757 @@
 									]
 								}
 							},
-							"status": "Created",
-							"code": 201,
-							"_postman_previewlanguage": "json",
-							"header": [
+							"response": [
 								{
-									"key": "Content-Type",
-									"value": "application/json; charset=utf-8"
-								},
+									"name": "Vendor with multiple namespaces",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"company\": {{CompanyName}},\r\n    \"namespacePrefixes\": \"uri://ed-fi.org,uri://academicbenchmarks.com\",\r\n    \"contactName\": {{ContactName}},\r\n    \"contactEmailAddress\": {{ContactEmail}}\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_URL}}/vendors",
+											"host": [
+												"{{API_URL}}"
+											],
+											"path": [
+												"vendors"
+											]
+										}
+									},
+									"status": "Created",
+									"code": 201,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json; charset=utf-8"
+										},
+										{
+											"key": "Date",
+											"value": "Thu, 02 Jun 2022 23:13:53 GMT"
+										},
+										{
+											"key": "Server",
+											"value": "Kestrel"
+										},
+										{
+											"key": "Location",
+											"value": "/Vendors/2"
+										},
+										{
+											"key": "Transfer-Encoding",
+											"value": "chunked"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"result\": {\n        \"vendorId\": 2,\n        \"company\": \"Test Company\",\n        \"namespacePrefixes\": \"uri://ed-fi.org,uri://academicbenchmarks.com\",\n        \"contactName\": \"Test User\",\n        \"contactEmailAddress\": \"test@test-ed-fi.org\"\n    },\n    \"status\": 201,\n    \"title\": \"Vendor created successfully\"\n}"
+								}
+							]
+						},
+						{
+							"name": "Vendors - Invalid",
+							"event": [
 								{
-									"key": "Date",
-									"value": "Thu, 02 Jun 2022 23:13:53 GMT"
-								},
-								{
-									"key": "Server",
-									"value": "Kestrel"
-								},
-								{
-									"key": "Location",
-									"value": "/Vendors/2"
-								},
-								{
-									"key": "Transfer-Encoding",
-									"value": "chunked"
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is Bad Request\", function () {\r",
+											"    pm.response.to.have.status(400);\r",
+											"});\r",
+											"\r",
+											"const response = pm.response.json();\r",
+											"\r",
+											"pm.test(\"Response matches error format\", function () {\r",
+											"    pm.expect(response.status).to.equal(400);\r",
+											"    pm.expect(response).to.have.property(\"title\");\r",
+											"    pm.expect(response).to.have.property(\"errors\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response title is helpful and accurate\", function () {\r",
+											"    pm.expect(response.title.toLowerCase()).to.contain(\"validation\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response errors include messages by property\", function () {\r",
+											"    pm.expect(response.errors[\"Company\"].length).to.equal(1);\r",
+											"    pm.expect(response.errors[\"ContactName\"].length).to.equal(1);\r",
+											"    pm.expect(response.errors[\"ContactEmailAddress\"].length).to.equal(2);\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
 								}
 							],
-							"cookie": [],
-							"body": "{\n    \"result\": {\n        \"vendorId\": 2,\n        \"company\": \"Test Company\",\n        \"namespacePrefixes\": \"uri://ed-fi.org,uri://academicbenchmarks.com\",\n        \"contactName\": \"Test User\",\n        \"contactEmailAddress\": \"test@test-ed-fi.org\"\n    },\n    \"status\": 201,\n    \"title\": \"Vendor created successfully\"\n}"
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"company\": \"\",\r\n    \"namespacePrefixes\": \"\",\r\n    \"contactName\": \"\",\r\n    \"contactEmailAddress\": \"\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{API_URL}}/vendors",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"vendors"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Vendors",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is OK\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											"\r",
+											"const response = pm.response.json();\r",
+											"const results = pm.response.json().result;\r",
+											"\r",
+											"pm.test(\"Response matches success format\", function () {\r",
+											"    pm.expect(response.status).to.equal(200);\r",
+											"    pm.expect(response).to.have.property(\"title\");\r",
+											"    pm.expect(response).to.have.property(\"result\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response result includes vendors\", function () {\r",
+											"    pm.expect(results.length).to.be.greaterThan(0);\r",
+											"\r",
+											"    const indexOfVendor = results.map(\r",
+											"        function(vendor) { return vendor.vendorId; }\r",
+											"    ).indexOf(pm.collectionVariables.get(\"CreatedVendorId\"));\r",
+											"\r",
+											"    const result = results[indexOfVendor];\r",
+											"    pm.expect(result.company).to.equal(\"Test Company\");\r",
+											"    pm.expect(result.namespacePrefixes).to.equal(\"uri://ed-fi.org\");\r",
+											"    pm.expect(result.contactName).to.equal(\"Test User\");\r",
+											"    pm.expect(result.contactEmailAddress).to.equal(\"test@test-ed-fi.org\");\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "GET",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{API_URL}}/vendors",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"vendors"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Vendors by ID",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is OK\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											"\r",
+											"const response = pm.response.json();\r",
+											"const result = pm.response.json().result;\r",
+											"\r",
+											"pm.test(\"Response matches success format\", function () {\r",
+											"    pm.expect(response.status).to.equal(200);\r",
+											"    pm.expect(response).to.have.property(\"title\");\r",
+											"    pm.expect(response).to.have.property(\"result\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response result matches vendor\", function () {\r",
+											"    const vendorId = pm.collectionVariables.get(\"CreatedVendorId\");\r",
+											"    \r",
+											"    pm.expect(result.vendorId).to.equal(vendorId);\r",
+											"    pm.expect(result.company).to.equal(\"Test Company\");\r",
+											"    pm.expect(result.namespacePrefixes).to.equal(\"uri://ed-fi.org\");\r",
+											"    pm.expect(result.contactName).to.equal(\"Test User\");\r",
+											"    pm.expect(result.contactEmailAddress).to.equal(\"test@test-ed-fi.org\");\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{API_URL}}/vendors/{{CreatedVendorId}}",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"vendors",
+										"{{CreatedVendorId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Vendors",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is OK\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											"\r",
+											"const response = pm.response.json();\r",
+											"const result = pm.response.json().result;\r",
+											"\r",
+											"pm.test(\"Response matches success format\", function () {\r",
+											"    pm.expect(response.status).to.equal(200);\r",
+											"    pm.expect(response).to.have.property(\"title\");\r",
+											"    pm.expect(response).to.have.property(\"result\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response title is helpful and accurate\", function () {\r",
+											"    pm.expect(response.title.toLowerCase()).to.contain(\"vendor\");\r",
+											"    pm.expect(response.title.toLowerCase()).to.contain(\"updated\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response result includes updated vendor\", function () {\r",
+											"    pm.expect(result.company).to.equal(\"Updated Test Company\");\r",
+											"    pm.expect(result.namespacePrefixes).to.equal(\"uri://academicbenchmarks.com\");\r",
+											"    pm.expect(result.contactName).to.equal(\"Updated User\");\r",
+											"    pm.expect(result.contactEmailAddress).to.equal(\"updated@example.com\");\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"company\": \"Updated Test Company\",\r\n    \"namespacePrefixes\": \"uri://academicbenchmarks.com\",\r\n    \"contactName\": \"Updated User\",\r\n    \"contactEmailAddress\": \"updated@example.com\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{API_URL}}/vendors/{{CreatedVendorId}}",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"vendors",
+										"{{CreatedVendorId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Vendors - Invalid",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is Bad Request\", function () {\r",
+											"    pm.response.to.have.status(400);\r",
+											"});\r",
+											"\r",
+											"const response = pm.response.json();\r",
+											"\r",
+											"pm.test(\"Response matches error format\", function () {\r",
+											"    pm.expect(response.status).to.equal(400);\r",
+											"    pm.expect(response).to.have.property(\"title\");\r",
+											"    pm.expect(response).to.have.property(\"errors\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response title is helpful and accurate\", function () {\r",
+											"    pm.expect(response.title.toLowerCase()).to.contain(\"validation\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response errors include messages by property\", function () {\r",
+											"    pm.expect(response.errors[\"Company\"].length).to.equal(1);\r",
+											"    pm.expect(response.errors[\"ContactName\"].length).to.equal(1);\r",
+											"    pm.expect(response.errors[\"ContactEmailAddress\"].length).to.equal(2);\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"company\": \"\",\r\n    \"contactName\": \"\",\r\n    \"contactEmailAddress\": \"\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{API_URL}}/vendors/{{CreatedVendorId}}",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"vendors",
+										"{{CreatedVendorId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Vendors",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is OK\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											"\r",
+											"const response = pm.response.json();\r",
+											"\r",
+											"pm.test(\"Response matches success format\", function () {\r",
+											"    pm.expect(response.status).to.equal(200);\r",
+											"    pm.expect(response).to.have.property(\"title\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response title is helpful and accurate\", function () {\r",
+											"    pm.expect(response.title.toLowerCase()).to.contain(\"vendor\");\r",
+											"    pm.expect(response.title.toLowerCase()).to.contain(\"deleted\");\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{API_URL}}/vendors/{{CreatedVendorId}}",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"vendors",
+										"{{CreatedVendorId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Vendors -  Not Found",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is Not Found\", function () {\r",
+											"    pm.response.to.have.status(404);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response matches error format\", function () {\r",
+											"    const response = pm.response.json();\r",
+											"\r",
+											"    pm.expect(response.status).to.equal(404);\r",
+											"    pm.expect(response).to.have.property(\"title\");\r",
+											"    pm.expect(response).to.have.property(\"errors\");\r",
+											"    pm.expect(response.errors).to.contain(response.title);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response title is helpful and accurate\", function () {\r",
+											"    const response = pm.response.json();\r",
+											"\r",
+											"    pm.expect(response.title).to.contain(\"Not found\");\r",
+											"    pm.expect(response.title).to.contain(\"vendor\");\r",
+											"    pm.expect(response.title).to.contain(pm.collectionVariables.get(\"CreatedVendorId\"));\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{API_URL}}/vendors/{{CreatedVendorId}}",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"vendors",
+										"{{CreatedVendorId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Vendors - Not Found",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is Not Found\", function () {\r",
+											"    pm.response.to.have.status(404);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response matches error format\", function () {\r",
+											"    const response = pm.response.json();\r",
+											"\r",
+											"    pm.expect(response.status).to.equal(404);\r",
+											"    pm.expect(response).to.have.property(\"title\");\r",
+											"    pm.expect(response).to.have.property(\"errors\");\r",
+											"    pm.expect(response.errors).to.contain(response.title);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response title is helpful and accurate\", function () {\r",
+											"    const response = pm.response.json();\r",
+											"\r",
+											"    pm.expect(response.title).to.contain(\"Not found\");\r",
+											"    pm.expect(response.title).to.contain(\"vendor\");\r",
+											"    pm.expect(response.title).to.contain(pm.collectionVariables.get(\"CreatedVendorId\"));\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"company\": \"Updated Test Company\",\r\n    \"namespacePrefixes\": \"uri://academicbenchmarks.com\",\r\n    \"contactName\": \"Updated User\",\r\n    \"contactEmailAddress\": \"updated@example.com\"\r\n}\r\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{API_URL}}/vendors/{{CreatedVendorId}}",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"vendors",
+										"{{CreatedVendorId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Vendors - Not Found",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is Not Found\", function () {\r",
+											"    pm.response.to.have.status(404);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response matches error format\", function () {\r",
+											"    const response = pm.response.json();\r",
+											"\r",
+											"    pm.expect(response.status).to.equal(404);\r",
+											"    pm.expect(response).to.have.property(\"title\");\r",
+											"    pm.expect(response).to.have.property(\"errors\");\r",
+											"    pm.expect(response.errors).to.contain(response.title);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response title is helpful and accurate\", function () {\r",
+											"    const response = pm.response.json();\r",
+											"\r",
+											"    pm.expect(response.title).to.contain(\"Not found\");\r",
+											"    pm.expect(response.title).to.contain(\"vendor\");\r",
+											"    pm.expect(response.title).to.contain(pm.collectionVariables.get(\"CreatedVendorId\"));\r",
+											"});\r",
+											"\r",
+											"pm.collectionVariables.unset(\"CreatedVendorId\");\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{API_URL}}/vendors/{{CreatedVendorId}}",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"vendors",
+										"{{CreatedVendorId}}"
+									]
+								}
+							},
+							"response": []
 						}
 					]
 				},
 				{
-					"name": "Vendors - Invalid",
-					"event": [
+					"name": "Application",
+					"item": [
 						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is Bad Request\", function () {\r",
-									"    pm.response.to.have.status(400);\r",
-									"});\r",
-									"\r",
-									"const response = pm.response.json();\r",
-									"\r",
-									"pm.test(\"Response matches error format\", function () {\r",
-									"    pm.expect(response.status).to.equal(400);\r",
-									"    pm.expect(response).to.have.property(\"title\");\r",
-									"    pm.expect(response).to.have.property(\"errors\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response title is helpful and accurate\", function () {\r",
-									"    pm.expect(response.title.toLowerCase()).to.contain(\"validation\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response errors include messages by property\", function () {\r",
-									"    pm.expect(response.errors[\"Company\"].length).to.equal(1);\r",
-									"    pm.expect(response.errors[\"ContactName\"].length).to.equal(1);\r",
-									"    pm.expect(response.errors[\"ContactEmailAddress\"].length).to.equal(2);\r",
-									"});\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n    \"company\": \"\",\r\n    \"namespacePrefixes\": \"\",\r\n    \"contactName\": \"\",\r\n    \"contactEmailAddress\": \"\"\r\n}",
-							"options": {
-								"raw": {
-									"language": "json"
+							"name": "Applications",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"pm.sendRequest({\r",
+											"  url: `${pm.variables.get(\"API_URL\")}/vendors`,\r",
+											"  method: 'POST',\r",
+											"  header: {\r",
+											"      \"Content-Type\": \"application/json\",\r",
+											"      \"Authorization\": `Bearer ${pm.collectionVariables.get(\"TOKEN\")}`\r",
+											"  },\r",
+											"  body: {\r",
+											"    mode: 'raw',\r",
+											"    raw:JSON.stringify({\r",
+											"      \"company\": \"Application Company\",\r",
+											"      \"namespacePrefixes\": \"uri://ed-fi.org\",\r",
+											"      \"contactName\": \"Application User\",\r",
+											"      \"contactEmailAddress\": \"application@example.com\"\r",
+											"    }), \r",
+											"  }\r",
+											"},  \r",
+											"function (err, response) {\r",
+											"  if(err) { console.log(\"Error in Pre-request:\", err); }\r",
+											"  const json = response.json();\r",
+											"  if(!json.result.vendorId) { console.log('Error in Pre-request: vendorID missing from response. Response is:', json); }\r",
+											"  else {\r",
+											"    pm.collectionVariables.set(\"ApplicationVendorId\", json.result.vendorId);\r",
+											"  }\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is Created\", function () {\r",
+											"    pm.response.to.have.status(201);\r",
+											"});\r",
+											"\r",
+											"const response = pm.response.json();\r",
+											"const result = pm.response.json().result;\r",
+											"\r",
+											"pm.test(\"Response matches success format\", function () {\r",
+											"    pm.expect(response.status).to.equal(201);\r",
+											"    pm.expect(response).to.have.property(\"title\");\r",
+											"    pm.expect(response).to.have.property(\"result\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response title is helpful and accurate\", function () {\r",
+											"    pm.expect(response.title.toLowerCase()).to.contain(\"application\");\r",
+											"    pm.expect(response.title.toLowerCase()).to.contain(\"created\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response includes location in header\", function () {\r",
+											"    pm.response.to.have.header(\"Location\");\r",
+											"    pm.response.to.be.header(\"Location\", `/applications/${result.applicationId}`);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response result includes application key and secret\", function () {\r",
+											"    pm.expect(result).to.have.property(\"applicationId\");\r",
+											"    pm.expect(result).to.have.property(\"key\");\r",
+											"    pm.expect(result).to.have.property(\"secret\");\r",
+											"});\r",
+											"\r",
+											"if(result.applicationId) {\r",
+											"    pm.collectionVariables.set(\"CreatedApplicationId\", result.applicationId);\r",
+											"}\r",
+											""
+										],
+										"type": "text/javascript"
+									}
 								}
-							}
-						},
-						"url": {
-							"raw": "{{API_URL}}/vendors",
-							"host": [
-								"{{API_URL}}"
 							],
-							"path": [
-								"vendors"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Vendors",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is OK\", function () {\r",
-									"    pm.response.to.have.status(200);\r",
-									"});\r",
-									"\r",
-									"const response = pm.response.json();\r",
-									"const results = pm.response.json().result;\r",
-									"\r",
-									"pm.test(\"Response matches success format\", function () {\r",
-									"    pm.expect(response.status).to.equal(200);\r",
-									"    pm.expect(response).to.have.property(\"title\");\r",
-									"    pm.expect(response).to.have.property(\"result\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response result includes vendors\", function () {\r",
-									"    pm.expect(results.length).to.be.greaterThan(0);\r",
-									"\r",
-									"    const indexOfVendor = results.map(\r",
-									"        function(vendor) { return vendor.vendorId; }\r",
-									"    ).indexOf(pm.collectionVariables.get(\"CreatedVendorId\"));\r",
-									"\r",
-									"    const result = results[indexOfVendor];\r",
-									"    pm.expect(result.company).to.equal(\"Test Company\");\r",
-									"    pm.expect(result.namespacePrefixes).to.equal(\"uri://ed-fi.org\");\r",
-									"    pm.expect(result.contactName).to.equal(\"Test User\");\r",
-									"    pm.expect(result.contactEmailAddress).to.equal(\"test@test-ed-fi.org\");\r",
-									"});\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"protocolProfileBehavior": {
-						"disableBodyPruning": true
-					},
-					"request": {
-						"method": "GET",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "",
-							"options": {
-								"raw": {
-									"language": "json"
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"applicationName\": \"Test Application\",\r\n  \"vendorId\": {{ApplicationVendorId}},\r\n  \"claimSetName\": \"Ed-Fi Sandbox\",\r\n  \"profileId\": null,\r\n  \"educationOrganizationIds\": [ 255901 ]\r\n}\r\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{API_URL}}/applications/",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"applications",
+										""
+									]
 								}
-							}
-						},
-						"url": {
-							"raw": "{{API_URL}}/vendors",
-							"host": [
-								"{{API_URL}}"
-							],
-							"path": [
-								"vendors"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Vendors by ID",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is OK\", function () {\r",
-									"    pm.response.to.have.status(200);\r",
-									"});\r",
-									"\r",
-									"const response = pm.response.json();\r",
-									"const result = pm.response.json().result;\r",
-									"\r",
-									"pm.test(\"Response matches success format\", function () {\r",
-									"    pm.expect(response.status).to.equal(200);\r",
-									"    pm.expect(response).to.have.property(\"title\");\r",
-									"    pm.expect(response).to.have.property(\"result\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response result matches vendor\", function () {\r",
-									"    const vendorId = pm.collectionVariables.get(\"CreatedVendorId\");\r",
-									"    \r",
-									"    pm.expect(result.vendorId).to.equal(vendorId);\r",
-									"    pm.expect(result.company).to.equal(\"Test Company\");\r",
-									"    pm.expect(result.namespacePrefixes).to.equal(\"uri://ed-fi.org\");\r",
-									"    pm.expect(result.contactName).to.equal(\"Test User\");\r",
-									"    pm.expect(result.contactEmailAddress).to.equal(\"test@test-ed-fi.org\");\r",
-									"});\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{API_URL}}/vendors/{{CreatedVendorId}}",
-							"host": [
-								"{{API_URL}}"
-							],
-							"path": [
-								"vendors",
-								"{{CreatedVendorId}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Vendors",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is OK\", function () {\r",
-									"    pm.response.to.have.status(200);\r",
-									"});\r",
-									"\r",
-									"const response = pm.response.json();\r",
-									"const result = pm.response.json().result;\r",
-									"\r",
-									"pm.test(\"Response matches success format\", function () {\r",
-									"    pm.expect(response.status).to.equal(200);\r",
-									"    pm.expect(response).to.have.property(\"title\");\r",
-									"    pm.expect(response).to.have.property(\"result\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response title is helpful and accurate\", function () {\r",
-									"    pm.expect(response.title.toLowerCase()).to.contain(\"vendor\");\r",
-									"    pm.expect(response.title.toLowerCase()).to.contain(\"updated\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response result includes updated vendor\", function () {\r",
-									"    pm.expect(result.company).to.equal(\"Updated Test Company\");\r",
-									"    pm.expect(result.namespacePrefixes).to.equal(\"uri://academicbenchmarks.com\");\r",
-									"    pm.expect(result.contactName).to.equal(\"Updated User\");\r",
-									"    pm.expect(result.contactEmailAddress).to.equal(\"updated@example.com\");\r",
-									"});\r",
-									""
-								],
-								"type": "text/javascript"
-							}
+							},
+							"response": []
 						},
 						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n    \"company\": \"Updated Test Company\",\r\n    \"namespacePrefixes\": \"uri://academicbenchmarks.com\",\r\n    \"contactName\": \"Updated User\",\r\n    \"contactEmailAddress\": \"updated@example.com\"\r\n}",
-							"options": {
-								"raw": {
-									"language": "json"
+							"name": "Applications - Invalid",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is Bad Request\", function () {\r",
+											"    pm.response.to.have.status(400);\r",
+											"});\r",
+											"\r",
+											"const response = pm.response.json();\r",
+											"\r",
+											"pm.test(\"Response matches error format\", function () {\r",
+											"    pm.expect(response.status).to.equal(400);\r",
+											"    pm.expect(response).to.have.property(\"title\");\r",
+											"    pm.expect(response).to.have.property(\"errors\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response title is helpful and accurate\", function () {\r",
+											"    pm.expect(response.title.toLowerCase()).to.contain(\"validation\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response errors include messages by property\", function () {\r",
+											"    pm.expect(response.errors[\"ApplicationName\"].length).to.equal(1);\r",
+											"    pm.expect(response.errors[\"ClaimSetName\"].length).to.equal(1);\r",
+											"    pm.expect(response.errors[\"EducationOrganizationIds\"].length).to.equal(1);\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
 								}
-							}
-						},
-						"url": {
-							"raw": "{{API_URL}}/vendors/{{CreatedVendorId}}",
-							"host": [
-								"{{API_URL}}"
 							],
-							"path": [
-								"vendors",
-								"{{CreatedVendorId}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Vendors - Invalid",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is Bad Request\", function () {\r",
-									"    pm.response.to.have.status(400);\r",
-									"});\r",
-									"\r",
-									"const response = pm.response.json();\r",
-									"\r",
-									"pm.test(\"Response matches error format\", function () {\r",
-									"    pm.expect(response.status).to.equal(400);\r",
-									"    pm.expect(response).to.have.property(\"title\");\r",
-									"    pm.expect(response).to.have.property(\"errors\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response title is helpful and accurate\", function () {\r",
-									"    pm.expect(response.title.toLowerCase()).to.contain(\"validation\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response errors include messages by property\", function () {\r",
-									"    pm.expect(response.errors[\"Company\"].length).to.equal(1);\r",
-									"    pm.expect(response.errors[\"ContactName\"].length).to.equal(1);\r",
-									"    pm.expect(response.errors[\"ContactEmailAddress\"].length).to.equal(2);\r",
-									"});\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n    \"company\": \"\",\r\n    \"contactName\": \"\",\r\n    \"contactEmailAddress\": \"\"\r\n}",
-							"options": {
-								"raw": {
-									"language": "json"
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"applicationName\": \"\",\r\n  \"vendorId\": {{ApplicationVendorId}},\r\n  \"claimSetName\": \"\",\r\n  \"profileId\": null,\r\n  \"educationOrganizationIds\": []\r\n}\r\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{API_URL}}/applications/",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"applications",
+										""
+									]
 								}
-							}
+							},
+							"response": []
 						},
-						"url": {
-							"raw": "{{API_URL}}/vendors/{{CreatedVendorId}}",
-							"host": [
-								"{{API_URL}}"
-							],
-							"path": [
-								"vendors",
-								"{{CreatedVendorId}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Vendors",
-					"event": [
 						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is OK\", function () {\r",
-									"    pm.response.to.have.status(200);\r",
-									"});\r",
-									"\r",
-									"const response = pm.response.json();\r",
-									"\r",
-									"pm.test(\"Response matches success format\", function () {\r",
-									"    pm.expect(response.status).to.equal(200);\r",
-									"    pm.expect(response).to.have.property(\"title\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response title is helpful and accurate\", function () {\r",
-									"    pm.expect(response.title.toLowerCase()).to.contain(\"vendor\");\r",
-									"    pm.expect(response.title.toLowerCase()).to.contain(\"deleted\");\r",
-									"});\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "DELETE",
-						"header": [],
-						"url": {
-							"raw": "{{API_URL}}/vendors/{{CreatedVendorId}}",
-							"host": [
-								"{{API_URL}}"
-							],
-							"path": [
-								"vendors",
-								"{{CreatedVendorId}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Vendors -  Not Found",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is Not Found\", function () {\r",
-									"    pm.response.to.have.status(404);\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response matches error format\", function () {\r",
-									"    const response = pm.response.json();\r",
-									"\r",
-									"    pm.expect(response.status).to.equal(404);\r",
-									"    pm.expect(response).to.have.property(\"title\");\r",
-									"    pm.expect(response).to.have.property(\"errors\");\r",
-									"    pm.expect(response.errors).to.contain(response.title);\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response title is helpful and accurate\", function () {\r",
-									"    const response = pm.response.json();\r",
-									"\r",
-									"    pm.expect(response.title).to.contain(\"Not found\");\r",
-									"    pm.expect(response.title).to.contain(\"vendor\");\r",
-									"    pm.expect(response.title).to.contain(pm.collectionVariables.get(\"CreatedVendorId\"));\r",
-									"});\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{API_URL}}/vendors/{{CreatedVendorId}}",
-							"host": [
-								"{{API_URL}}"
-							],
-							"path": [
-								"vendors",
-								"{{CreatedVendorId}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Vendors - Not Found",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is Not Found\", function () {\r",
-									"    pm.response.to.have.status(404);\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response matches error format\", function () {\r",
-									"    const response = pm.response.json();\r",
-									"\r",
-									"    pm.expect(response.status).to.equal(404);\r",
-									"    pm.expect(response).to.have.property(\"title\");\r",
-									"    pm.expect(response).to.have.property(\"errors\");\r",
-									"    pm.expect(response.errors).to.contain(response.title);\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response title is helpful and accurate\", function () {\r",
-									"    const response = pm.response.json();\r",
-									"\r",
-									"    pm.expect(response.title).to.contain(\"Not found\");\r",
-									"    pm.expect(response.title).to.contain(\"vendor\");\r",
-									"    pm.expect(response.title).to.contain(pm.collectionVariables.get(\"CreatedVendorId\"));\r",
-									"});\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n    \"company\": \"Updated Test Company\",\r\n    \"namespacePrefixes\": \"uri://academicbenchmarks.com\",\r\n    \"contactName\": \"Updated User\",\r\n    \"contactEmailAddress\": \"updated@example.com\"\r\n}\r\n",
-							"options": {
-								"raw": {
-									"language": "json"
+							"name": "Applications - Invalid Vendor",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is Bad Request\", function () {\r",
+											"    pm.response.to.have.status(400);\r",
+											"});\r",
+											"\r",
+											"const response = pm.response.json();\r",
+											"\r",
+											"pm.test(\"Response matches error format\", function () {\r",
+											"    pm.expect(response.status).to.equal(400);\r",
+											"    pm.expect(response).to.have.property(\"title\");\r",
+											"    pm.expect(response).to.have.property(\"errors\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response title is helpful and accurate\", function () {\r",
+											"    pm.expect(response.title.toLowerCase()).to.contain(\"validation\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response errors include messages by property\", function () {\r",
+											"    pm.expect(response.errors.VendorId.length).to.equal(1);\r",
+											"    pm.expect(response.errors.VendorId[0]).to.contain(\"not found\");\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
 								}
-							}
-						},
-						"url": {
-							"raw": "{{API_URL}}/vendors/{{CreatedVendorId}}",
-							"host": [
-								"{{API_URL}}"
 							],
-							"path": [
-								"vendors",
-								"{{CreatedVendorId}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Vendors - Not Found",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is Not Found\", function () {\r",
-									"    pm.response.to.have.status(404);\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response matches error format\", function () {\r",
-									"    const response = pm.response.json();\r",
-									"\r",
-									"    pm.expect(response.status).to.equal(404);\r",
-									"    pm.expect(response).to.have.property(\"title\");\r",
-									"    pm.expect(response).to.have.property(\"errors\");\r",
-									"    pm.expect(response.errors).to.contain(response.title);\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response title is helpful and accurate\", function () {\r",
-									"    const response = pm.response.json();\r",
-									"\r",
-									"    pm.expect(response.title).to.contain(\"Not found\");\r",
-									"    pm.expect(response.title).to.contain(\"vendor\");\r",
-									"    pm.expect(response.title).to.contain(pm.collectionVariables.get(\"CreatedVendorId\"));\r",
-									"});\r",
-									"\r",
-									"pm.collectionVariables.unset(\"CreatedVendorId\");\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "DELETE",
-						"header": [],
-						"url": {
-							"raw": "{{API_URL}}/vendors/{{CreatedVendorId}}",
-							"host": [
-								"{{API_URL}}"
-							],
-							"path": [
-								"vendors",
-								"{{CreatedVendorId}}"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "Application",
-			"item": [
-				{
-					"name": "Applications",
-					"event": [
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									"pm.sendRequest({\r",
-									"  url: `${pm.variables.get(\"API_URL\")}/vendors`,\r",
-									"  method: 'POST',\r",
-									"  header: {\r",
-									"      \"Content-Type\": \"application/json\",\r",
-									"      \"Authorization\": `Bearer ${pm.collectionVariables.get(\"TOKEN\")}`\r",
-									"  },\r",
-									"  body: {\r",
-									"    mode: 'raw',\r",
-									"    raw:JSON.stringify({\r",
-									"      \"company\": \"Application Company\",\r",
-									"      \"namespacePrefixes\": \"uri://ed-fi.org\",\r",
-									"      \"contactName\": \"Application User\",\r",
-									"      \"contactEmailAddress\": \"application@example.com\"\r",
-									"    }), \r",
-									"  }\r",
-									"},  \r",
-									"function (err, response) {\r",
-									"  if(err) { console.log(\"Error in Pre-request:\", err); }\r",
-									"  const json = response.json();\r",
-									"  if(!json.result.vendorId) { console.log('Error in Pre-request: vendorID missing from response. Response is:', json); }\r",
-									"  else {\r",
-									"    pm.collectionVariables.set(\"ApplicationVendorId\", json.result.vendorId);\r",
-									"  }\r",
-									"});\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is Created\", function () {\r",
-									"    pm.response.to.have.status(201);\r",
-									"});\r",
-									"\r",
-									"const response = pm.response.json();\r",
-									"const result = pm.response.json().result;\r",
-									"\r",
-									"pm.test(\"Response matches success format\", function () {\r",
-									"    pm.expect(response.status).to.equal(201);\r",
-									"    pm.expect(response).to.have.property(\"title\");\r",
-									"    pm.expect(response).to.have.property(\"result\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response title is helpful and accurate\", function () {\r",
-									"    pm.expect(response.title.toLowerCase()).to.contain(\"application\");\r",
-									"    pm.expect(response.title.toLowerCase()).to.contain(\"created\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response includes location in header\", function () {\r",
-									"    pm.response.to.have.header(\"Location\");\r",
-									"    pm.response.to.be.header(\"Location\", `/applications/${result.applicationId}`);\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response result includes application key and secret\", function () {\r",
-									"    pm.expect(result).to.have.property(\"applicationId\");\r",
-									"    pm.expect(result).to.have.property(\"key\");\r",
-									"    pm.expect(result).to.have.property(\"secret\");\r",
-									"});\r",
-									"\r",
-									"if(result.applicationId) {\r",
-									"    pm.collectionVariables.set(\"CreatedApplicationId\", result.applicationId);\r",
-									"}\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n  \"applicationName\": \"Test Application\",\r\n  \"vendorId\": {{ApplicationVendorId}},\r\n  \"claimSetName\": \"Ed-Fi Sandbox\",\r\n  \"profileId\": null,\r\n  \"educationOrganizationIds\": [ 255901 ]\r\n}\r\n",
-							"options": {
-								"raw": {
-									"language": "json"
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"applicationName\": \"Test Application\",\r\n  \"vendorId\": 9999,\r\n  \"claimSetName\": \"Ed-Fi Sandbox\",\r\n  \"profileId\": null,\r\n  \"educationOrganizationIds\": [ 255901 ]\r\n}\r\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{API_URL}}/applications/",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"applications",
+										""
+									]
 								}
-							}
-						},
-						"url": {
-							"raw": "{{API_URL}}/applications/",
-							"host": [
-								"{{API_URL}}"
-							],
-							"path": [
-								"applications",
-								""
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Applications - Invalid",
-					"event": [
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
+							},
+							"response": []
 						},
 						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is Bad Request\", function () {\r",
-									"    pm.response.to.have.status(400);\r",
-									"});\r",
-									"\r",
-									"const response = pm.response.json();\r",
-									"\r",
-									"pm.test(\"Response matches error format\", function () {\r",
-									"    pm.expect(response.status).to.equal(400);\r",
-									"    pm.expect(response).to.have.property(\"title\");\r",
-									"    pm.expect(response).to.have.property(\"errors\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response title is helpful and accurate\", function () {\r",
-									"    pm.expect(response.title.toLowerCase()).to.contain(\"validation\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response errors include messages by property\", function () {\r",
-									"    pm.expect(response.errors[\"ApplicationName\"].length).to.equal(1);\r",
-									"    pm.expect(response.errors[\"ClaimSetName\"].length).to.equal(1);\r",
-									"    pm.expect(response.errors[\"EducationOrganizationIds\"].length).to.equal(1);\r",
-									"});\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n  \"applicationName\": \"\",\r\n  \"vendorId\": {{ApplicationVendorId}},\r\n  \"claimSetName\": \"\",\r\n  \"profileId\": null,\r\n  \"educationOrganizationIds\": []\r\n}\r\n",
-							"options": {
-								"raw": {
-									"language": "json"
+							"name": "Applications - Invalid Profile",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is Bad Request\", function () {\r",
+											"    pm.response.to.have.status(400);\r",
+											"});\r",
+											"\r",
+											"const response = pm.response.json();\r",
+											"const errors = pm.response.json().errors;\r",
+											"\r",
+											"pm.test(\"Response matches error format\", function () {\r",
+											"    pm.expect(response.status).to.equal(400);\r",
+											"    pm.expect(response).to.have.property(\"title\");\r",
+											"    pm.expect(response).to.have.property(\"errors\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response title is helpful and accurate\", function () {\r",
+											"    pm.expect(response.title.toLowerCase()).to.contain(\"validation\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response errors include messages by property\", function () {\r",
+											"    pm.expect(response.errors.ProfileId.length).to.equal(1);\r",
+											"    pm.expect(response.errors.ProfileId[0]).to.contain(\"not found\");\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
 								}
-							}
-						},
-						"url": {
-							"raw": "{{API_URL}}/applications/",
-							"host": [
-								"{{API_URL}}"
 							],
-							"path": [
-								"applications",
-								""
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Applications - Invalid Vendor",
-					"event": [
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is Bad Request\", function () {\r",
-									"    pm.response.to.have.status(400);\r",
-									"});\r",
-									"\r",
-									"const response = pm.response.json();\r",
-									"\r",
-									"pm.test(\"Response matches error format\", function () {\r",
-									"    pm.expect(response.status).to.equal(400);\r",
-									"    pm.expect(response).to.have.property(\"title\");\r",
-									"    pm.expect(response).to.have.property(\"errors\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response title is helpful and accurate\", function () {\r",
-									"    pm.expect(response.title.toLowerCase()).to.contain(\"validation\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response errors include messages by property\", function () {\r",
-									"    pm.expect(response.errors.VendorId.length).to.equal(1);\r",
-									"    pm.expect(response.errors.VendorId[0]).to.contain(\"not found\");\r",
-									"});\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n  \"applicationName\": \"Test Application\",\r\n  \"vendorId\": 9999,\r\n  \"claimSetName\": \"Ed-Fi Sandbox\",\r\n  \"profileId\": null,\r\n  \"educationOrganizationIds\": [ 255901 ]\r\n}\r\n",
-							"options": {
-								"raw": {
-									"language": "json"
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"applicationName\": \"Test Application\",\r\n  \"vendorId\": {{ApplicationVendorId}},\r\n  \"claimSetName\": \"Ed-Fi Sandbox\",\r\n  \"profileId\": 9999,\r\n  \"educationOrganizationIds\": [ 255901 ]\r\n}\r\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{API_URL}}/applications/",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"applications",
+										""
+									]
 								}
-							}
-						},
-						"url": {
-							"raw": "{{API_URL}}/applications/",
-							"host": [
-								"{{API_URL}}"
-							],
-							"path": [
-								"applications",
-								""
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Applications - Invalid Profile",
-					"event": [
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
+							},
+							"response": []
 						},
 						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is Bad Request\", function () {\r",
-									"    pm.response.to.have.status(400);\r",
-									"});\r",
-									"\r",
-									"const response = pm.response.json();\r",
-									"const errors = pm.response.json().errors;\r",
-									"\r",
-									"pm.test(\"Response matches error format\", function () {\r",
-									"    pm.expect(response.status).to.equal(400);\r",
-									"    pm.expect(response).to.have.property(\"title\");\r",
-									"    pm.expect(response).to.have.property(\"errors\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response title is helpful and accurate\", function () {\r",
-									"    pm.expect(response.title.toLowerCase()).to.contain(\"validation\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response errors include messages by property\", function () {\r",
-									"    pm.expect(response.errors.ProfileId.length).to.equal(1);\r",
-									"    pm.expect(response.errors.ProfileId[0]).to.contain(\"not found\");\r",
-									"});\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n  \"applicationName\": \"Test Application\",\r\n  \"vendorId\": {{ApplicationVendorId}},\r\n  \"claimSetName\": \"Ed-Fi Sandbox\",\r\n  \"profileId\": 9999,\r\n  \"educationOrganizationIds\": [ 255901 ]\r\n}\r\n",
-							"options": {
-								"raw": {
-									"language": "json"
+							"name": "Applications",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is OK\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											"\r",
+											"const response = pm.response.json();\r",
+											"const results = pm.response.json().result;\r",
+											"\r",
+											"pm.test(\"Response matches success format\", function () {\r",
+											"    pm.expect(response.status).to.equal(200);\r",
+											"    pm.expect(response).to.have.property(\"title\");\r",
+											"    pm.expect(response).to.have.property(\"result\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response result includes applications\", function () {\r",
+											"    pm.expect(results.length).to.be.greaterThan(0);\r",
+											"\r",
+											"    const indexOfApplication = results.map(\r",
+											"        function(application) { return application.applicationId; }\r",
+											"    ).indexOf(pm.collectionVariables.get(\"CreatedApplicationId\"));\r",
+											"\r",
+											"    const result = results[indexOfApplication];\r",
+											"    pm.expect(result.applicationName).to.equal(\"Test Application\");\r",
+											"    pm.expect(result.claimSetName).to.equal(\"Ed-Fi Sandbox\");\r",
+											"    pm.expect(result.educationOrganizationId).to.equal(255901);\r",
+											"    pm.expect(result.profileName).to.equal(null);\r",
+											"    pm.expect(result.odsInstanceName).to.equal(null);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response results do not include key or secret\", function () {\r",
+											"    results.forEach(function(result, i) {\r",
+											"        pm.expect(result).to.not.have.property(\"key\");\r",
+											"        pm.expect(result).to.not.have.property(\"secret\");\r",
+											"    });\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
 								}
-							}
-						},
-						"url": {
-							"raw": "{{API_URL}}/applications/",
-							"host": [
-								"{{API_URL}}"
 							],
-							"path": [
-								"applications",
-								""
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Applications",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is OK\", function () {\r",
-									"    pm.response.to.have.status(200);\r",
-									"});\r",
-									"\r",
-									"const response = pm.response.json();\r",
-									"const results = pm.response.json().result;\r",
-									"\r",
-									"pm.test(\"Response matches success format\", function () {\r",
-									"    pm.expect(response.status).to.equal(200);\r",
-									"    pm.expect(response).to.have.property(\"title\");\r",
-									"    pm.expect(response).to.have.property(\"result\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response result includes applications\", function () {\r",
-									"    pm.expect(results.length).to.be.greaterThan(0);\r",
-									"\r",
-									"    const indexOfApplication = results.map(\r",
-									"        function(application) { return application.applicationId; }\r",
-									"    ).indexOf(pm.collectionVariables.get(\"CreatedApplicationId\"));\r",
-									"\r",
-									"    const result = results[indexOfApplication];\r",
-									"    pm.expect(result.applicationName).to.equal(\"Test Application\");\r",
-									"    pm.expect(result.claimSetName).to.equal(\"Ed-Fi Sandbox\");\r",
-									"    pm.expect(result.educationOrganizationId).to.equal(255901);\r",
-									"    pm.expect(result.profileName).to.equal(null);\r",
-									"    pm.expect(result.odsInstanceName).to.equal(null);\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response results do not include key or secret\", function () {\r",
-									"    results.forEach(function(result, i) {\r",
-									"        pm.expect(result).to.not.have.property(\"key\");\r",
-									"        pm.expect(result).to.not.have.property(\"secret\");\r",
-									"    });\r",
-									"});\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{API_URL}}/applications/",
-							"host": [
-								"{{API_URL}}"
-							],
-							"path": [
-								"applications",
-								""
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Applications by ID",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is OK\", function () {\r",
-									"    pm.response.to.have.status(200);\r",
-									"});\r",
-									"\r",
-									"const response = pm.response.json();\r",
-									"const result = pm.response.json().result;\r",
-									"\r",
-									"pm.test(\"Response matches success format\", function () {\r",
-									"    pm.expect(response.status).to.equal(200);\r",
-									"    pm.expect(response).to.have.property(\"title\");\r",
-									"    pm.expect(response).to.have.property(\"result\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response result matches application\", function () {\r",
-									"    const applicationId = pm.collectionVariables.get(\"CreatedApplicationId\");\r",
-									"    \r",
-									"    pm.expect(result.applicationId).to.equal(applicationId);\r",
-									"    pm.expect(result.applicationName).to.equal(\"Test Application\");\r",
-									"    pm.expect(result.claimSetName).to.equal(\"Ed-Fi Sandbox\");\r",
-									"    pm.expect(result.educationOrganizationId).to.equal(255901);\r",
-									"    pm.expect(result.profileName).to.equal(null);\r",
-									"    pm.expect(result.odsInstanceName).to.equal(null);\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response result does not include key or secret\", function () {  \r",
-									"    pm.expect(result).to.not.have.property(\"key\");\r",
-									"    pm.expect(result).to.not.have.property(\"secret\");\r",
-									"});\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}",
-							"host": [
-								"{{API_URL}}"
-							],
-							"path": [
-								"applications",
-								"{{CreatedApplicationId}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Applications by Vendor",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is OK\", function () {\r",
-									"    pm.response.to.have.status(200);\r",
-									"});\r",
-									"\r",
-									"const response = pm.response.json();\r",
-									"const results = pm.response.json().result;\r",
-									"\r",
-									"pm.test(\"Response matches success format\", function () {\r",
-									"    pm.expect(response.status).to.equal(200);\r",
-									"    pm.expect(response).to.have.property(\"title\");\r",
-									"    pm.expect(response).to.have.property(\"result\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response result includes applications\", function () {\r",
-									"    pm.expect(results.length).to.be.greaterThan(0);\r",
-									"\r",
-									"    const indexOfApplication = results.map(\r",
-									"        function(application) { return application.applicationId; }\r",
-									"    ).indexOf(pm.collectionVariables.get(\"CreatedApplicationId\"));\r",
-									"\r",
-									"    const result = results[indexOfApplication];\r",
-									"    pm.expect(result.applicationName).to.equal(\"Test Application\");\r",
-									"    pm.expect(result.claimSetName).to.equal(\"Ed-Fi Sandbox\");\r",
-									"    pm.expect(result.educationOrganizationId).to.equal(255901);\r",
-									"    pm.expect(result.profileName).to.equal(null);\r",
-									"    pm.expect(result.odsInstanceName).to.equal(null);\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response result is filtered by vendor\", function () {\r",
-									"    const resultApplicationIds = results.map(\r",
-									"        function(application) { return application.applicationId; }\r",
-									"    );\r",
-									"\r",
-									"    pm.expect(resultApplicationIds).to.contain(pm.collectionVariables.get(\"CreatedApplicationId\"));\r",
-									"    pm.expect(resultApplicationIds).to.not.contain(pm.collectionVariables.get(\"OtherApplicationId\"));\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response results do not include key or secret\", function () {\r",
-									"    results.forEach(function(result, i) {\r",
-									"        pm.expect(result).to.not.have.property(\"key\");\r",
-									"        pm.expect(result).to.not.have.property(\"secret\");\r",
-									"    });\r",
-									"});\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									"pm.sendRequest({\r",
-									"  url: `${pm.variables.get(\"API_URL\")}/vendors`,\r",
-									"  method: 'POST',\r",
-									"  header: {\r",
-									"      \"Content-Type\": \"application/json\",\r",
-									"      \"Authorization\": `Bearer ${pm.collectionVariables.get(\"TOKEN\")}`\r",
-									"  },\r",
-									"  body: {\r",
-									"    mode: 'raw',\r",
-									"    raw:JSON.stringify({\r",
-									"      \"company\": \"Other Company\",\r",
-									"      \"namespacePrefixes\": \"uri://ed-fi.org\",\r",
-									"      \"contactName\": \"Other Application User\",\r",
-									"      \"contactEmailAddress\": \"otherapplication@example.com\"\r",
-									"    }), \r",
-									"  }\r",
-									"},\r",
-									"function (vendorErr, vendorResponse) {\r",
-									"  if(vendorErr) { console.log(\"Error in Pre-request:\", vendorErr); }\r",
-									"  const vendorJson = vendorResponse.json();\r",
-									"  if(!vendorJson.result.vendorId) { console.log('Error in Pre-request: vendorID missing from response. Response is:', vendorJson); }\r",
-									"  pm.collectionVariables.set(\"OtherApplicationVendorId\", vendorJson.result.vendorId);\r",
-									"\r",
-									"  pm.sendRequest({\r",
-									"    url: `${pm.variables.get(\"API_URL\")}/applications`,\r",
-									"    method: 'POST',\r",
-									"    header: {\r",
-									"        \"Content-Type\": \"application/json\",\r",
-									"        \"Authorization\": `Bearer ${pm.collectionVariables.get(\"TOKEN\")}`\r",
-									"    },\r",
-									"    body: {\r",
-									"      mode: 'raw',\r",
-									"      raw:JSON.stringify({\r",
-									"        \"applicationName\": \"Other Vendor Application\",\r",
-									"        \"vendorId\": pm.collectionVariables.get(\"OtherApplicationVendorId\"),\r",
-									"        \"claimSetName\": \"Ed-Fi Sandbox\",\r",
-									"        \"profileId\": null,\r",
-									"        \"educationOrganizationIds\": [ 255901 ]\r",
-									"      }),\r",
-									"    }\r",
-									"  },  \r",
-									"  function (appErr, appResonse) {\r",
-									"    if(appErr) { console.log(\"Error in Pre-request:\", appErr); }\r",
-									"    const appJson = appResonse.json();\r",
-									"    if(!appJson.result.applicationId) { console.log('Error in Pre-request: applicationId missing from response. Response is:', appJson); }\r",
-									"    else {\r",
-									"      pm.collectionVariables.set(\"OtherApplicationId\", appJson.result.applicationId);\r",
-									"    }\r",
-									"  });\r",
-									"});\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{API_URL}}/vendors/{{ApplicationVendorId}}/applications",
-							"host": [
-								"{{API_URL}}"
-							],
-							"path": [
-								"vendors",
-								"{{ApplicationVendorId}}",
-								"applications"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Applications",
-					"event": [
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is OK\", function () {\r",
-									"    pm.response.to.have.status(200);\r",
-									"});\r",
-									"\r",
-									"const response = pm.response.json();\r",
-									"const result = pm.response.json().result;\r",
-									"\r",
-									"pm.test(\"Response matches success format\", function () {\r",
-									"    pm.expect(response.status).to.equal(200);\r",
-									"    pm.expect(response).to.have.property(\"title\");\r",
-									"    pm.expect(response).to.have.property(\"result\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response title is helpful and accurate\", function () {\r",
-									"    pm.expect(response.title.toLowerCase()).to.contain(\"application\");\r",
-									"    pm.expect(response.title.toLowerCase()).to.contain(\"updated\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response result includes updated application\", function () {\r",
-									"    pm.expect(result.applicationName).to.equal(\"Updated Application Name\");\r",
-									"    pm.expect(result.claimSetName).to.equal(\"Ed-Fi ODS Admin App\");\r",
-									"    pm.expect(result.educationOrganizationId).to.equal(1234);\r",
-									"    pm.expect(result.profileName).to.equal(null);\r",
-									"    pm.expect(result.odsInstanceName).to.equal(null);\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response result does not include application key and secret\", function () {\r",
-									"    pm.expect(result).to.not.have.property(\"key\");\r",
-									"    pm.expect(result).to.not.have.property(\"secret\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Request updated Application/Vendor relationship\", function () {\r",
-									"    pm.sendRequest({\r",
-									"      url: `${pm.variables.get(\"API_URL\")}/vendors/${pm.collectionVariables.get(\"ApplicationVendorId\")}/applications`,\r",
-									"      method: 'GET',\r",
-									"      header: {\r",
-									"          \"Content-Type\": \"application/json\",\r",
-									"          \"Authorization\": `Bearer ${pm.collectionVariables.get(\"TOKEN\")}`\r",
-									"      },\r",
-									"      body: {\r",
-									"        mode: 'raw',\r",
-									"        raw:JSON.stringify({\r",
-									"          \"company\": \"Application Company\",\r",
-									"          \"namespacePrefixes\": \"uri://ed-fi.org\",\r",
-									"          \"contactName\": \"Application User\",\r",
-									"          \"contactEmailAddress\": \"application@example.com\"\r",
-									"        }), \r",
-									"      }\r",
-									"  },  \r",
-									"  function (err, response) {\r",
-									"    if(err) { console.log(\"Error in test request:\", err); }\r",
-									"    if(response.code != 200) { console.log('Error in  test request. Response is:', response); }\r",
-									"    const results = response.json().result;\r",
-									"    pm.expect(results.length).to.equal(0);\r",
-									"  });\r",
-									"});\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n  \"applicationId\": {{CreatedApplicationId}},\r\n  \"applicationName\": \"Updated Application Name\",\r\n  \"vendorId\": {{OtherApplicationVendorId}},\r\n  \"claimSetName\": \"Ed-Fi ODS Admin App\",\r\n  \"profileId\": null,\r\n  \"educationOrganizationIds\": [1234]\r\n}\r\n",
-							"options": {
-								"raw": {
-									"language": "json"
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{API_URL}}/applications/",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"applications",
+										""
+									]
 								}
-							}
-						},
-						"url": {
-							"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}",
-							"host": [
-								"{{API_URL}}"
-							],
-							"path": [
-								"applications",
-								"{{CreatedApplicationId}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Applications - Invalid",
-					"event": [
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
+							},
+							"response": []
 						},
 						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is Bad Request\", function () {\r",
-									"    pm.response.to.have.status(400);\r",
-									"});\r",
-									"\r",
-									"const response = pm.response.json();\r",
-									"\r",
-									"pm.test(\"Response matches error format\", function () {\r",
-									"    pm.expect(response.status).to.equal(400);\r",
-									"    pm.expect(response).to.have.property(\"title\");\r",
-									"    pm.expect(response).to.have.property(\"errors\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response title is helpful and accurate\", function () {\r",
-									"    pm.expect(response.title.toLowerCase()).to.contain(\"validation\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response errors include messages by property\", function () {\r",
-									"    pm.expect(response.errors[\"ApplicationName\"].length).to.equal(1);\r",
-									"    pm.expect(response.errors[\"ClaimSetName\"].length).to.equal(1);\r",
-									"    pm.expect(response.errors[\"EducationOrganizationIds\"].length).to.equal(1);\r",
-									"});\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n  \"applicationId\": {{CreatedApplicationId}},\r\n  \"applicationName\": \"\",\r\n  \"vendorId\": {{OtherApplicationVendorId}},\r\n  \"claimSetName\": \"\",\r\n  \"profileId\": null,\r\n  \"educationOrganizationIds\": []\r\n}\r\n",
-							"options": {
-								"raw": {
-									"language": "json"
+							"name": "Applications by ID",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is OK\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											"\r",
+											"const response = pm.response.json();\r",
+											"const result = pm.response.json().result;\r",
+											"\r",
+											"pm.test(\"Response matches success format\", function () {\r",
+											"    pm.expect(response.status).to.equal(200);\r",
+											"    pm.expect(response).to.have.property(\"title\");\r",
+											"    pm.expect(response).to.have.property(\"result\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response result matches application\", function () {\r",
+											"    const applicationId = pm.collectionVariables.get(\"CreatedApplicationId\");\r",
+											"    \r",
+											"    pm.expect(result.applicationId).to.equal(applicationId);\r",
+											"    pm.expect(result.applicationName).to.equal(\"Test Application\");\r",
+											"    pm.expect(result.claimSetName).to.equal(\"Ed-Fi Sandbox\");\r",
+											"    pm.expect(result.educationOrganizationId).to.equal(255901);\r",
+											"    pm.expect(result.profileName).to.equal(null);\r",
+											"    pm.expect(result.odsInstanceName).to.equal(null);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response result does not include key or secret\", function () {  \r",
+											"    pm.expect(result).to.not.have.property(\"key\");\r",
+											"    pm.expect(result).to.not.have.property(\"secret\");\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
 								}
-							}
-						},
-						"url": {
-							"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}",
-							"host": [
-								"{{API_URL}}"
 							],
-							"path": [
-								"applications",
-								"{{CreatedApplicationId}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Applications - Invalid Vendor",
-					"event": [
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is Bad Request\", function () {\r",
-									"    pm.response.to.have.status(400);\r",
-									"});\r",
-									"\r",
-									"const response = pm.response.json();\r",
-									"\r",
-									"pm.test(\"Response matches error format\", function () {\r",
-									"    pm.expect(response.status).to.equal(400);\r",
-									"    pm.expect(response).to.have.property(\"title\");\r",
-									"    pm.expect(response).to.have.property(\"errors\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response title is helpful and accurate\", function () {\r",
-									"    pm.expect(response.title.toLowerCase()).to.contain(\"validation\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response errors include messages by property\", function () {\r",
-									"    pm.expect(response.errors.VendorId.length).to.equal(1);\r",
-									"    pm.expect(response.errors.VendorId[0]).to.contain(\"not found\");\r",
-									"});\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n  \"applicationId\": {{CreatedApplicationId}},\r\n  \"applicationName\": \"Updated Application Name\",\r\n  \"vendorId\": 9999,\r\n  \"claimSetName\": \"Ed-Fi ODS Admin App\",\r\n  \"profileId\": null,\r\n  \"educationOrganizationIds\": [1234]\r\n}\r\n",
-							"options": {
-								"raw": {
-									"language": "json"
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"applications",
+										"{{CreatedApplicationId}}"
+									]
 								}
-							}
-						},
-						"url": {
-							"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}",
-							"host": [
-								"{{API_URL}}"
-							],
-							"path": [
-								"applications",
-								"{{CreatedApplicationId}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Applications - Invalid Profile",
-					"event": [
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									""
-								],
-								"type": "text/javascript"
-							}
+							},
+							"response": []
 						},
 						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is Bad Request\", function () {\r",
-									"    pm.response.to.have.status(400);\r",
-									"});\r",
-									"\r",
-									"const response = pm.response.json();\r",
-									"const errors = pm.response.json().errors;\r",
-									"\r",
-									"pm.test(\"Response matches error format\", function () {\r",
-									"    pm.expect(response.status).to.equal(400);\r",
-									"    pm.expect(response).to.have.property(\"title\");\r",
-									"    pm.expect(response).to.have.property(\"errors\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response title is helpful and accurate\", function () {\r",
-									"    pm.expect(response.title.toLowerCase()).to.contain(\"validation\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response errors include messages by property\", function () {\r",
-									"    pm.expect(response.errors.ProfileId.length).to.equal(1);\r",
-									"    pm.expect(response.errors.ProfileId[0]).to.contain(\"not found\");\r",
-									"});\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n  \"applicationId\": {{CreatedApplicationId}},\r\n  \"applicationName\": \"Updated Application Name\",\r\n  \"vendorId\": {{OtherApplicationVendorId}},\r\n  \"claimSetName\": \"Ed-Fi ODS Admin App\",\r\n  \"profileId\": 9999,\r\n  \"educationOrganizationIds\": [1234]\r\n}\r\n",
-							"options": {
-								"raw": {
-									"language": "json"
+							"name": "Applications by Vendor",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is OK\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											"\r",
+											"const response = pm.response.json();\r",
+											"const results = pm.response.json().result;\r",
+											"\r",
+											"pm.test(\"Response matches success format\", function () {\r",
+											"    pm.expect(response.status).to.equal(200);\r",
+											"    pm.expect(response).to.have.property(\"title\");\r",
+											"    pm.expect(response).to.have.property(\"result\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response result includes applications\", function () {\r",
+											"    pm.expect(results.length).to.be.greaterThan(0);\r",
+											"\r",
+											"    const indexOfApplication = results.map(\r",
+											"        function(application) { return application.applicationId; }\r",
+											"    ).indexOf(pm.collectionVariables.get(\"CreatedApplicationId\"));\r",
+											"\r",
+											"    const result = results[indexOfApplication];\r",
+											"    pm.expect(result.applicationName).to.equal(\"Test Application\");\r",
+											"    pm.expect(result.claimSetName).to.equal(\"Ed-Fi Sandbox\");\r",
+											"    pm.expect(result.educationOrganizationId).to.equal(255901);\r",
+											"    pm.expect(result.profileName).to.equal(null);\r",
+											"    pm.expect(result.odsInstanceName).to.equal(null);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response result is filtered by vendor\", function () {\r",
+											"    const resultApplicationIds = results.map(\r",
+											"        function(application) { return application.applicationId; }\r",
+											"    );\r",
+											"\r",
+											"    pm.expect(resultApplicationIds).to.contain(pm.collectionVariables.get(\"CreatedApplicationId\"));\r",
+											"    pm.expect(resultApplicationIds).to.not.contain(pm.collectionVariables.get(\"OtherApplicationId\"));\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response results do not include key or secret\", function () {\r",
+											"    results.forEach(function(result, i) {\r",
+											"        pm.expect(result).to.not.have.property(\"key\");\r",
+											"        pm.expect(result).to.not.have.property(\"secret\");\r",
+											"    });\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"pm.sendRequest({\r",
+											"  url: `${pm.variables.get(\"API_URL\")}/vendors`,\r",
+											"  method: 'POST',\r",
+											"  header: {\r",
+											"      \"Content-Type\": \"application/json\",\r",
+											"      \"Authorization\": `Bearer ${pm.collectionVariables.get(\"TOKEN\")}`\r",
+											"  },\r",
+											"  body: {\r",
+											"    mode: 'raw',\r",
+											"    raw:JSON.stringify({\r",
+											"      \"company\": \"Other Company\",\r",
+											"      \"namespacePrefixes\": \"uri://ed-fi.org\",\r",
+											"      \"contactName\": \"Other Application User\",\r",
+											"      \"contactEmailAddress\": \"otherapplication@example.com\"\r",
+											"    }), \r",
+											"  }\r",
+											"},\r",
+											"function (vendorErr, vendorResponse) {\r",
+											"  if(vendorErr) { console.log(\"Error in Pre-request:\", vendorErr); }\r",
+											"  const vendorJson = vendorResponse.json();\r",
+											"  if(!vendorJson.result.vendorId) { console.log('Error in Pre-request: vendorID missing from response. Response is:', vendorJson); }\r",
+											"  pm.collectionVariables.set(\"OtherApplicationVendorId\", vendorJson.result.vendorId);\r",
+											"\r",
+											"  pm.sendRequest({\r",
+											"    url: `${pm.variables.get(\"API_URL\")}/applications`,\r",
+											"    method: 'POST',\r",
+											"    header: {\r",
+											"        \"Content-Type\": \"application/json\",\r",
+											"        \"Authorization\": `Bearer ${pm.collectionVariables.get(\"TOKEN\")}`\r",
+											"    },\r",
+											"    body: {\r",
+											"      mode: 'raw',\r",
+											"      raw:JSON.stringify({\r",
+											"        \"applicationName\": \"Other Vendor Application\",\r",
+											"        \"vendorId\": pm.collectionVariables.get(\"OtherApplicationVendorId\"),\r",
+											"        \"claimSetName\": \"Ed-Fi Sandbox\",\r",
+											"        \"profileId\": null,\r",
+											"        \"educationOrganizationIds\": [ 255901 ]\r",
+											"      }),\r",
+											"    }\r",
+											"  },  \r",
+											"  function (appErr, appResonse) {\r",
+											"    if(appErr) { console.log(\"Error in Pre-request:\", appErr); }\r",
+											"    const appJson = appResonse.json();\r",
+											"    if(!appJson.result.applicationId) { console.log('Error in Pre-request: applicationId missing from response. Response is:', appJson); }\r",
+											"    else {\r",
+											"      pm.collectionVariables.set(\"OtherApplicationId\", appJson.result.applicationId);\r",
+											"    }\r",
+											"  });\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
 								}
-							}
-						},
-						"url": {
-							"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}",
-							"host": [
-								"{{API_URL}}"
 							],
-							"path": [
-								"applications",
-								"{{CreatedApplicationId}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Reset Credential",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is OK\", function () {\r",
-									"    pm.response.to.have.status(200);\r",
-									"});\r",
-									"\r",
-									"const response = pm.response.json();\r",
-									"const result = pm.response.json().result;\r",
-									"\r",
-									"pm.test(\"Response matches success format\", function () {\r",
-									"    pm.expect(response.status).to.equal(200);\r",
-									"    pm.expect(response).to.have.property(\"title\");\r",
-									"    pm.expect(response).to.have.property(\"result\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response title is helpful and accurate\", function () {\r",
-									"    pm.expect(response.title.toLowerCase()).to.contain(\"application\");\r",
-									"    pm.expect(response.title.toLowerCase()).to.contain(\"updated\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response result includes application key and secret\", function () {\r",
-									"    pm.expect(result).to.have.property(\"applicationId\");\r",
-									"    pm.expect(result).to.have.property(\"key\");\r",
-									"    pm.expect(result).to.have.property(\"secret\");\r",
-									"});\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"url": {
-							"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}/reset-credential",
-							"host": [
-								"{{API_URL}}"
-							],
-							"path": [
-								"applications",
-								"{{CreatedApplicationId}}",
-								"reset-credential"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Applications",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is OK\", function () {\r",
-									"    pm.response.to.have.status(200);\r",
-									"});\r",
-									"\r",
-									"const response = pm.response.json();\r",
-									"\r",
-									"pm.test(\"Response matches success format\", function () {\r",
-									"    pm.expect(response.status).to.equal(200);\r",
-									"    pm.expect(response).to.have.property(\"title\");\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response title is helpful and accurate\", function () {\r",
-									"    pm.expect(response.title.toLowerCase()).to.contain(\"application\");\r",
-									"    pm.expect(response.title.toLowerCase()).to.contain(\"deleted\");\r",
-									"});\r",
-									"\r",
-									"pm.collectionVariables.unset(\"OtherApplicationVendorId\");\r",
-									"pm.collectionVariables.unset(\"OtherApplicationId\");\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "DELETE",
-						"header": [],
-						"url": {
-							"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}",
-							"host": [
-								"{{API_URL}}"
-							],
-							"path": [
-								"applications",
-								"{{CreatedApplicationId}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Applications - Not Found",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is Not Found\", function () {\r",
-									"    pm.response.to.have.status(404);\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response matches error format\", function () {\r",
-									"    const response = pm.response.json();\r",
-									"\r",
-									"    pm.expect(response.status).to.equal(404);\r",
-									"    pm.expect(response).to.have.property(\"title\");\r",
-									"    pm.expect(response).to.have.property(\"errors\");\r",
-									"    pm.expect(response.errors).to.contain(response.title);\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response title is helpful and accurate\", function () {\r",
-									"    const response = pm.response.json();\r",
-									"\r",
-									"    pm.expect(response.title).to.contain(\"Not found\");\r",
-									"    pm.expect(response.title).to.contain(\"application\");\r",
-									"    pm.expect(response.title).to.contain(pm.collectionVariables.get(\"CreatedApplicationId\"));\r",
-									"});\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}",
-							"host": [
-								"{{API_URL}}"
-							],
-							"path": [
-								"applications",
-								"{{CreatedApplicationId}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Reset Credential - Not Found",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is Not Found\", function () {\r",
-									"    pm.response.to.have.status(404);\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response matches error format\", function () {\r",
-									"    const response = pm.response.json();\r",
-									"\r",
-									"    pm.expect(response.status).to.equal(404);\r",
-									"    pm.expect(response).to.have.property(\"title\");\r",
-									"    pm.expect(response).to.have.property(\"errors\");\r",
-									"    pm.expect(response.errors).to.contain(response.title);\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response title is helpful and accurate\", function () {\r",
-									"    const response = pm.response.json();\r",
-									"\r",
-									"    pm.expect(response.title).to.contain(\"Not found\");\r",
-									"    pm.expect(response.title).to.contain(\"application\");\r",
-									"    pm.expect(response.title).to.contain(pm.collectionVariables.get(\"CreatedApplicationId\"));\r",
-									"});\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"url": {
-							"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}/reset-credential",
-							"host": [
-								"{{API_URL}}"
-							],
-							"path": [
-								"applications",
-								"{{CreatedApplicationId}}",
-								"reset-credential"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Applications - Not Found",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is Not Found\", function () {\r",
-									"    pm.response.to.have.status(404);\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response matches error format\", function () {\r",
-									"    const response = pm.response.json();\r",
-									"\r",
-									"    pm.expect(response.status).to.equal(404);\r",
-									"    pm.expect(response).to.have.property(\"title\");\r",
-									"    pm.expect(response).to.have.property(\"errors\");\r",
-									"    pm.expect(response.errors).to.contain(response.title);\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response title is helpful and accurate\", function () {\r",
-									"    const response = pm.response.json();\r",
-									"\r",
-									"    pm.expect(response.title).to.contain(\"Not found\");\r",
-									"    pm.expect(response.title).to.contain(\"application\");\r",
-									"    pm.expect(response.title).to.contain(pm.collectionVariables.get(\"CreatedApplicationId\"));\r",
-									"});\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n  \"applicationId\": {{CreatedApplicationId}},\r\n  \"applicationName\": \"Test Application\",\r\n  \"vendorId\": {{ApplicationVendorId}},\r\n  \"claimSetName\": \"Ed-Fi Sandbox\",\r\n  \"profileId\": null,\r\n  \"educationOrganizationIds\": [ 255901 ]\r\n}\r\n",
-							"options": {
-								"raw": {
-									"language": "json"
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{API_URL}}/vendors/{{ApplicationVendorId}}/applications",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"vendors",
+										"{{ApplicationVendorId}}",
+										"applications"
+									]
 								}
-							}
+							},
+							"response": []
 						},
-						"url": {
-							"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}",
-							"host": [
-								"{{API_URL}}"
-							],
-							"path": [
-								"applications",
-								"{{CreatedApplicationId}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Applications - Not Found",
-					"event": [
 						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is Not Found\", function () {\r",
-									"    pm.response.to.have.status(404);\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response matches error format\", function () {\r",
-									"    const response = pm.response.json();\r",
-									"\r",
-									"    pm.expect(response.status).to.equal(404);\r",
-									"    pm.expect(response).to.have.property(\"title\");\r",
-									"    pm.expect(response).to.have.property(\"errors\");\r",
-									"    pm.expect(response.errors).to.contain(response.title);\r",
-									"});\r",
-									"\r",
-									"pm.test(\"Response title is helpful and accurate\", function () {\r",
-									"    const response = pm.response.json();\r",
-									"\r",
-									"    pm.expect(response.title).to.contain(\"Not found\");\r",
-									"    pm.expect(response.title).to.contain(\"application\");\r",
-									"    pm.expect(response.title).to.contain(pm.collectionVariables.get(\"CreatedApplicationId\"));\r",
-									"});\r",
-									"\r",
-									"pm.collectionVariables.unset(\"ApplicationVendorId\");\r",
-									"pm.collectionVariables.unset(\"CreatedApplicationId\");\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "DELETE",
-						"header": [],
-						"url": {
-							"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}",
-							"host": [
-								"{{API_URL}}"
+							"name": "Applications",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is OK\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											"\r",
+											"const response = pm.response.json();\r",
+											"const result = pm.response.json().result;\r",
+											"\r",
+											"pm.test(\"Response matches success format\", function () {\r",
+											"    pm.expect(response.status).to.equal(200);\r",
+											"    pm.expect(response).to.have.property(\"title\");\r",
+											"    pm.expect(response).to.have.property(\"result\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response title is helpful and accurate\", function () {\r",
+											"    pm.expect(response.title.toLowerCase()).to.contain(\"application\");\r",
+											"    pm.expect(response.title.toLowerCase()).to.contain(\"updated\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response result includes updated application\", function () {\r",
+											"    pm.expect(result.applicationName).to.equal(\"Updated Application Name\");\r",
+											"    pm.expect(result.claimSetName).to.equal(\"Ed-Fi ODS Admin App\");\r",
+											"    pm.expect(result.educationOrganizationId).to.equal(1234);\r",
+											"    pm.expect(result.profileName).to.equal(null);\r",
+											"    pm.expect(result.odsInstanceName).to.equal(null);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response result does not include application key and secret\", function () {\r",
+											"    pm.expect(result).to.not.have.property(\"key\");\r",
+											"    pm.expect(result).to.not.have.property(\"secret\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Request updated Application/Vendor relationship\", function () {\r",
+											"    pm.sendRequest({\r",
+											"      url: `${pm.variables.get(\"API_URL\")}/vendors/${pm.collectionVariables.get(\"ApplicationVendorId\")}/applications`,\r",
+											"      method: 'GET',\r",
+											"      header: {\r",
+											"          \"Content-Type\": \"application/json\",\r",
+											"          \"Authorization\": `Bearer ${pm.collectionVariables.get(\"TOKEN\")}`\r",
+											"      },\r",
+											"      body: {\r",
+											"        mode: 'raw',\r",
+											"        raw:JSON.stringify({\r",
+											"          \"company\": \"Application Company\",\r",
+											"          \"namespacePrefixes\": \"uri://ed-fi.org\",\r",
+											"          \"contactName\": \"Application User\",\r",
+											"          \"contactEmailAddress\": \"application@example.com\"\r",
+											"        }), \r",
+											"      }\r",
+											"  },  \r",
+											"  function (err, response) {\r",
+											"    if(err) { console.log(\"Error in test request:\", err); }\r",
+											"    if(response.code != 200) { console.log('Error in  test request. Response is:', response); }\r",
+											"    const results = response.json().result;\r",
+											"    pm.expect(results.length).to.equal(0);\r",
+											"  });\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
 							],
-							"path": [
-								"applications",
-								"{{CreatedApplicationId}}"
-							]
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"applicationId\": {{CreatedApplicationId}},\r\n  \"applicationName\": \"Updated Application Name\",\r\n  \"vendorId\": {{OtherApplicationVendorId}},\r\n  \"claimSetName\": \"Ed-Fi ODS Admin App\",\r\n  \"profileId\": null,\r\n  \"educationOrganizationIds\": [1234]\r\n}\r\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"applications",
+										"{{CreatedApplicationId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Applications - Invalid",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is Bad Request\", function () {\r",
+											"    pm.response.to.have.status(400);\r",
+											"});\r",
+											"\r",
+											"const response = pm.response.json();\r",
+											"\r",
+											"pm.test(\"Response matches error format\", function () {\r",
+											"    pm.expect(response.status).to.equal(400);\r",
+											"    pm.expect(response).to.have.property(\"title\");\r",
+											"    pm.expect(response).to.have.property(\"errors\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response title is helpful and accurate\", function () {\r",
+											"    pm.expect(response.title.toLowerCase()).to.contain(\"validation\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response errors include messages by property\", function () {\r",
+											"    pm.expect(response.errors[\"ApplicationName\"].length).to.equal(1);\r",
+											"    pm.expect(response.errors[\"ClaimSetName\"].length).to.equal(1);\r",
+											"    pm.expect(response.errors[\"EducationOrganizationIds\"].length).to.equal(1);\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"applicationId\": {{CreatedApplicationId}},\r\n  \"applicationName\": \"\",\r\n  \"vendorId\": {{OtherApplicationVendorId}},\r\n  \"claimSetName\": \"\",\r\n  \"profileId\": null,\r\n  \"educationOrganizationIds\": []\r\n}\r\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"applications",
+										"{{CreatedApplicationId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Applications - Invalid Vendor",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is Bad Request\", function () {\r",
+											"    pm.response.to.have.status(400);\r",
+											"});\r",
+											"\r",
+											"const response = pm.response.json();\r",
+											"\r",
+											"pm.test(\"Response matches error format\", function () {\r",
+											"    pm.expect(response.status).to.equal(400);\r",
+											"    pm.expect(response).to.have.property(\"title\");\r",
+											"    pm.expect(response).to.have.property(\"errors\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response title is helpful and accurate\", function () {\r",
+											"    pm.expect(response.title.toLowerCase()).to.contain(\"validation\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response errors include messages by property\", function () {\r",
+											"    pm.expect(response.errors.VendorId.length).to.equal(1);\r",
+											"    pm.expect(response.errors.VendorId[0]).to.contain(\"not found\");\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"applicationId\": {{CreatedApplicationId}},\r\n  \"applicationName\": \"Updated Application Name\",\r\n  \"vendorId\": 9999,\r\n  \"claimSetName\": \"Ed-Fi ODS Admin App\",\r\n  \"profileId\": null,\r\n  \"educationOrganizationIds\": [1234]\r\n}\r\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"applications",
+										"{{CreatedApplicationId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Applications - Invalid Profile",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is Bad Request\", function () {\r",
+											"    pm.response.to.have.status(400);\r",
+											"});\r",
+											"\r",
+											"const response = pm.response.json();\r",
+											"const errors = pm.response.json().errors;\r",
+											"\r",
+											"pm.test(\"Response matches error format\", function () {\r",
+											"    pm.expect(response.status).to.equal(400);\r",
+											"    pm.expect(response).to.have.property(\"title\");\r",
+											"    pm.expect(response).to.have.property(\"errors\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response title is helpful and accurate\", function () {\r",
+											"    pm.expect(response.title.toLowerCase()).to.contain(\"validation\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response errors include messages by property\", function () {\r",
+											"    pm.expect(response.errors.ProfileId.length).to.equal(1);\r",
+											"    pm.expect(response.errors.ProfileId[0]).to.contain(\"not found\");\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"applicationId\": {{CreatedApplicationId}},\r\n  \"applicationName\": \"Updated Application Name\",\r\n  \"vendorId\": {{OtherApplicationVendorId}},\r\n  \"claimSetName\": \"Ed-Fi ODS Admin App\",\r\n  \"profileId\": 9999,\r\n  \"educationOrganizationIds\": [1234]\r\n}\r\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"applications",
+										"{{CreatedApplicationId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Reset Credential",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is OK\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											"\r",
+											"const response = pm.response.json();\r",
+											"const result = pm.response.json().result;\r",
+											"\r",
+											"pm.test(\"Response matches success format\", function () {\r",
+											"    pm.expect(response.status).to.equal(200);\r",
+											"    pm.expect(response).to.have.property(\"title\");\r",
+											"    pm.expect(response).to.have.property(\"result\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response title is helpful and accurate\", function () {\r",
+											"    pm.expect(response.title.toLowerCase()).to.contain(\"application\");\r",
+											"    pm.expect(response.title.toLowerCase()).to.contain(\"updated\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response result includes application key and secret\", function () {\r",
+											"    pm.expect(result).to.have.property(\"applicationId\");\r",
+											"    pm.expect(result).to.have.property(\"key\");\r",
+											"    pm.expect(result).to.have.property(\"secret\");\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}/reset-credential",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"applications",
+										"{{CreatedApplicationId}}",
+										"reset-credential"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Applications",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is OK\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											"\r",
+											"const response = pm.response.json();\r",
+											"\r",
+											"pm.test(\"Response matches success format\", function () {\r",
+											"    pm.expect(response.status).to.equal(200);\r",
+											"    pm.expect(response).to.have.property(\"title\");\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response title is helpful and accurate\", function () {\r",
+											"    pm.expect(response.title.toLowerCase()).to.contain(\"application\");\r",
+											"    pm.expect(response.title.toLowerCase()).to.contain(\"deleted\");\r",
+											"});\r",
+											"\r",
+											"pm.collectionVariables.unset(\"OtherApplicationVendorId\");\r",
+											"pm.collectionVariables.unset(\"OtherApplicationId\");\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"applications",
+										"{{CreatedApplicationId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Applications - Not Found",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is Not Found\", function () {\r",
+											"    pm.response.to.have.status(404);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response matches error format\", function () {\r",
+											"    const response = pm.response.json();\r",
+											"\r",
+											"    pm.expect(response.status).to.equal(404);\r",
+											"    pm.expect(response).to.have.property(\"title\");\r",
+											"    pm.expect(response).to.have.property(\"errors\");\r",
+											"    pm.expect(response.errors).to.contain(response.title);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response title is helpful and accurate\", function () {\r",
+											"    const response = pm.response.json();\r",
+											"\r",
+											"    pm.expect(response.title).to.contain(\"Not found\");\r",
+											"    pm.expect(response.title).to.contain(\"application\");\r",
+											"    pm.expect(response.title).to.contain(pm.collectionVariables.get(\"CreatedApplicationId\"));\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"applications",
+										"{{CreatedApplicationId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Reset Credential - Not Found",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is Not Found\", function () {\r",
+											"    pm.response.to.have.status(404);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response matches error format\", function () {\r",
+											"    const response = pm.response.json();\r",
+											"\r",
+											"    pm.expect(response.status).to.equal(404);\r",
+											"    pm.expect(response).to.have.property(\"title\");\r",
+											"    pm.expect(response).to.have.property(\"errors\");\r",
+											"    pm.expect(response.errors).to.contain(response.title);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response title is helpful and accurate\", function () {\r",
+											"    const response = pm.response.json();\r",
+											"\r",
+											"    pm.expect(response.title).to.contain(\"Not found\");\r",
+											"    pm.expect(response.title).to.contain(\"application\");\r",
+											"    pm.expect(response.title).to.contain(pm.collectionVariables.get(\"CreatedApplicationId\"));\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}/reset-credential",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"applications",
+										"{{CreatedApplicationId}}",
+										"reset-credential"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Applications - Not Found",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is Not Found\", function () {\r",
+											"    pm.response.to.have.status(404);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response matches error format\", function () {\r",
+											"    const response = pm.response.json();\r",
+											"\r",
+											"    pm.expect(response.status).to.equal(404);\r",
+											"    pm.expect(response).to.have.property(\"title\");\r",
+											"    pm.expect(response).to.have.property(\"errors\");\r",
+											"    pm.expect(response.errors).to.contain(response.title);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response title is helpful and accurate\", function () {\r",
+											"    const response = pm.response.json();\r",
+											"\r",
+											"    pm.expect(response.title).to.contain(\"Not found\");\r",
+											"    pm.expect(response.title).to.contain(\"application\");\r",
+											"    pm.expect(response.title).to.contain(pm.collectionVariables.get(\"CreatedApplicationId\"));\r",
+											"});\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"applicationId\": {{CreatedApplicationId}},\r\n  \"applicationName\": \"Test Application\",\r\n  \"vendorId\": {{ApplicationVendorId}},\r\n  \"claimSetName\": \"Ed-Fi Sandbox\",\r\n  \"profileId\": null,\r\n  \"educationOrganizationIds\": [ 255901 ]\r\n}\r\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"applications",
+										"{{CreatedApplicationId}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Applications - Not Found",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is Not Found\", function () {\r",
+											"    pm.response.to.have.status(404);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response matches error format\", function () {\r",
+											"    const response = pm.response.json();\r",
+											"\r",
+											"    pm.expect(response.status).to.equal(404);\r",
+											"    pm.expect(response).to.have.property(\"title\");\r",
+											"    pm.expect(response).to.have.property(\"errors\");\r",
+											"    pm.expect(response.errors).to.contain(response.title);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Response title is helpful and accurate\", function () {\r",
+											"    const response = pm.response.json();\r",
+											"\r",
+											"    pm.expect(response.title).to.contain(\"Not found\");\r",
+											"    pm.expect(response.title).to.contain(\"application\");\r",
+											"    pm.expect(response.title).to.contain(pm.collectionVariables.get(\"CreatedApplicationId\"));\r",
+											"});\r",
+											"\r",
+											"pm.collectionVariables.unset(\"ApplicationVendorId\");\r",
+											"pm.collectionVariables.unset(\"CreatedApplicationId\");\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"applications",
+										"{{CreatedApplicationId}}"
+									]
+								}
+							},
+							"response": []
 						}
-					},
-					"response": []
+					]
 				}
 			]
 		}

--- a/Application/EdFi.Ods.Admin.Api/E2E Tests/Admin API E2E.postman_collection.json
+++ b/Application/EdFi.Ods.Admin.Api/E2E Tests/Admin API E2E.postman_collection.json
@@ -726,11 +726,12 @@
 									}
 								},
 								"url": {
-									"raw": "{{API_URL}}/vendors",
+									"raw": "{{API_URL}}/v1/vendors",
 									"host": [
 										"{{API_URL}}"
 									],
 									"path": [
+										"v1",
 										"vendors"
 									]
 								}
@@ -837,11 +838,12 @@
 									}
 								},
 								"url": {
-									"raw": "{{API_URL}}/vendors",
+									"raw": "{{API_URL}}/v1/vendors",
 									"host": [
 										"{{API_URL}}"
 									],
 									"path": [
+										"v1",
 										"vendors"
 									]
 								}
@@ -903,11 +905,12 @@
 									}
 								},
 								"url": {
-									"raw": "{{API_URL}}/vendors",
+									"raw": "{{API_URL}}/v1/vendors",
 									"host": [
 										"{{API_URL}}"
 									],
 									"path": [
+										"v1",
 										"vendors"
 									]
 								}
@@ -953,11 +956,12 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{API_URL}}/vendors/{{CreatedVendorId}}",
+									"raw": "{{API_URL}}/v1/vendors/{{CreatedVendorId}}",
 									"host": [
 										"{{API_URL}}"
 									],
 									"path": [
+										"v1",
 										"vendors",
 										"{{CreatedVendorId}}"
 									]
@@ -1024,11 +1028,12 @@
 									}
 								},
 								"url": {
-									"raw": "{{API_URL}}/vendors/{{CreatedVendorId}}",
+									"raw": "{{API_URL}}/v1/vendors/{{CreatedVendorId}}",
 									"host": [
 										"{{API_URL}}"
 									],
 									"path": [
+										"v1",
 										"vendors",
 										"{{CreatedVendorId}}"
 									]
@@ -1092,11 +1097,12 @@
 									}
 								},
 								"url": {
-									"raw": "{{API_URL}}/vendors/{{CreatedVendorId}}",
+									"raw": "{{API_URL}}/v1/vendors/{{CreatedVendorId}}",
 									"host": [
 										"{{API_URL}}"
 									],
 									"path": [
+										"v1",
 										"vendors",
 										"{{CreatedVendorId}}"
 									]
@@ -1136,11 +1142,12 @@
 								"method": "DELETE",
 								"header": [],
 								"url": {
-									"raw": "{{API_URL}}/vendors/{{CreatedVendorId}}",
+									"raw": "{{API_URL}}/v1/vendors/{{CreatedVendorId}}",
 									"host": [
 										"{{API_URL}}"
 									],
 									"path": [
+										"v1",
 										"vendors",
 										"{{CreatedVendorId}}"
 									]
@@ -1185,11 +1192,12 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{API_URL}}/vendors/{{CreatedVendorId}}",
+									"raw": "{{API_URL}}/v1/vendors/{{CreatedVendorId}}",
 									"host": [
 										"{{API_URL}}"
 									],
 									"path": [
+										"v1",
 										"vendors",
 										"{{CreatedVendorId}}"
 									]
@@ -1243,11 +1251,12 @@
 									}
 								},
 								"url": {
-									"raw": "{{API_URL}}/vendors/{{CreatedVendorId}}",
+									"raw": "{{API_URL}}/v1/vendors/{{CreatedVendorId}}",
 									"host": [
 										"{{API_URL}}"
 									],
 									"path": [
+										"v1",
 										"vendors",
 										"{{CreatedVendorId}}"
 									]
@@ -1294,11 +1303,12 @@
 								"method": "DELETE",
 								"header": [],
 								"url": {
-									"raw": "{{API_URL}}/vendors/{{CreatedVendorId}}",
+									"raw": "{{API_URL}}/v1/vendors/{{CreatedVendorId}}",
 									"host": [
 										"{{API_URL}}"
 									],
 									"path": [
+										"v1",
 										"vendors",
 										"{{CreatedVendorId}}"
 									]
@@ -1319,7 +1329,7 @@
 									"script": {
 										"exec": [
 											"pm.sendRequest({\r",
-											"  url: `${pm.variables.get(\"API_URL\")}/vendors`,\r",
+											"  url: `${pm.variables.get(\"API_URL\")}/v1/vendors`,\r",
 											"  method: 'POST',\r",
 											"  header: {\r",
 											"      \"Content-Type\": \"application/json\",\r",
@@ -1403,11 +1413,12 @@
 									}
 								},
 								"url": {
-									"raw": "{{API_URL}}/applications/",
+									"raw": "{{API_URL}}/v1/applications/",
 									"host": [
 										"{{API_URL}}"
 									],
 									"path": [
+										"v1",
 										"applications",
 										""
 									]
@@ -1471,11 +1482,12 @@
 									}
 								},
 								"url": {
-									"raw": "{{API_URL}}/applications/",
+									"raw": "{{API_URL}}/v1/applications/",
 									"host": [
 										"{{API_URL}}"
 									],
 									"path": [
+										"v1",
 										"applications",
 										""
 									]
@@ -1538,11 +1550,12 @@
 									}
 								},
 								"url": {
-									"raw": "{{API_URL}}/applications/",
+									"raw": "{{API_URL}}/v1/applications/",
 									"host": [
 										"{{API_URL}}"
 									],
 									"path": [
+										"v1",
 										"applications",
 										""
 									]
@@ -1606,11 +1619,12 @@
 									}
 								},
 								"url": {
-									"raw": "{{API_URL}}/applications/",
+									"raw": "{{API_URL}}/v1/applications/",
 									"host": [
 										"{{API_URL}}"
 									],
 									"path": [
+										"v1",
 										"applications",
 										""
 									]
@@ -1669,11 +1683,12 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{API_URL}}/applications/",
+									"raw": "{{API_URL}}/v1/applications/",
 									"host": [
 										"{{API_URL}}"
 									],
 									"path": [
+										"v1",
 										"applications",
 										""
 									]
@@ -1726,11 +1741,12 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}",
+									"raw": "{{API_URL}}/v1/applications/{{CreatedApplicationId}}",
 									"host": [
 										"{{API_URL}}"
 									],
 									"path": [
+										"v1",
 										"applications",
 										"{{CreatedApplicationId}}"
 									]
@@ -1798,7 +1814,7 @@
 									"script": {
 										"exec": [
 											"pm.sendRequest({\r",
-											"  url: `${pm.variables.get(\"API_URL\")}/vendors`,\r",
+											"  url: `${pm.variables.get(\"API_URL\")}/v1/vendors`,\r",
 											"  method: 'POST',\r",
 											"  header: {\r",
 											"      \"Content-Type\": \"application/json\",\r",
@@ -1821,7 +1837,7 @@
 											"  pm.collectionVariables.set(\"OtherApplicationVendorId\", vendorJson.result.vendorId);\r",
 											"\r",
 											"  pm.sendRequest({\r",
-											"    url: `${pm.variables.get(\"API_URL\")}/applications`,\r",
+											"    url: `${pm.variables.get(\"API_URL\")}/v1/applications`,\r",
 											"    method: 'POST',\r",
 											"    header: {\r",
 											"        \"Content-Type\": \"application/json\",\r",
@@ -1857,11 +1873,12 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{API_URL}}/vendors/{{ApplicationVendorId}}/applications",
+									"raw": "{{API_URL}}/v1/vendors/{{ApplicationVendorId}}/applications",
 									"host": [
 										"{{API_URL}}"
 									],
 									"path": [
+										"v1",
 										"vendors",
 										"{{ApplicationVendorId}}",
 										"applications"
@@ -1919,7 +1936,7 @@
 											"\r",
 											"pm.test(\"Request updated Application/Vendor relationship\", function () {\r",
 											"    pm.sendRequest({\r",
-											"      url: `${pm.variables.get(\"API_URL\")}/vendors/${pm.collectionVariables.get(\"ApplicationVendorId\")}/applications`,\r",
+											"      url: `${pm.variables.get(\"API_URL\")}/v1/vendors/${pm.collectionVariables.get(\"ApplicationVendorId\")}/applications`,\r",
 											"      method: 'GET',\r",
 											"      header: {\r",
 											"          \"Content-Type\": \"application/json\",\r",
@@ -1961,11 +1978,12 @@
 									}
 								},
 								"url": {
-									"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}",
+									"raw": "{{API_URL}}/v1/applications/{{CreatedApplicationId}}",
 									"host": [
 										"{{API_URL}}"
 									],
 									"path": [
+										"v1",
 										"applications",
 										"{{CreatedApplicationId}}"
 									]
@@ -2029,11 +2047,12 @@
 									}
 								},
 								"url": {
-									"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}",
+									"raw": "{{API_URL}}/v1/applications/{{CreatedApplicationId}}",
 									"host": [
 										"{{API_URL}}"
 									],
 									"path": [
+										"v1",
 										"applications",
 										"{{CreatedApplicationId}}"
 									]
@@ -2096,11 +2115,12 @@
 									}
 								},
 								"url": {
-									"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}",
+									"raw": "{{API_URL}}/v1/applications/{{CreatedApplicationId}}",
 									"host": [
 										"{{API_URL}}"
 									],
 									"path": [
+										"v1",
 										"applications",
 										"{{CreatedApplicationId}}"
 									]
@@ -2164,11 +2184,12 @@
 									}
 								},
 								"url": {
-									"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}",
+									"raw": "{{API_URL}}/v1/applications/{{CreatedApplicationId}}",
 									"host": [
 										"{{API_URL}}"
 									],
 									"path": [
+										"v1",
 										"applications",
 										"{{CreatedApplicationId}}"
 									]
@@ -2216,11 +2237,12 @@
 								"method": "PUT",
 								"header": [],
 								"url": {
-									"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}/reset-credential",
+									"raw": "{{API_URL}}/v1/applications/{{CreatedApplicationId}}/reset-credential",
 									"host": [
 										"{{API_URL}}"
 									],
 									"path": [
+										"v1",
 										"applications",
 										"{{CreatedApplicationId}}",
 										"reset-credential"
@@ -2264,11 +2286,12 @@
 								"method": "DELETE",
 								"header": [],
 								"url": {
-									"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}",
+									"raw": "{{API_URL}}/v1/applications/{{CreatedApplicationId}}",
 									"host": [
 										"{{API_URL}}"
 									],
 									"path": [
+										"v1",
 										"applications",
 										"{{CreatedApplicationId}}"
 									]
@@ -2313,11 +2336,12 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}",
+									"raw": "{{API_URL}}/v1/applications/{{CreatedApplicationId}}",
 									"host": [
 										"{{API_URL}}"
 									],
 									"path": [
+										"v1",
 										"applications",
 										"{{CreatedApplicationId}}"
 									]
@@ -2362,11 +2386,12 @@
 								"method": "PUT",
 								"header": [],
 								"url": {
-									"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}/reset-credential",
+									"raw": "{{API_URL}}/v1/applications/{{CreatedApplicationId}}/reset-credential",
 									"host": [
 										"{{API_URL}}"
 									],
 									"path": [
+										"v1",
 										"applications",
 										"{{CreatedApplicationId}}",
 										"reset-credential"
@@ -2421,11 +2446,12 @@
 									}
 								},
 								"url": {
-									"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}",
+									"raw": "{{API_URL}}/v1/applications/{{CreatedApplicationId}}",
 									"host": [
 										"{{API_URL}}"
 									],
 									"path": [
+										"v1",
 										"applications",
 										"{{CreatedApplicationId}}"
 									]
@@ -2473,11 +2499,12 @@
 								"method": "DELETE",
 								"header": [],
 								"url": {
-									"raw": "{{API_URL}}/applications/{{CreatedApplicationId}}",
+									"raw": "{{API_URL}}/v1/applications/{{CreatedApplicationId}}",
 									"host": [
 										"{{API_URL}}"
 									],
 									"path": [
+										"v1",
 										"applications",
 										"{{CreatedApplicationId}}"
 									]

--- a/Application/EdFi.Ods.Admin.Api/EdFi.Ods.Admin.Api.csproj
+++ b/Application/EdFi.Ods.Admin.Api/EdFi.Ods.Admin.Api.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Asp.Versioning.Http" Version="6.0.0-preview.3" />
     <PackageReference Include="AutoMapper" Version="11.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
     <PackageReference Include="FluentValidation" Version="10.4.0" />

--- a/Application/EdFi.Ods.Admin.Api/Features/Applications/AddApplication.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/Applications/AddApplication.cs
@@ -18,7 +18,9 @@ namespace EdFi.Ods.Admin.Api.Features.Applications
     {
         public void MapEndpoints(IEndpointRouteBuilder endpoints)
         {
-            endpoints.MapPostWithDefaultOptions($"/{FeatureConstants.Applications}", Handle, FeatureConstants.Applications);
+            AdminApiEndpointBuilder.MapPost(endpoints, $"/{FeatureConstants.Applications}", Handle)
+                .WithRouteOptions(rhb => rhb.WithDefaultPostOptions(FeatureConstants.Applications))
+                .BuildForVersions(AdminApiVersions.V1);
         }
 
         public async Task<IResult> Handle(Validator validator, IAddApplicationCommand addApplicationCommand, IMapper mapper, IUsersContext db, Request request)

--- a/Application/EdFi.Ods.Admin.Api/Features/Applications/DeleteApplication.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/Applications/DeleteApplication.cs
@@ -6,13 +6,15 @@
 using EdFi.Ods.Admin.Api.Infrastructure;
 using EdFi.Ods.AdminApp.Management.Database.Commands;
 
-namespace EdFi.Ods.Admin.Api.Features.Vendors
+namespace EdFi.Ods.Admin.Api.Features.Applications
 {
     public class DeleteApplication : IFeature
     {
         public void MapEndpoints(IEndpointRouteBuilder endpoints)
         {
-            endpoints.MapDeleteWithDefaultOptions($"/{FeatureConstants.Applications}" + "/{id}", Handle, FeatureConstants.Applications);
+            AdminApiEndpointBuilder.MapDelete(endpoints, $"/{FeatureConstants.Applications}" + "/{id}", Handle)
+                .WithRouteOptions(rhb => rhb.WithDefaultDeleteOptions(FeatureConstants.Applications))
+                .BuildForVersions(AdminApiVersions.V1);
         }
 
         public Task<IResult> Handle(IDeleteApplicationCommand deleteApplicationCommand, int id)

--- a/Application/EdFi.Ods.Admin.Api/Features/Applications/EditApplication.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/Applications/EditApplication.cs
@@ -19,7 +19,9 @@ namespace EdFi.Ods.Admin.Api.Features.Applications
     {
         public void MapEndpoints(IEndpointRouteBuilder endpoints)
         {
-            endpoints.MapPutWithDefaultOptions($"/{FeatureConstants.Applications}" + "/{id}", Handle, FeatureConstants.Applications);
+            AdminApiEndpointBuilder.MapPut(endpoints, $"/{FeatureConstants.Applications}" + "/{id}", Handle)
+                .WithRouteOptions(rhb => rhb.WithDefaultPutOptions(FeatureConstants.Applications))
+                .BuildForVersions(AdminApiVersions.V1);
         }
 
         public async Task<IResult> Handle(IEditApplicationCommand editApplicationCommand, IMapper mapper,

--- a/Application/EdFi.Ods.Admin.Api/Features/Applications/ReadApplication.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/Applications/ReadApplication.cs
@@ -14,8 +14,13 @@ public class ReadApplication : IFeature
 {
     public void MapEndpoints(IEndpointRouteBuilder endpoints)
     {
-        endpoints.MapGetWithDefaultOptions($"/{FeatureConstants.Applications}", GetApplications, FeatureConstants.Applications);
-        endpoints.MapGetByIdWithDefaultOptions($"/{FeatureConstants.Applications}" + "/{id}", GetApplication, FeatureConstants.Applications);
+        AdminApiEndpointBuilder.MapGet(endpoints, $"/{FeatureConstants.Applications}", GetApplications)
+            .WithRouteOptions(rhb => rhb.WithDefaultGetOptions(FeatureConstants.Applications))
+            .BuildForVersions(AdminApiVersions.V1);
+
+        AdminApiEndpointBuilder.MapGet(endpoints, $"/{FeatureConstants.Applications}" + "/{id}", GetApplication)
+            .WithRouteOptions(rhb => rhb.WithDefaultGetByIdOptions(FeatureConstants.Applications))
+            .BuildForVersions(AdminApiVersions.V1);
     }
 
     internal Task<IResult> GetApplications(IGetVendorsQuery getVendorsAndApplicationsQuery, IMapper mapper)

--- a/Application/EdFi.Ods.Admin.Api/Features/Applications/ReadApplicationsByVendor.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/Applications/ReadApplicationsByVendor.cs
@@ -14,7 +14,10 @@ public class ReadApplicationsByVendor : IFeature
     public void MapEndpoints(IEndpointRouteBuilder endpoints)
     {
         var url = $"{FeatureConstants.Vendors}/"+"{id}"+$"/{FeatureConstants.Applications}";
-        endpoints.MapGetByIdWithDefaultOptions(url , GetVendorApplications, FeatureConstants.Vendors);
+
+        AdminApiEndpointBuilder.MapGet(endpoints, url, GetVendorApplications)
+            .WithRouteOptions(rhb => rhb.WithDefaultGetOptions(FeatureConstants.Vendors))
+            .BuildForVersions(AdminApiVersions.V1);
     }
 
     internal Task<IResult> GetVendorApplications(GetApplicationsByVendorIdQuery getApplicationByVendorIdQuery, IMapper mapper, int id)

--- a/Application/EdFi.Ods.Admin.Api/Features/Applications/ResetApplicationCredentials.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/Applications/ResetApplicationCredentials.cs
@@ -13,7 +13,9 @@ public class ResetApplicationCredentials : IFeature
 {
     public void MapEndpoints(IEndpointRouteBuilder endpoints)
     {
-        endpoints.MapPutWithDefaultOptions($"/{FeatureConstants.Applications}" + "/{id}/reset-credential", HandleResetCredentials, FeatureConstants.Applications);
+        AdminApiEndpointBuilder.MapPut(endpoints, $"/{FeatureConstants.Applications}" + "/{id}/reset-credential", HandleResetCredentials)
+            .WithRouteOptions(rhb => rhb.WithDefaultPutOptions(FeatureConstants.Applications))
+            .BuildForVersions(AdminApiVersions.V1);
     }
 
     public async Task<IResult> HandleResetCredentials(RegenerateApiClientSecretCommand resetSecretCommand, IMapper mapper, int id)

--- a/Application/EdFi.Ods.Admin.Api/Features/ClaimSets/ReadClaimSets.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/ClaimSets/ReadClaimSets.cs
@@ -12,7 +12,9 @@ public class ReadClaimSets : IFeature
 {
     public void MapEndpoints(IEndpointRouteBuilder endpoints)
     {
-        endpoints.MapGetWithDefaultOptions($"/{FeatureConstants.ClaimSets}", GetClaimSets, FeatureConstants.ClaimSets);
+        AdminApiEndpointBuilder.MapGet(endpoints, $"/{FeatureConstants.ClaimSets}", GetClaimSets)
+            .WithRouteOptions(rhb => rhb.WithDefaultGetOptions(FeatureConstants.ClaimSets))
+            .BuildForVersions(AdminApiVersions.V1);
     }
 
     internal Task<IResult> GetClaimSets(GetClaimSetNamesQuery getClaimSetsQuery)

--- a/Application/EdFi.Ods.Admin.Api/Features/Vendors/AddVendor.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/Vendors/AddVendor.cs
@@ -17,7 +17,10 @@ namespace EdFi.Ods.Admin.Api.Features.Vendors
     {
         public void MapEndpoints(IEndpointRouteBuilder endpoints)
         {
-            endpoints.MapPostWithDefaultOptions($"/{FeatureConstants.Vendors}", Handle, FeatureConstants.Vendors);
+            AdminApiEndpointBuilder
+                .MapPost(endpoints, $"/{FeatureConstants.Vendors}", Handle)
+                .WithRouteOptions(rhb => rhb.WithDefaultPostOptions(FeatureConstants.Vendors))
+                .BuildForVersions(AdminApiVersions.V1);
         }
 
         public async Task<IResult> Handle(Validator validator, AddVendorCommand addVendorCommand, IMapper mapper, Request request)

--- a/Application/EdFi.Ods.Admin.Api/Features/Vendors/DeleteVendor.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/Vendors/DeleteVendor.cs
@@ -12,7 +12,9 @@ namespace EdFi.Ods.Admin.Api.Features.Vendors
     {
         public void MapEndpoints(IEndpointRouteBuilder endpoints)
         {
-            endpoints.MapDeleteWithDefaultOptions($"/{FeatureConstants.Vendors}" + "/{id}", Handle, FeatureConstants.Vendors);
+            AdminApiEndpointBuilder.MapDelete(endpoints, $"/{FeatureConstants.Vendors}" + "/{id}", Handle)
+                .WithRouteOptions(rhb => rhb.WithDefaultDeleteOptions(FeatureConstants.Vendors))
+                .BuildForVersions(AdminApiVersions.V1);
         }
 
         public Task<IResult> Handle(DeleteVendorCommand deleteVendorCommand, int id)

--- a/Application/EdFi.Ods.Admin.Api/Features/Vendors/EditVendor.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/Vendors/EditVendor.cs
@@ -17,7 +17,9 @@ namespace EdFi.Ods.Admin.Api.Features.Vendors
     {
         public void MapEndpoints(IEndpointRouteBuilder endpoints)
         {
-            endpoints.MapPutWithDefaultOptions($"/{FeatureConstants.Vendors}" + "/{id}", Handle, FeatureConstants.Vendors);
+            AdminApiEndpointBuilder.MapPut(endpoints, $"/{FeatureConstants.Vendors}" + "/{id}", Handle)
+                .WithRouteOptions(rhb => rhb.WithDefaultPutOptions(FeatureConstants.Vendors))
+                .BuildForVersions(AdminApiVersions.V1);
         }
 
         public async Task<IResult> Handle(EditVendorCommand editVendorCommand, IMapper mapper,

--- a/Application/EdFi.Ods.Admin.Api/Features/Vendors/ReadVendor.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/Vendors/ReadVendor.cs
@@ -17,11 +17,11 @@ public class ReadVendor : IFeature
     {
         AdminApiEndpointBuilder.MapGet(endpoints, $"{FeatureConstants.Vendors}", GetVendors)
             .WithRouteOptions(rhb => EndpointExtensions.DefaultGetOptions(rhb, FeatureConstants.Vendors))
-            .BuildForVersions("v1", "v2");
+            .BuildForVersions(AdminApiVersions.V1, AdminApiVersions.V2);
 
         AdminApiEndpointBuilder.MapGet(endpoints, $"/{FeatureConstants.Vendors}" + "/{id}", GetVendor)
             .WithRouteOptions(rhb => EndpointExtensions.DefaultGetOptions(rhb, FeatureConstants.Vendors))
-            .BuildForVersions("v1", "v2");
+            .BuildForVersions(AdminApiVersions.V1, AdminApiVersions.V2);
     }
 
     internal Task<IResult> GetVendors(IGetVendorsQuery getVendorsQuery, IMapper mapper)

--- a/Application/EdFi.Ods.Admin.Api/Features/Vendors/ReadVendor.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/Vendors/ReadVendor.cs
@@ -16,11 +16,11 @@ public class ReadVendor : IFeature
     {
         AdminApiEndpointBuilder.MapGet(endpoints, $"{FeatureConstants.Vendors}", GetVendors)
             .WithRouteOptions(rhb => rhb.WithDefaultGetOptions(FeatureConstants.Vendors))
-            .BuildForVersions(AdminApiVersions.V1, AdminApiVersions.V2);
+            .BuildForVersions(AdminApiVersions.V1);
 
         AdminApiEndpointBuilder.MapGet(endpoints, $"/{FeatureConstants.Vendors}" + "/{id}", GetVendor)
             .WithRouteOptions(rhb => rhb.WithDefaultGetByIdOptions(FeatureConstants.Vendors))
-            .BuildForVersions(AdminApiVersions.V1, AdminApiVersions.V2);
+            .BuildForVersions(AdminApiVersions.V1);
     }
 
     internal Task<IResult> GetVendors(IGetVendorsQuery getVendorsQuery, IMapper mapper)

--- a/Application/EdFi.Ods.Admin.Api/Features/Vendors/ReadVendor.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/Vendors/ReadVendor.cs
@@ -7,7 +7,6 @@ using AutoMapper;
 using EdFi.Ods.Admin.Api.Infrastructure;
 using EdFi.Ods.AdminApp.Management.Database.Queries;
 using EdFi.Ods.AdminApp.Management.ErrorHandling;
-using EndpointExtensions = EdFi.Ods.Admin.Api.Infrastructure.EndpointRouteBuilderExtensions;
 
 namespace EdFi.Ods.Admin.Api.Features.Vendors;
 
@@ -16,11 +15,17 @@ public class ReadVendor : IFeature
     public void MapEndpoints(IEndpointRouteBuilder endpoints)
     {
         AdminApiEndpointBuilder.MapGet(endpoints, $"{FeatureConstants.Vendors}", GetVendors)
-            .WithRouteOptions(rhb => EndpointExtensions.DefaultGetOptions(rhb, FeatureConstants.Vendors))
+            .WithRouteOptions(rhb =>
+            {
+                rhb.WithDefaultGetOptions(FeatureConstants.Vendors);
+            })
             .BuildForVersions(AdminApiVersions.V1, AdminApiVersions.V2);
 
         AdminApiEndpointBuilder.MapGet(endpoints, $"/{FeatureConstants.Vendors}" + "/{id}", GetVendor)
-            .WithRouteOptions(rhb => EndpointExtensions.DefaultGetOptions(rhb, FeatureConstants.Vendors))
+            .WithRouteOptions(rhb =>
+            {
+                rhb.WithDefaultGetOptions(FeatureConstants.Vendors);
+            })
             .BuildForVersions(AdminApiVersions.V1, AdminApiVersions.V2);
     }
 

--- a/Application/EdFi.Ods.Admin.Api/Features/Vendors/ReadVendor.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/Vendors/ReadVendor.cs
@@ -15,17 +15,11 @@ public class ReadVendor : IFeature
     public void MapEndpoints(IEndpointRouteBuilder endpoints)
     {
         AdminApiEndpointBuilder.MapGet(endpoints, $"{FeatureConstants.Vendors}", GetVendors)
-            .WithRouteOptions(rhb =>
-            {
-                rhb.WithDefaultGetOptions(FeatureConstants.Vendors);
-            })
+            .WithRouteOptions(rhb => rhb.WithDefaultGetOptions(FeatureConstants.Vendors))
             .BuildForVersions(AdminApiVersions.V1, AdminApiVersions.V2);
 
         AdminApiEndpointBuilder.MapGet(endpoints, $"/{FeatureConstants.Vendors}" + "/{id}", GetVendor)
-            .WithRouteOptions(rhb =>
-            {
-                rhb.WithDefaultGetOptions(FeatureConstants.Vendors);
-            })
+            .WithRouteOptions(rhb => rhb.WithDefaultGetByIdOptions(FeatureConstants.Vendors))
             .BuildForVersions(AdminApiVersions.V1, AdminApiVersions.V2);
     }
 

--- a/Application/EdFi.Ods.Admin.Api/Features/Vendors/ReadVendor.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/Vendors/ReadVendor.cs
@@ -7,6 +7,7 @@ using AutoMapper;
 using EdFi.Ods.Admin.Api.Infrastructure;
 using EdFi.Ods.AdminApp.Management.Database.Queries;
 using EdFi.Ods.AdminApp.Management.ErrorHandling;
+using EndpointExtensions = EdFi.Ods.Admin.Api.Infrastructure.EndpointRouteBuilderExtensions;
 
 namespace EdFi.Ods.Admin.Api.Features.Vendors;
 
@@ -14,8 +15,13 @@ public class ReadVendor : IFeature
 {
     public void MapEndpoints(IEndpointRouteBuilder endpoints)
     {
-        endpoints.MapGetWithDefaultOptions($"/{FeatureConstants.Vendors}", GetVendors, FeatureConstants.Vendors);
-        endpoints.MapGetByIdWithDefaultOptions($"/{FeatureConstants.Vendors}" + "/{id}", GetVendor, FeatureConstants.Vendors);
+        AdminApiEndpointBuilder.MapGet(endpoints, $"{FeatureConstants.Vendors}", GetVendors)
+            .WithRouteOptions(rhb => EndpointExtensions.DefaultGetOptions(rhb, FeatureConstants.Vendors))
+            .BuildForVersions("v1", "v2");
+
+        AdminApiEndpointBuilder.MapGet(endpoints, $"/{FeatureConstants.Vendors}" + "/{id}", GetVendor)
+            .WithRouteOptions(rhb => EndpointExtensions.DefaultGetOptions(rhb, FeatureConstants.Vendors))
+            .BuildForVersions("v1", "v2");
     }
 
     internal Task<IResult> GetVendors(IGetVendorsQuery getVendorsQuery, IMapper mapper)

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiEndpointBuilder.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiEndpointBuilder.cs
@@ -20,6 +20,7 @@ public class AdminApiEndpointBuilder
     private readonly HttpVerb _verb;
     private string _route;
     private Delegate _handler;
+    private List<Action<RouteHandlerBuilder>> _routeOptions = new();
 
     public static AdminApiEndpointBuilder MapGet(IEndpointRouteBuilder endpoints, string route, Delegate handler)
         => new(endpoints, HttpVerb.GET, route, handler);
@@ -47,9 +48,19 @@ public class AdminApiEndpointBuilder
                 HttpVerb.DELETE => _endpoints.MapDelete(versionedRoute, _handler),
                 _ => throw new ArgumentOutOfRangeException($"Unconfigured HTTP verb for mapping: {_}")
             };
+
+            foreach (var action in _routeOptions)
+            {
+                action(builder);
+            }
         }
     }
 
-    private enum HttpVerb { GET, POST, PUT, DELETE }
+    public AdminApiEndpointBuilder WithRouteOptions(Action<RouteHandlerBuilder> routeHandlerBuilderAction)
+    {
+        _routeOptions.Add(routeHandlerBuilderAction);
+        return this;
+    }
 
+    private enum HttpVerb { GET, POST, PUT, DELETE }
 }

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiEndpointBuilder.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiEndpointBuilder.cs
@@ -37,7 +37,7 @@ public class AdminApiEndpointBuilder
     public void BuildForVersions(params AdminApiVersions.AdminApiVersion[] versions)
     {
         if(versions.Length == 0) throw new ArgumentException("Must register for at least 1 version");
-        if(string.IsNullOrEmpty(_route)) throw new Exception("Invalid endpoint registration. Route must be specified");
+        if(_route == null) throw new Exception("Invalid endpoint registration. Route must be specified");
 
         foreach (var version in versions)
         {

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiEndpointBuilder.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiEndpointBuilder.cs
@@ -34,13 +34,15 @@ public class AdminApiEndpointBuilder
     public static AdminApiEndpointBuilder MapDelete(IEndpointRouteBuilder endpoints, string route, Delegate handler)
         => new(endpoints, HttpVerb.DELETE, route, handler);
 
-    public void BuildForVersions(params string[] versions)
+    public void BuildForVersions(params AdminApiVersions.AdminApiVersion[] versions)
     {
         if(versions.Length == 0) throw new ArgumentException("Must register for at least 1 version");
         if(string.IsNullOrEmpty(_route)) throw new Exception("Invalid endpoint registration. Route must be specified");
 
         foreach (var version in versions)
         {
+            if(version == null) throw new ArgumentException("Version cannot be null");
+
             var versionedRoute = $"/{version}/{_route}";
 
             var builder = _verb switch
@@ -52,7 +54,7 @@ public class AdminApiEndpointBuilder
                 _ => throw new ArgumentOutOfRangeException($"Unconfigured HTTP verb for mapping: {_verb}")
             };
 
-            builder.WithGroupName(version);
+            builder.WithGroupName(version.ToString());
 
             foreach (var action in _routeOptions)
             {

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiEndpointBuilder.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiEndpointBuilder.cs
@@ -17,10 +17,10 @@ public class AdminApiEndpointBuilder
     }
 
     private readonly IEndpointRouteBuilder _endpoints;
-    private readonly HttpVerb _verb;
-    private string _route;
-    private Delegate _handler;
-    private List<Action<RouteHandlerBuilder>> _routeOptions = new();
+    private readonly HttpVerb? _verb;
+    private readonly string? _route;
+    private readonly Delegate? _handler;
+    private readonly List<Action<RouteHandlerBuilder>> _routeOptions = new();
 
     public static AdminApiEndpointBuilder MapGet(IEndpointRouteBuilder endpoints, string route, Delegate handler)
         => new(endpoints, HttpVerb.GET, route, handler);
@@ -38,6 +38,7 @@ public class AdminApiEndpointBuilder
     {
         if(versions.Length == 0) throw new ArgumentException("Must register for at least 1 version");
         if(_route == null) throw new Exception("Invalid endpoint registration. Route must be specified");
+        if(_handler == null) throw new Exception("Invalid endpoint registration. Handler must be specified");
 
         foreach (var version in versions)
         {

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiEndpointBuilder.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiEndpointBuilder.cs
@@ -12,7 +12,7 @@ public class AdminApiEndpointBuilder
     {
         _endpoints = endpoints;
         _verb = verb;
-        _route = route;
+        _route = route.Trim('/');
         _handler = handler;
     }
 

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiEndpointBuilder.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiEndpointBuilder.cs
@@ -52,6 +52,8 @@ public class AdminApiEndpointBuilder
                 _ => throw new ArgumentOutOfRangeException($"Unconfigured HTTP verb for mapping: {_verb}")
             };
 
+            builder.WithGroupName(version);
+
             foreach (var action in _routeOptions)
             {
                 action(builder);

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiEndpointBuilder.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiEndpointBuilder.cs
@@ -36,9 +36,12 @@ public class AdminApiEndpointBuilder
 
     public void BuildForVersions(params string[] versions)
     {
+        if(versions.Length == 0) throw new ArgumentException("Must register for at least 1 version");
+        if(string.IsNullOrEmpty(_route)) throw new Exception("Invalid endpoint registration. Route must be specified");
+
         foreach (var version in versions)
         {
-            var versionedRoute = $"{version}/{_route}";
+            var versionedRoute = $"/{version}/{_route}";
 
             var builder = _verb switch
             {
@@ -46,7 +49,7 @@ public class AdminApiEndpointBuilder
                 HttpVerb.POST => _endpoints.MapPost(versionedRoute, _handler),
                 HttpVerb.PUT => _endpoints.MapPut(versionedRoute, _handler),
                 HttpVerb.DELETE => _endpoints.MapDelete(versionedRoute, _handler),
-                _ => throw new ArgumentOutOfRangeException($"Unconfigured HTTP verb for mapping: {_}")
+                _ => throw new ArgumentOutOfRangeException($"Unconfigured HTTP verb for mapping: {_verb}")
             };
 
             foreach (var action in _routeOptions)

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiEndpointBuilder.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiEndpointBuilder.cs
@@ -1,0 +1,55 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.Ods.Admin.Api.Infrastructure;
+
+public class AdminApiEndpointBuilder
+{
+    private AdminApiEndpointBuilder(IEndpointRouteBuilder endpoints,
+        HttpVerb verb, string route, Delegate handler)
+    {
+        _endpoints = endpoints;
+        _verb = verb;
+        _route = route;
+        _handler = handler;
+    }
+
+    private readonly IEndpointRouteBuilder _endpoints;
+    private readonly HttpVerb _verb;
+    private string _route;
+    private Delegate _handler;
+
+    public static AdminApiEndpointBuilder MapGet(IEndpointRouteBuilder endpoints, string route, Delegate handler)
+        => new(endpoints, HttpVerb.GET, route, handler);
+
+    public static AdminApiEndpointBuilder MapPost(IEndpointRouteBuilder endpoints, string route, Delegate handler)
+        => new(endpoints, HttpVerb.POST, route, handler);
+
+    public static AdminApiEndpointBuilder MapPut(IEndpointRouteBuilder endpoints, string route, Delegate handler)
+        => new(endpoints, HttpVerb.PUT, route, handler);
+
+    public static AdminApiEndpointBuilder MapDelete(IEndpointRouteBuilder endpoints, string route, Delegate handler)
+        => new(endpoints, HttpVerb.DELETE, route, handler);
+
+    public void BuildForVersions(params string[] versions)
+    {
+        foreach (var version in versions)
+        {
+            var versionedRoute = $"{version}/{_route}";
+
+            var builder = _verb switch
+            {
+                HttpVerb.GET => _endpoints.MapGet(versionedRoute, _handler),
+                HttpVerb.POST => _endpoints.MapPost(versionedRoute, _handler),
+                HttpVerb.PUT => _endpoints.MapPut(versionedRoute, _handler),
+                HttpVerb.DELETE => _endpoints.MapDelete(versionedRoute, _handler),
+                _ => throw new ArgumentOutOfRangeException($"Unconfigured HTTP verb for mapping: {_}")
+            };
+        }
+    }
+
+    private enum HttpVerb { GET, POST, PUT, DELETE }
+
+}

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiVersions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiVersions.cs
@@ -12,11 +12,8 @@ namespace EdFi.Ods.Admin.Api.Infrastructure;
 public class AdminApiVersions
 {
     private static bool _isInitialized;
-    public const double V1Version = 1.0;
-    public const double V2Version = 2.0;
 
-    public static AdminApiVersion V1 = new AdminApiVersion(V1Version, "v1");
-    public static AdminApiVersion V2 = new AdminApiVersion(2.0, "v2");
+    public static AdminApiVersion V1 = new(1.0, "v1");
     private static ApiVersionSet? _versionSet;
 
     public static void Initialize(WebApplication app)
@@ -25,7 +22,6 @@ public class AdminApiVersions
 
         _versionSet = app.NewApiVersionSet()
             .HasApiVersion(V1.Version)
-            .HasApiVersion(V2.Version)
             .Build();
 
         _isInitialized = true;

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiVersions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiVersions.cs
@@ -38,7 +38,7 @@ public class AdminApiVersions
     {
         return typeof(AdminApiVersions)
             .GetFields(BindingFlags.Public | BindingFlags.Static)
-            .Where(field => field == typeof(AdminApiVersion))
+            .Where(field => field.FieldType == typeof(AdminApiVersion))
             .Select(field => field.GetValue(null) as AdminApiVersion)
             .Select(apiVersion => apiVersion?.ToString() ?? "")
             .ToArray();

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiVersions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiVersions.cs
@@ -1,0 +1,59 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Reflection;
+using Asp.Versioning.Builder;
+using Asp.Versioning.Conventions;
+
+namespace EdFi.Ods.Admin.Api.Infrastructure;
+
+public class AdminApiVersions
+{
+    private static bool _isInitialized;
+    public static AdminApiVersion V1 = new AdminApiVersion(1.0, "v1");
+    public static AdminApiVersion V2 = new AdminApiVersion(2.0, "v2");
+    private static ApiVersionSet? _versionSet;
+
+    public static void Initialize(WebApplication app)
+    {
+        if(_isInitialized) throw new InvalidOperationException("Versions are already initialized");
+
+        _versionSet = app.NewApiVersionSet()
+            .HasApiVersion(V1.Version)
+            .HasApiVersion(V2.Version)
+            .Build();
+
+        _isInitialized = true;
+    }
+
+    public static ApiVersionSet VersionSet
+    {
+        get => _versionSet ?? throw new Exception(
+            "Admin API Versions have not been initialized. Call Initialize() at app startup");
+    }
+
+    public static string[] GetAllVersions()
+    {
+        return typeof(AdminApiVersions)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field == typeof(AdminApiVersion))
+            .Select(field => field.GetValue(null) as AdminApiVersion)
+            .Select(apiVersion => apiVersion?.ToString() ?? "")
+            .ToArray();
+    }
+
+    public class AdminApiVersion
+    {
+        public double Version { get; }
+        public string DisplayName { get; }
+        public override string ToString() => DisplayName;
+
+        public AdminApiVersion(double version, string displayName)
+        {
+            Version = version;
+            DisplayName = displayName;
+        }
+    }
+}

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiVersions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/AdminApiVersions.cs
@@ -12,7 +12,10 @@ namespace EdFi.Ods.Admin.Api.Infrastructure;
 public class AdminApiVersions
 {
     private static bool _isInitialized;
-    public static AdminApiVersion V1 = new AdminApiVersion(1.0, "v1");
+    public const double V1Version = 1.0;
+    public const double V2Version = 2.0;
+
+    public static AdminApiVersion V1 = new AdminApiVersion(V1Version, "v1");
     public static AdminApiVersion V2 = new AdminApiVersion(2.0, "v2");
     private static ApiVersionSet? _versionSet;
 
@@ -34,13 +37,20 @@ public class AdminApiVersions
             "Admin API Versions have not been initialized. Call Initialize() at app startup");
     }
 
-    public static string[] GetAllVersions()
+    public static IEnumerable<AdminApiVersion> GetAllVersions()
     {
         return typeof(AdminApiVersions)
             .GetFields(BindingFlags.Public | BindingFlags.Static)
             .Where(field => field.FieldType == typeof(AdminApiVersion))
             .Select(field => field.GetValue(null) as AdminApiVersion)
-            .Select(apiVersion => apiVersion?.ToString() ?? "")
+            .Where(apiVersion => apiVersion != null)
+            .ToArray()!;
+    }
+
+    public static string[] GetAllVersionStrings()
+    {
+        return GetAllVersions()
+            .Select(apiVersion => apiVersion.ToString())
             .ToArray();
     }
 

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/EndpointRouteBuilderExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/EndpointRouteBuilderExtensions.cs
@@ -23,13 +23,8 @@ namespace EdFi.Ods.Admin.Api.Infrastructure
         internal static RouteHandlerBuilder WithDefaultPutOptions(this RouteHandlerBuilder builder, string tag)
             => SetDefaultOptions(builder, $"Updates {tag.ToSingleEntity()} based on the resource identifier.", tag);
 
-        internal static RouteHandlerBuilder MapDeleteWithDefaultOptions(this IEndpointRouteBuilder builder,
-           string route, Delegate handler, string tag)
-        {
-            var routeHandler = builder.MapDelete(route, handler);
-            SetDefaultOptions(routeHandler, $"Deletes an existing {tag.ToSingleEntity()} using the resource identifier.", tag);
-            return routeHandler;
-        }
+        internal static RouteHandlerBuilder WithDefaultDeleteOptions(this RouteHandlerBuilder builder, string tag)
+            => SetDefaultOptions(builder, $"Deletes an existing {tag.ToSingleEntity()} using the resource identifier.", tag);
 
         private static RouteHandlerBuilder SetDefaultOptions(RouteHandlerBuilder routeHandlerBuilder, string operationSummary, string tag)
         {

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/EndpointRouteBuilderExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/EndpointRouteBuilderExtensions.cs
@@ -11,6 +11,9 @@ namespace EdFi.Ods.Admin.Api.Infrastructure
             return builder;
         }
 
+        internal static void DefaultGetOptions(RouteHandlerBuilder builder, string tag)
+            => SetDefaultOptions(builder, $"Retrieves all {tag}.", tag);
+
         internal static RouteHandlerBuilder MapGetWithDefaultOptions(this IEndpointRouteBuilder builder,
            string route, Delegate handler, string tag)
         {

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/EndpointRouteBuilderExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/EndpointRouteBuilderExtensions.cs
@@ -20,13 +20,8 @@ namespace EdFi.Ods.Admin.Api.Infrastructure
         internal static RouteHandlerBuilder WithDefaultPostOptions(this RouteHandlerBuilder builder, string tag)
             => SetDefaultOptions(builder, $"Creates {tag.ToSingleEntity()} based on the supplied values.", tag);
 
-        internal static RouteHandlerBuilder MapPutWithDefaultOptions(this IEndpointRouteBuilder builder,
-           string route, Delegate handler, string tag)
-        {
-            var routeHandler = builder.MapPut(route, handler);
-            SetDefaultOptions(routeHandler, $"Updates {tag.ToSingleEntity()} based on the resource identifier.", tag);
-            return routeHandler;
-        }
+        internal static RouteHandlerBuilder WithDefaultPutOptions(this RouteHandlerBuilder builder, string tag)
+            => SetDefaultOptions(builder, $"Updates {tag.ToSingleEntity()} based on the resource identifier.", tag);
 
         internal static RouteHandlerBuilder MapDeleteWithDefaultOptions(this IEndpointRouteBuilder builder,
            string route, Delegate handler, string tag)

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/EndpointRouteBuilderExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/EndpointRouteBuilderExtensions.cs
@@ -5,6 +5,12 @@ namespace EdFi.Ods.Admin.Api.Infrastructure
 {
     public static class EndpointRouteBuilderExtensions
     {
+        internal static AdminApiEndpointBuilder WithDefaultOptions(this AdminApiEndpointBuilder builder, string tag)
+        {
+            builder.WithRouteOptions(rhb => SetDefaultOptions(rhb, "Temp Message Will Fix", tag));
+            return builder;
+        }
+
         internal static RouteHandlerBuilder MapGetWithDefaultOptions(this IEndpointRouteBuilder builder,
            string route, Delegate handler, string tag)
         {

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/EndpointRouteBuilderExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/EndpointRouteBuilderExtensions.cs
@@ -14,21 +14,8 @@ namespace EdFi.Ods.Admin.Api.Infrastructure
         internal static RouteHandlerBuilder WithDefaultGetOptions(this RouteHandlerBuilder builder, string tag)
             => SetDefaultOptions(builder, $"Retrieves all {tag}.", tag);
 
-        internal static RouteHandlerBuilder MapGetWithDefaultOptions(this IEndpointRouteBuilder builder,
-           string route, Delegate handler, string tag)
-        {
-            var routeHandler = builder.MapGet(route, handler);
-            SetDefaultOptions(routeHandler, $"Retrieves all {tag}.", tag);
-            return routeHandler;
-        }
-
-        internal static RouteHandlerBuilder MapGetByIdWithDefaultOptions(this IEndpointRouteBuilder builder,
-          string route, Delegate handler, string tag)
-        {
-            var routeHandler = builder.MapGet(route, handler);
-            SetDefaultOptions(routeHandler, $"Retrieves a specific {tag.ToSingleEntity()} based on the resource identifier.", tag);
-            return routeHandler;
-        }
+        internal static RouteHandlerBuilder WithDefaultGetByIdOptions(this RouteHandlerBuilder builder, string tag)
+            => SetDefaultOptions(builder, $"Retrieves a specific {tag.ToSingleEntity()} based on the identifier.", tag);
 
         internal static RouteHandlerBuilder MapPostWithDefaultOptions(this IEndpointRouteBuilder builder,
            string route, Delegate handler, string tag)

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/EndpointRouteBuilderExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/EndpointRouteBuilderExtensions.cs
@@ -17,13 +17,8 @@ namespace EdFi.Ods.Admin.Api.Infrastructure
         internal static RouteHandlerBuilder WithDefaultGetByIdOptions(this RouteHandlerBuilder builder, string tag)
             => SetDefaultOptions(builder, $"Retrieves a specific {tag.ToSingleEntity()} based on the identifier.", tag);
 
-        internal static RouteHandlerBuilder MapPostWithDefaultOptions(this IEndpointRouteBuilder builder,
-           string route, Delegate handler, string tag)
-        {
-            var routeHandler = builder.MapPost(route, handler);
-            SetDefaultOptions(routeHandler, $"Creates {tag.ToSingleEntity()} based on the supplied values.", tag);
-            return routeHandler;
-        }
+        internal static RouteHandlerBuilder WithDefaultPostOptions(this RouteHandlerBuilder builder, string tag)
+            => SetDefaultOptions(builder, $"Creates {tag.ToSingleEntity()} based on the supplied values.", tag);
 
         internal static RouteHandlerBuilder MapPutWithDefaultOptions(this IEndpointRouteBuilder builder,
            string route, Delegate handler, string tag)

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/EndpointRouteBuilderExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/EndpointRouteBuilderExtensions.cs
@@ -11,7 +11,7 @@ namespace EdFi.Ods.Admin.Api.Infrastructure
             return builder;
         }
 
-        internal static void DefaultGetOptions(RouteHandlerBuilder builder, string tag)
+        internal static RouteHandlerBuilder WithDefaultGetOptions(this RouteHandlerBuilder builder, string tag)
             => SetDefaultOptions(builder, $"Retrieves all {tag}.", tag);
 
         internal static RouteHandlerBuilder MapGetWithDefaultOptions(this IEndpointRouteBuilder builder,
@@ -54,11 +54,13 @@ namespace EdFi.Ods.Admin.Api.Infrastructure
             return routeHandler;
         }
 
-        private static void SetDefaultOptions(RouteHandlerBuilder routeHandlerBuilder, string operationSummary, string tag)
+        private static RouteHandlerBuilder SetDefaultOptions(RouteHandlerBuilder routeHandlerBuilder, string operationSummary, string tag)
         {
             routeHandlerBuilder.WithMetadata(new OperationDescriptionAttribute(operationSummary, null));
             routeHandlerBuilder.WithTags(tag);
             routeHandlerBuilder.RequireAuthorization();
+
+            return routeHandlerBuilder;
         }
     }
 }

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -108,7 +108,7 @@ public static class WebApplicationBuilderExtensions
                 }
             );
 
-            foreach (var version in AdminApiVersions.GetAllVersions())
+            foreach (var version in AdminApiVersions.GetAllVersionStrings())
             {
                 opt.SwaggerDoc(version, new OpenApiInfo
                 {

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -63,6 +63,12 @@ public static class WebApplicationBuilderExtensions
         // Add services to the container.
         // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
         webApplicationBuilder.Services.AddEndpointsApiExplorer();
+        webApplicationBuilder.Services.AddApiVersioning(opt =>
+        {
+            opt.ReportApiVersions = true;
+            opt.AssumeDefaultVersionWhenUnspecified = false;
+        });
+
         var issuer = webApplicationBuilder.Configuration.GetValue<string>("Authentication:IssuerUrl");
         webApplicationBuilder.Services.AddSwaggerGen(opt =>
         {

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -106,6 +106,11 @@ public static class WebApplicationBuilderExtensions
             {
                 Title = "Admin API Documentation", Version = "v1"
             });
+
+            opt.SwaggerDoc("v2", new OpenApiInfo
+            {
+                Title = "Admin API Documentation", Version = "v2"
+            });
             opt.DocumentFilter<OperationResponsesDocumentFilter>();
             opt.DocumentFilter<RemoveSchemaDocumentFilter>();
             opt.DocumentFilter<AddRegisterSchemaDocumentFilter>();

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -102,15 +102,14 @@ public static class WebApplicationBuilderExtensions
                 }
             );
 
-            opt.SwaggerDoc("v1", new OpenApiInfo
+            foreach (var version in AdminApiVersions.GetAllVersions())
             {
-                Title = "Admin API Documentation", Version = "v1"
-            });
+                opt.SwaggerDoc(version, new OpenApiInfo
+                {
+                    Title = "Admin API Documentation", Version = version
+                });
+            }
 
-            opt.SwaggerDoc("v2", new OpenApiInfo
-            {
-                Title = "Admin API Documentation", Version = "v2"
-            });
             opt.DocumentFilter<OperationResponsesDocumentFilter>();
             opt.DocumentFilter<RemoveSchemaDocumentFilter>();
             opt.DocumentFilter<AddRegisterSchemaDocumentFilter>();

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationExtensions.cs
@@ -17,4 +17,14 @@ public static class WebApplicationExtensions
             }
         });
     }
+
+    public static void DefineSwaggerUIWithApiVersions(this WebApplication application, params string[] versions)
+    {
+        application.UseSwaggerUI(definitions => {
+            foreach (var version in versions)
+            {
+                definitions.SwaggerEndpoint($"/swagger/{version}/swagger.json", version);
+            }
+        });
+    }
 }

--- a/Application/EdFi.Ods.Admin.Api/Program.cs
+++ b/Application/EdFi.Ods.Admin.Api/Program.cs
@@ -34,6 +34,8 @@ else
 
 app.UseHttpsRedirection();
 
+AdminApiVersions.Initialize(app);
+
 //The ordering here is meaningful: Routing -> Auth -> Endpoints
 app.UseRouting();
 app.UseAuthentication();
@@ -45,7 +47,7 @@ app.UseHealthChecks("/health");
 if (app.Configuration.GetValue<bool>("EnableSwagger"))
 {
     app.UseSwagger();
-    app.DefineSwaggerUIWithApiVersions("v1", "v2");
+    app.DefineSwaggerUIWithApiVersions(AdminApiVersions.GetAllVersions());
 }
 
 app.Run();

--- a/Application/EdFi.Ods.Admin.Api/Program.cs
+++ b/Application/EdFi.Ods.Admin.Api/Program.cs
@@ -47,7 +47,7 @@ app.UseHealthChecks("/health");
 if (app.Configuration.GetValue<bool>("EnableSwagger"))
 {
     app.UseSwagger();
-    app.DefineSwaggerUIWithApiVersions(AdminApiVersions.GetAllVersions());
+    app.DefineSwaggerUIWithApiVersions(AdminApiVersions.GetAllVersionStrings());
 }
 
 app.Run();

--- a/Application/EdFi.Ods.Admin.Api/Program.cs
+++ b/Application/EdFi.Ods.Admin.Api/Program.cs
@@ -45,7 +45,7 @@ app.UseHealthChecks("/health");
 if (app.Configuration.GetValue<bool>("EnableSwagger"))
 {
     app.UseSwagger();
-    app.UseSwaggerUI();
+    app.DefineSwaggerUIWithApiVersions("v1", "v2");
 }
 
 app.Run();


### PR DESCRIPTION
Future-proof Admin API endpoints by applying a `/v1` prefix to all feature endpoints.

- introduces a wrapper around `IEndpointRouteBuilder` to allow adjusting routes before mapping them
  - supports registering an endpoint for multiple versions
  - preserves ability to adjust routes by `RouteHandlerBuilder` extensions
  - will ease some elements of AA-1544
  - similar syntax to eventual support from .NET (probably)
- uses ASP.NET 6 versioning under the hood to prepare for future support
- `Connect` and `Information` (`/`) endpoints are _not_ versioned
  - Root is not versioned
  - Versioning for auth endpoints will ideally be simplified with future minimal API support from OpenIddict or ASP.NET versioning libraries
- Testing:
  - E2E test collection updated for `v1` prefix
  - Revert the final commit to restore a `v2` which is applied to the Vendor GET endpoints

I want to acknowledge the work done by @CSR2017 and @saa14 on #293 that led us here. That spike revealed what can, should, and can't be done and it's unfortunate that versioning-by-route middleware is not ready for primetime for minimal APIs.