### PR TITLE
[AA-1513] Remove .NET 3 Install

### DIFF
--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -1200,10 +1200,10 @@ function Set-SqlLogins {
         {
             Write-Host "Adding Sql Login for Admin Database:";
             Add-SqlLogins $Config.AdminDbConnectionInfo $Config.WebApplicationName -IsCustomLogin
-            
+
             Write-Host "Adding Sql Login for Ed-Fi ODS Database:";
             Add-SqlLogins $Config.OdsDbConnectionInfo $Config.WebApplicationName -IsCustomLogin
-            
+
             Write-Host "Adding Sql Login for Security Database:";
             Add-SqlLogins $Config.SecurityDbConnectionInfo $Config.WebApplicationName -IsCustomLogin
         }

--- a/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
+++ b/EdFi.Suite3.Installer.AdminApp/Install-EdFiOdsAdminApp.psm1
@@ -24,7 +24,6 @@ $RequiredDotNetHostingBundleVersion = "6.0.0"
 
 Import-Module -Force "$appCommonDirectory/Environment/Prerequisites.psm1" -Scope Global
 Set-TlsVersion
-Install-DotNetCore "C:\temp\tools"
 
 Import-Module -Force "$appCommonDirectory/Utility/hashtable.psm1" -Scope Global
 Import-Module -Force "$appCommonDirectory/Utility/nuget-helper.psm1"


### PR DESCRIPTION
Remove .NET Core 3.1 installation step from Admin App Installer, as Admin App requires .NET 6 only.

Additionally, we plan to update `Installer.AppCommon` to change the function removed here to allow the .NET version to be specified as a parameter. We may also combine this with the check for the correctly installed version.