### PR TITLE
AA-1572 Update command in order to select the firsts element in the s…

### DIFF
--- a/Application/EdFi.Ods.AdminApp.E2E.Tests/features/models/applicationsPage.ts
+++ b/Application/EdFi.Ods.AdminApp.E2E.Tests/features/models/applicationsPage.ts
@@ -111,7 +111,7 @@ export class ApplicationsPage extends AdminAppPage {
     }
 
     async addApplication(): Promise<void> {
-        await this.page.locator(this.addNewApplicationBtn).click();
+        await this.page.locator(this.addNewApplicationBtn).first().click();
     }
 
     async fillApplicationForm(): Promise<void> {
@@ -242,15 +242,15 @@ export class ApplicationsPage extends AdminAppPage {
     }
 
     async clickEdit(): Promise<void> {
-        await this.page.locator(this.editApplicationBtn).click();
+        await this.page.locator(this.editApplicationBtn).first().click();
     }
 
     async clickDelete(): Promise<void> {
-        await this.page.locator(this.deleteApplicationBtn).click();
+        await this.page.locator(this.deleteApplicationBtn).first().click();
     }
 
     async clickRegenerate() {
-        await this.page.locator(this.regenerateBtn).click();
+        await this.page.locator(this.regenerateBtn).first().click();
     }
 
     async confirmRegenerate() {
@@ -292,7 +292,7 @@ export class ApplicationsPage extends AdminAppPage {
     }
 
     async clickCollapse(): Promise<void> {
-        await this.page.locator(this.collapseBtn).click();
+        await this.page.locator(this.collapseBtn).first().click();
     }
 
     async isCollapsed(): Promise<boolean> {

--- a/Application/EdFi.Ods.AdminApp.E2E.Tests/features/models/vendorsPage.ts
+++ b/Application/EdFi.Ods.AdminApp.E2E.Tests/features/models/vendorsPage.ts
@@ -187,7 +187,7 @@ export class VendorsPage extends AdminAppPage {
     }
 
     async clickDelete(): Promise<void> {
-        await this.page.locator(this.deleteVendorBtn).click();
+        await this.page.locator(this.deleteVendorBtn).first().click();
     }
 
     async deleteVendor(): Promise<void> {
@@ -202,7 +202,7 @@ export class VendorsPage extends AdminAppPage {
     }
 
     async clickEdit(): Promise<void> {
-        await this.page.locator(this.editVendorBtn).click();
+        await this.page.locator(this.editVendorBtn).first().click();
     }
 
     async editVendorForm(): Promise<void> {

--- a/Application/EdFi.Ods.AdminApp.E2E.Tests/features/models/vendorsPage.ts
+++ b/Application/EdFi.Ods.AdminApp.E2E.Tests/features/models/vendorsPage.ts
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+
 import { context, network } from "../management/setup";
 import { AdminAppPage } from "./adminAppPage";
 


### PR DESCRIPTION
Update search selectors to take the first element they find in the region. Now it happens not every time that it finds two selectors with the same name and the test fails.

This change should not affect running in a clean environment or one that already has data.

<img width="1333" alt="188953319-130ab76e-041f-46b3-b1c1-bc5abb069192" src="https://user-images.githubusercontent.com/111309322/188968219-4b71a417-c7fc-4f78-96a2-b90aeda38612.png">
