### PR TITLE
[AA-1395] - Add Validation for Api Mode on AdminApp Installer

### DIFF
--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -598,6 +598,15 @@ function Invoke-InstallationPreCheck{
                 exit
             }
         }
+
+        if($Config.AdminAppFeatures.ContainsKey("ApiMode") -and $Config.AdminAppFeatures.ApiMode) {
+            $apiMode = $Config.AdminAppFeatures.ApiMode
+            $supportedModes = @('sandbox', 'sharedinstance', 'yearspecific', 'districtspecific')
+            if ($supportedModes -NotContains $apiMode) {
+                Write-Warning "Not supported ApiMode: '$apiMode'. Please use one of the supported modes for the ApiMode Admin App feature. Supported modes:'$($supportedModes -join "','")'"
+                exit
+            }
+        }
     }
 }
 

--- a/EdFi.Suite3.Installer.AdminApp/install.ps1
+++ b/EdFi.Suite3.Installer.AdminApp/install.ps1
@@ -66,7 +66,7 @@ Deploy Admin App for use with a "District Specific" ODS API
 #>
 
 $adminAppFeatures = @{
-    ApiMode = "sharedInstance"
+    ApiMode = "sharedinstance"
 }
 
 $p = @{

--- a/EdFi.Suite3.Installer.AdminApp/test.ps1
+++ b/EdFi.Suite3.Installer.AdminApp/test.ps1
@@ -175,7 +175,7 @@ function Invoke-InstallMultiInstanceSqlServer {
     }
 
     $adminAppFeatures = @{
-        ApiMode = "yearSpecific"
+        ApiMode = "yearspecific"
     }
 
     $p = @{


### PR DESCRIPTION
**Description**
- Added a validation check for ApiMode admin app feature. The installation exits if the api mode specified is not contained within the specified set of supported modes.Added a validation check for ApiMode admin app feature. The installation exits if the api mode specified is not contained within the specified set of supported modes.
- Refactored to use lowercase ApiMode settings to be in sync with the supported modes guidance.