### PR TITLE
[AA-1555] Allow to promote individual packages

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -15,6 +15,17 @@ on:
         - Prerelease
         - Release
         required: true
+      packages:
+        type: choice
+        description: Packages to promote
+        options:
+        - All
+        - EdFi.Suite3.ODS.AdminApp.Database
+        - EdFi.Suite3.ODS.AdminApp.Web
+        - EdFi.Suite3.ODS.Admin.Api
+        - EdFi.Suite3.Installer.AdminApp
+        required: true
+        default: All
 
 env:
   ARTIFACTS_API_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
@@ -40,6 +51,14 @@ jobs:
           Username    = "${{ env.ARTIFACTS_USERNAME }}"
           View        = "${{ github.event.inputs.view-type }}"
         }
+
+        $packages = "${{ github.event.inputs.packages }}"
+
+        if ($packages -eq "All") {
+            $arguments.Packages = @('EdFi.Suite3.ODS.AdminApp.Database', 'EdFi.Suite3.ODS.AdminApp.Web', 'EdFi.Suite3.ODS.Admin.Api', 'EdFi.Suite3.Installer.AdminApp')
+        } else {
+            $arguments.Packages = @($packages)
+        }
+
         $arguments.Password = (ConvertTo-SecureString -String "${{ secrets.ARTIFACTS_API_KEY }}" -AsPlainText -Force)
-        $arguments.Packages = @('EdFi.Suite3.ODS.AdminApp.Database', 'EdFi.Suite3.ODS.AdminApp.Web', 'EdFi.Suite3.ODS.Admin.Api', 'EdFi.Suite3.Installer.AdminApp')
         eng\promote-packages.ps1 @arguments

--- a/Application/EdFi.Ods.Admin.Api/E2E Tests/Admin API E2E.postman_collection.json
+++ b/Application/EdFi.Ods.Admin.Api/E2E Tests/Admin API E2E.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "3af680b2-e64a-45ca-bb94-9829551e4617",
+		"_postman_id": "18244070-0d8a-458a-b867-e3a557a75fbc",
 		"name": "Admin API E2E",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "20720204"
+		"_exporter_id": "15734759"
 	},
 	"item": [
 		{
@@ -59,7 +59,11 @@
 					},
 					"response": []
 				}
-			]
+			],
+			"auth": {
+				"type": "noauth"
+			},
+			"event": []
 		},
 		{
 			"name": "User Management",
@@ -260,12 +264,12 @@
 							"urlencoded": [
 								{
 									"key": "ClientId",
-									"value": "{{ClientId}}",
+									"value": "{{RegisteredClientId}}",
 									"type": "text"
 								},
 								{
 									"key": "ClientSecret",
-									"value": "{{ClientSecret}}",
+									"value": "{{RegisteredClientSecret}}",
 									"type": "text"
 								},
 								{
@@ -641,26 +645,7 @@
 			"auth": {
 				"type": "noauth"
 			},
-			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"type": "text/javascript",
-						"exec": [
-							""
-						]
-					}
-				},
-				{
-					"listen": "test",
-					"script": {
-						"type": "text/javascript",
-						"exec": [
-							""
-						]
-					}
-				}
-			]
+			"event": []
 		},
 		{
 			"name": "v1",
@@ -2533,6 +2518,10 @@
 			"script": {
 				"type": "text/javascript",
 				"exec": [
+					"if(pm.request.auth && pm.request.auth.type === \"noauth\") {",
+					"    return;",
+					"}",
+					"",
 					"let currentToken = pm.collectionVariables.get(\"TOKEN\");",
 					"if(currentToken) {",
 					"    return;",
@@ -2547,14 +2536,18 @@
 					"    body: {",
 					"        mode: 'urlencoded',",
 					"        urlencoded: [",
-					"            {key: 'client_id', value: pm.variables.get(\"ClientId\")},",
-					"            {key: 'client_secret', value: pm.variables.get(\"ClientSecret\")},",
+					"            {key: 'client_id', value: pm.variables.get(\"RegisteredClientId\")},",
+					"            {key: 'client_secret', value: pm.variables.get(\"RegisteredClientSecret\")},",
 					"            {key: 'grant_type', value: \"client_credentials\"},",
 					"            {key: 'scope', value: \"edfi_admin_api/full_access\"}",
 					"        ]",
 					"    }",
 					"},",
 					"    (err, res) => {",
+					"        error = res.json().error",
+					"        if(error) {",
+					"            throw res.json().error_description",
+					"        }",
 					"        pm.collectionVariables.set(\"TOKEN\", res.json().access_token)",
 					"});"
 				]

--- a/Application/EdFi.Ods.Admin.Api/E2E Tests/Admin API.postman_environment.json
+++ b/Application/EdFi.Ods.Admin.Api/E2E Tests/Admin API.postman_environment.json
@@ -1,5 +1,5 @@
 {
-	"id": "56d07b40-7cef-4c34-9948-4f4da9ea57a1",
+	"id": "9b30b51f-9e0b-43f5-8ac7-e2bb8f4ecb51",
 	"name": "Admin API",
 	"values": [
 		{
@@ -7,27 +7,9 @@
 			"value": "https://localhost:7214",
 			"type": "default",
 			"enabled": true
-		},
-		{
-			"key": "ClientId",
-			"value": "test-client",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "ClientSecret",
-			"value": "test-secret",
-			"type": "secret",
-			"enabled": true
-		},
-		{
-			"key": "UserName",
-			"value": "TestClient",
-			"type": "default",
-			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2022-06-07T20:15:21.556Z",
-	"_postman_exported_using": "Postman/9.21.1"
+	"_postman_exported_at": "2022-07-27T23:27:44.797Z",
+	"_postman_exported_using": "Postman/9.26.2"
 }


### PR DESCRIPTION
- Fixes issue that only allows to promote all packages at the same time.
- Update postman collection to remove references to old unused variable that makes the test fail when default user is not already present.