### PR TITLE
[AA-1478] - Vendor NamespacePrefix Empty String fix

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Commands/AddVendorCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Commands/AddVendorCommandTests.cs
@@ -82,6 +82,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Database.Commands
 
         [TestCase("http://www.test1.com/, http://www.test2.com/,", "http://www.test1.com/,http://www.test2.com/")]
         [TestCase(", ,", "")]
+        [TestCase(" ", "")]
+        [TestCase(null, "")]
         public void ShouldNotAddEmptyNamespacePrefixesWhileAddingVendor(string inputNamespacePrefixes, string expectedNamespacePrefixes)
         {
             var newVendor = new Mock<IAddVendorModel>();

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Commands/AddVendorCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Commands/AddVendorCommandTests.cs
@@ -81,7 +81,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Database.Commands
         }
 
         [TestCase("http://www.test1.com/, http://www.test2.com/,", "http://www.test1.com/,http://www.test2.com/")]
-        [TestCase(",", "")]
+        [TestCase(", ,", "")]
         public void ShouldNotAddEmptyNamespacePrefixesWhileAddingVendor(string inputNamespacePrefixes, string expectedNamespacePrefixes)
         {
             var newVendor = new Mock<IAddVendorModel>();

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Commands/EditVendorCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Commands/EditVendorCommandTests.cs
@@ -168,7 +168,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Database.Commands
         }
 
         [TestCase("http://www.test1.com/, http://www.test2.com/,", "http://www.test1.com/,http://www.test2.com/")]
-        [TestCase(",", "")]
+        [TestCase(", ,", "")]
         public void ShouldNotAddEmptyNameSpacePrefixesWhileEditingVendor(string inputNamespacePrefixes, string expectedNamespacePrefixes)
         {
             var newVendorData = new Mock<IEditVendor>();

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Commands/EditVendorCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Commands/EditVendorCommandTests.cs
@@ -66,7 +66,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Database.Commands
                 var editVendorCommand = new EditVendorCommand(usersContext);
                 editVendorCommand.Execute(newVendorData.Object);
             });
-            
+
             Transaction(usersContext =>
             {
                 var changedVendor = usersContext.Vendors.Single(v => v.VendorId == _vendorId);
@@ -140,7 +140,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Database.Commands
             });
             var newNamespacePrefixes = new List<string>
             {
-                
+
                 "http://www.test1.com/",
                 "http://www.test2.com/",
                 "http://www.test3.com/"

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Commands/EditVendorCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Commands/EditVendorCommandTests.cs
@@ -169,6 +169,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Database.Commands
 
         [TestCase("http://www.test1.com/, http://www.test2.com/,", "http://www.test1.com/,http://www.test2.com/")]
         [TestCase(", ,", "")]
+        [TestCase(" ", "")]
+        [TestCase(null, "")]
         public void ShouldNotAddEmptyNameSpacePrefixesWhileEditingVendor(string inputNamespacePrefixes, string expectedNamespacePrefixes)
         {
             var newVendorData = new Mock<IEditVendor>();

--- a/Application/EdFi.Ods.AdminApp.Management/Database/Commands/AddVendorCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/Commands/AddVendorCommand.cs
@@ -22,18 +22,13 @@ namespace EdFi.Ods.AdminApp.Management.Database.Commands
 
         public Vendor Execute(IAddVendorModel newVendor)
         {
-            var namespacePrefixes = new List<VendorNamespacePrefix>();
-            if (!string.IsNullOrWhiteSpace(newVendor.NamespacePrefixes))
-            {
-                var namespacePrefixSplits = newVendor.NamespacePrefixes.Split(",")
-                    .Where(namespacePrefix => !string.IsNullOrWhiteSpace(namespacePrefix))
-                    .Select(namespacePrefix => new VendorNamespacePrefix
-                    {
-                        NamespacePrefix = namespacePrefix.Trim()
-                    });
-
-                namespacePrefixes.AddRange(namespacePrefixSplits);
-            }
+            var namespacePrefixes = newVendor.NamespacePrefixes?.Split(",")
+                .Where(namespacePrefix => !string.IsNullOrWhiteSpace(namespacePrefix))
+                .Select(namespacePrefix => new VendorNamespacePrefix
+                {
+                    NamespacePrefix = namespacePrefix.Trim()
+                })
+                .ToList();
 
             var vendor = new Vendor
             {

--- a/Application/EdFi.Ods.AdminApp.Management/Database/Commands/AddVendorCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/Commands/AddVendorCommand.cs
@@ -27,7 +27,9 @@ namespace EdFi.Ods.AdminApp.Management.Database.Commands
             {
                 var namespacePrefixSplits = newVendor.NamespacePrefixes.Split(",");
 
-                namespacePrefixes.AddRange(namespacePrefixSplits.Select(
+                namespacePrefixes.AddRange(namespacePrefixSplits
+                    .Where(namespacePrefix => !string.IsNullOrEmpty(namespacePrefix))
+                    .Select(
                         namespacePrefix => new VendorNamespacePrefix
                         {
                             NamespacePrefix = namespacePrefix.Trim()

--- a/Application/EdFi.Ods.AdminApp.Management/Database/Commands/AddVendorCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/Commands/AddVendorCommand.cs
@@ -28,11 +28,11 @@ namespace EdFi.Ods.AdminApp.Management.Database.Commands
                 var namespacePrefixSplits = newVendor.NamespacePrefixes.Split(",");
 
                 namespacePrefixes.AddRange(namespacePrefixSplits
-                    .Where(namespacePrefix => !string.IsNullOrEmpty(namespacePrefix))
+                    .Where(namespacePrefix => !string.IsNullOrWhiteSpace(namespacePrefix))
                     .Select(
                         namespacePrefix => new VendorNamespacePrefix
                         {
-                            NamespacePrefix = namespacePrefix.Trim()
+                            NamespacePrefix = namespacePrefix
                         }));
             }
 

--- a/Application/EdFi.Ods.AdminApp.Management/Database/Commands/AddVendorCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/Commands/AddVendorCommand.cs
@@ -25,15 +25,14 @@ namespace EdFi.Ods.AdminApp.Management.Database.Commands
             var namespacePrefixes = new List<VendorNamespacePrefix>();
             if (!string.IsNullOrWhiteSpace(newVendor.NamespacePrefixes))
             {
-                var namespacePrefixSplits = newVendor.NamespacePrefixes.Split(",");
-
-                namespacePrefixes.AddRange(namespacePrefixSplits
+                var namespacePrefixSplits = newVendor.NamespacePrefixes.Split(",")
                     .Where(namespacePrefix => !string.IsNullOrWhiteSpace(namespacePrefix))
-                    .Select(
-                        namespacePrefix => new VendorNamespacePrefix
-                        {
-                            NamespacePrefix = namespacePrefix
-                        }));
+                    .Select(namespacePrefix => new VendorNamespacePrefix
+                    {
+                        NamespacePrefix = namespacePrefix.Trim()
+                    });
+
+                namespacePrefixes.AddRange(namespacePrefixSplits);
             }
 
             var vendor = new Vendor

--- a/Application/EdFi.Ods.AdminApp.Management/Database/Commands/EditVendorCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/Commands/EditVendorCommand.cs
@@ -47,18 +47,17 @@ namespace EdFi.Ods.AdminApp.Management.Database.Commands
 
             if (!string.IsNullOrEmpty(changedVendorData.NamespacePrefixes))
             {
-                var namespacePrefixSplits = changedVendorData.NamespacePrefixes.Split(",");
-
-                foreach (var namespacePrefix in namespacePrefixSplits)
-                {
-                    if (!string.IsNullOrWhiteSpace(namespacePrefix))
+                var namespacePrefixes = changedVendorData.NamespacePrefixes.Split(",")
+                    .Where(namespacePrefix => !string.IsNullOrWhiteSpace(namespacePrefix))
+                    .Select(namespacePrefix => new VendorNamespacePrefix
                     {
-                        _context.VendorNamespacePrefixes.Add(new VendorNamespacePrefix
-                        {
-                            NamespacePrefix = namespacePrefix.Trim(),
-                            Vendor = vendor
-                        });
-                    }
+                        NamespacePrefix = namespacePrefix.Trim(),
+                        Vendor = vendor
+                    });
+
+                foreach (var namespacePrefix in namespacePrefixes)
+                {
+                    _context.VendorNamespacePrefixes.Add(namespacePrefix);
                 }
             }
 

--- a/Application/EdFi.Ods.AdminApp.Management/Database/Commands/EditVendorCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/Commands/EditVendorCommand.cs
@@ -55,7 +55,7 @@ namespace EdFi.Ods.AdminApp.Management.Database.Commands
                     {
                         _context.VendorNamespacePrefixes.Add(new VendorNamespacePrefix
                         {
-                            NamespacePrefix = namespacePrefix,
+                            NamespacePrefix = namespacePrefix.Trim(),
                             Vendor = vendor
                         });
                     }

--- a/Application/EdFi.Ods.AdminApp.Management/Database/Commands/EditVendorCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/Commands/EditVendorCommand.cs
@@ -51,11 +51,14 @@ namespace EdFi.Ods.AdminApp.Management.Database.Commands
 
                 foreach (var namespacePrefix in namespacePrefixSplits)
                 {
-                    _context.VendorNamespacePrefixes.Add(new VendorNamespacePrefix
+                    if (!string.IsNullOrEmpty(namespacePrefix))
                     {
-                        NamespacePrefix = namespacePrefix,
-                        Vendor = vendor
-                    });
+                        _context.VendorNamespacePrefixes.Add(new VendorNamespacePrefix
+                        {
+                            NamespacePrefix = namespacePrefix,
+                            Vendor = vendor
+                        });
+                    }
                 }
             }
 

--- a/Application/EdFi.Ods.AdminApp.Management/Database/Commands/EditVendorCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/Commands/EditVendorCommand.cs
@@ -41,7 +41,7 @@ namespace EdFi.Ods.AdminApp.Management.Database.Commands
             {
                 foreach (var vendorNamespacePrefix in vendor.VendorNamespacePrefixes.ToList())
                 {
-                     _context.VendorNamespacePrefixes.Remove(vendorNamespacePrefix);    
+                     _context.VendorNamespacePrefixes.Remove(vendorNamespacePrefix);
                 }
             }
 
@@ -51,7 +51,7 @@ namespace EdFi.Ods.AdminApp.Management.Database.Commands
 
                 foreach (var namespacePrefix in namespacePrefixSplits)
                 {
-                    if (!string.IsNullOrEmpty(namespacePrefix))
+                    if (!string.IsNullOrWhiteSpace(namespacePrefix))
                     {
                         _context.VendorNamespacePrefixes.Add(new VendorNamespacePrefix
                         {

--- a/Application/EdFi.Ods.AdminApp.Management/Database/Commands/EditVendorCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/Commands/EditVendorCommand.cs
@@ -45,20 +45,17 @@ namespace EdFi.Ods.AdminApp.Management.Database.Commands
                 }
             }
 
-            if (!string.IsNullOrEmpty(changedVendorData.NamespacePrefixes))
-            {
-                var namespacePrefixes = changedVendorData.NamespacePrefixes.Split(",")
-                    .Where(namespacePrefix => !string.IsNullOrWhiteSpace(namespacePrefix))
-                    .Select(namespacePrefix => new VendorNamespacePrefix
-                    {
-                        NamespacePrefix = namespacePrefix.Trim(),
-                        Vendor = vendor
-                    });
-
-                foreach (var namespacePrefix in namespacePrefixes)
+            var namespacePrefixes = changedVendorData.NamespacePrefixes?.Split(",")
+                .Where(namespacePrefix => !string.IsNullOrWhiteSpace(namespacePrefix))
+                .Select(namespacePrefix => new VendorNamespacePrefix
                 {
-                    _context.VendorNamespacePrefixes.Add(namespacePrefix);
-                }
+                    NamespacePrefix = namespacePrefix.Trim(),
+                    Vendor = vendor
+                });
+
+            foreach (var namespacePrefix in namespacePrefixes ?? Enumerable.Empty<VendorNamespacePrefix>())
+            {
+                _context.VendorNamespacePrefixes.Add(namespacePrefix);
             }
 
             if (vendor.Users?.FirstOrDefault() != null)


### PR DESCRIPTION
**Description**
- Added an "empty string" check on AddVendorCommand and EditVendorCommand to avoid trying to add empty strings as namespace prefixes. These strings will simply be avoided.
- Added a call to "Trim" on EditVendorCommand to remove leading and trailing spaces and be in parity with AddVendorCommand.
- Added AddVendor and EditVendor unit tests to cover the "empty" namespace prefix case.