### PR TITLE
[AA-1513] - Update AppCommon on AdminApp Installer

### DIFF
--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -1186,13 +1186,18 @@ function Set-SqlLogins {
 
         if($Config.usingSharedCredentials)
         {
-            Add-SqlLogins $Config.DbConnectionInfo $Config.WebApplicationName
+            Add-SqlLogins $Config.DbConnectionInfo $Config.WebApplicationName -IsCustomLogin
         }
         else
         {
-            Add-SqlLogins $Config.AdminDbConnectionInfo $Config.WebApplicationName
-            Add-SqlLogins $Config.OdsDbConnectionInfo $Config.WebApplicationName
-            Add-SqlLogins $Config.SecurityDbConnectionInfo $Config.WebApplicationName
+            Write-Host "Adding Sql Login for Admin Database:";
+            Add-SqlLogins $Config.AdminDbConnectionInfo $Config.WebApplicationName -IsCustomLogin
+            
+            Write-Host "Adding Sql Login for Ed-Fi ODS Database:";
+            Add-SqlLogins $Config.OdsDbConnectionInfo $Config.WebApplicationName -IsCustomLogin
+            
+            Write-Host "Adding Sql Login for Security Database:";
+            Add-SqlLogins $Config.SecurityDbConnectionInfo $Config.WebApplicationName -IsCustomLogin
         }
     }
 }

--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -20,6 +20,8 @@ function Set-TlsVersion {
 Import-Module "$PSScriptRoot/key-management.psm1"
 
 $appCommonDirectory = "$PSScriptRoot/AppCommon"
+$RequiredDotNetHostingBundleVersion = "6.0.0"
+
 Import-Module -Force "$appCommonDirectory/Environment/Prerequisites.psm1" -Scope Global
 Set-TlsVersion
 Install-DotNetCore "C:\temp\tools"
@@ -1165,6 +1167,7 @@ function Install-Application {
             WebSitePort = $Config.WebSitePort
             WebSiteName = $Config.WebSiteName
             CertThumbprint = $Config.CertThumbprint
+            DotNetVersion = $RequiredDotNetHostingBundleVersion
         }
 
         Install-EdFiApplicationIntoIIS @iisParams

--- a/EdFi.Suite3.Installer.AdminApp/build-package.ps1
+++ b/EdFi.Suite3.Installer.AdminApp/build-package.ps1
@@ -30,7 +30,7 @@ $Downloads = "$PSScriptRoot/downloads"
 $Version = "$SemanticVersion.$BuildCounter"
 
 $AppCommonPackageName = "EdFi.Installer.AppCommon"
-$AppCommonPackageVersion = "2.0.0"
+$AppCommonPackageVersion = "3.0.0"
 
 function Add-AppCommon{
 


### PR DESCRIPTION
**Description**
- Update AppCommon version on build-package.ps1 to 3.0.0.
- Added the RequiredDotNetHostingBundleVersion variable with the value 6.0.0 set and passed it as a parameter for the updated AppCommon's Install-EdFiApplicationIntoIIS call.
- Switched on the IsCustomLogin flag on Add-SqlLogins calls.