### PR TITLE
[AA-1510] Claimset Relationship Display

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/GetResourcesByClaimSetIdQuery.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/GetResourcesByClaimSetIdQuery.cs
@@ -173,7 +173,7 @@ namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
                         return actions;
                     }
                 }
-                
+
                 resultDictionary[resourceClaim.ResourceClaimId] = actions.ToArray();
             }
 

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/GetResourcesByClaimSetIdQuery.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/GetResourcesByClaimSetIdQuery.cs
@@ -85,6 +85,7 @@ namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
                     Read = x.Any(a => a.Action.ActionName == Action.Read.Value),
                     Update = x.Any(a => a.Action.ActionName == Action.Update.Value),
                     Delete = x.Any(a => a.Action.ActionName == Action.Delete.Value),
+                    IsParent = true,
                     DefaultAuthStrategiesForCRUD = defaultAuthStrategies[x.Key.ResourceClaimId],
                     AuthStrategyOverridesForCRUD = authStrategyOverrides[x.Key.ResourceClaimId].ToArray()
                 })
@@ -252,6 +253,7 @@ namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
                     Read = x.Any(a => a.Action.ActionName == Action.Read.Value),
                     Update = x.Any(a => a.Action.ActionName == Action.Update.Value),
                     Delete = x.Any(a => a.Action.ActionName == Action.Delete.Value),
+                    IsParent = false,
                     DefaultAuthStrategiesForCRUD = defaultAuthStrategies[x.Key.ResourceClaimId],
                     AuthStrategyOverridesForCRUD = authStrategyOverrides[x.Key.ResourceClaimId].ToArray()
                 })

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/ResourceClaim.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/ResourceClaim.cs
@@ -17,6 +17,7 @@ namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
         public bool Create { get; set; }
         public bool Update { get; set; }
         public bool Delete { get; set; }
+        public bool IsParent { get; set; }
         public AuthorizationStrategy[] DefaultAuthStrategiesForCRUD { get; set; }
         public AuthorizationStrategy[] AuthStrategyOverridesForCRUD { get; set; }
         public List<ResourceClaim> Children { get; set; }

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/ResourceClaim.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/ResourceClaim.cs
@@ -3,7 +3,6 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/ResourceClaim.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/ResourceClaim.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
 {
@@ -17,6 +18,7 @@ namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
         public bool Create { get; set; }
         public bool Update { get; set; }
         public bool Delete { get; set; }
+        [JsonIgnore]
         public bool IsParent { get; set; }
         public AuthorizationStrategy[] DefaultAuthStrategiesForCRUD { get; set; }
         public AuthorizationStrategy[] AuthStrategyOverridesForCRUD { get; set; }

--- a/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_ResourceEditor.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_ResourceEditor.cshtml
@@ -149,11 +149,11 @@ See the LICENSE and NOTICES files in the project root for more information.
     var childResourcesForParentUrl = '@Url.Action("GetSelectListForChildResourceClaims", "ClaimSets")';
     InitializeModalLoaders();
 
-    $("#ResourceClaimsDropDown").change(function () {        
+    $("#ResourceClaimsDropDown").change(function () {
         $('#add-resource-button').prop("disabled", false);
     });
-    $("#add-resource-button").click(function () {        
+    $("#add-resource-button").click(function () {
         $('#add-resource-button').prop("disabled", true);
     });
-</script>  
+</script>
 <script type="text/javascript" src="~/bundles/claimset.min.js" asp-append-version="true"></script>

--- a/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_ResourceEditor.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_ResourceEditor.cshtml
@@ -33,7 +33,7 @@ See the LICENSE and NOTICES files in the project root for more information.
                 {
                     <tr class="parent-resource-claim">
                         <td class="icon-cell">
-                            @if (resourceClaim.Children.Any())
+                            @if (resourceClaim.Children.Any() || resourceClaim.IsParent)
                             {<a class="claims-toggle" data-resource-id='@resourceClaim.Id'><span class="fa fa-chevron-down caret-custom"></span></a>}
                         </td>
                         <td data-resource-id='@resourceClaim.Id' class="resource-label">@resourceClaim.Name</td>

--- a/Application/EdFi.Ods.AdminApp.Web/wwwroot/Scripts/resource-editor.js
+++ b/Application/EdFi.Ods.AdminApp.Web/wwwroot/Scripts/resource-editor.js
@@ -372,11 +372,11 @@ var buildChildDropdownRow = function buildChildDropdownRow(parentResourceId) {
     return $row;
 };
 
-$("#add-resource-button").click(function (e) {        
+$("#add-resource-button").click(function (e) {
     e.preventDefault();
-    var dropDownList = $("#ResourceClaimsDropDown")[0];    
+    var dropDownList = $("#ResourceClaimsDropDown")[0];
     var selectedItem = dropDownList.options[dropDownList.selectedIndex];
-    if (selectedItem.closest("optgroup")) {        
+    if (selectedItem.closest("optgroup")) {
         var optGroup = selectedItem.closest("optgroup").label;
         if (!selectedItem.disabled) {
             if (optGroup === "Groups") {
@@ -423,7 +423,7 @@ var disableAlreadyAddedResources = function disableAlreadyAddedResources() {
 
 var populateChildren = function populateChildren() {
     $(".claims-toggle").each(function () {
-        var resourceId = $(this).data("resource-id");
+        var resourceId=  $(this).data("resource-id");
         populateChildResourcesForParent(resourceId);
     });
 };


### PR DESCRIPTION
Restores the "branch" `L`-looking icon which indicates child relationships when editing a claimset, previously missing when a child resource was added to an existing parent resource that had no children at load-time.

**The Fix**

Rather than try to re-organize newly added resources from the main dropdown to be under the appropriate category, I made a change to ensure the expand-arrow and "child" dropdown is present for _all_ parent resources (not just resources which have children saved on them already). This was straightforward in code since the query is split between parent and child resources already.