### PR TITLE
[AA-1556] Disable Product Improvement By Configuration

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Configuration/Configuration/ApplicationConfigurationServiceTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Configuration/Configuration/ApplicationConfigurationServiceTests.cs
@@ -110,15 +110,19 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Configuration.Configuration
         public void ShouldDisableProductImprovementAlwaysWhenDisabledInSettings()
         {
             EnableProductImprovement(enableProductImprovement: true, productRegistrationId: "", enableProductImprovementSettings: true);
-            IsProductImprovementEnabled().ShouldBe((true, ""));
+            IsProductImprovementEnabled(true).ShouldBe((true, ""));
+            Count<ApplicationConfiguration>().ShouldBe(1);
+
+            EnableProductImprovement(enableProductImprovement: true, productRegistrationId: "", enableProductImprovementSettings: true);
+            IsProductImprovementEnabled(false).ShouldBe((false, ""));
             Count<ApplicationConfiguration>().ShouldBe(1);
 
             EnableProductImprovement(enableProductImprovement: true, productRegistrationId: "", enableProductImprovementSettings: false);
-            IsProductImprovementEnabled().ShouldBe((false, ""));
+            IsProductImprovementEnabled(true).ShouldBe((false, ""));
             Count<ApplicationConfiguration>().ShouldBe(1);
 
             EnableProductImprovement(enableProductImprovement: false, productRegistrationId: "", enableProductImprovementSettings: false);
-            IsProductImprovementEnabled().ShouldBe((false, ""));
+            IsProductImprovementEnabled(true).ShouldBe((false, ""));
             Count<ApplicationConfiguration>().ShouldBe(1);
         }
 
@@ -138,7 +142,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Configuration.Configuration
             });
         }
 
-        private (bool, string) IsProductImprovementEnabled()
+        private (bool, string) IsProductImprovementEnabled(bool areProductImprovementSettingsEnabled = true)
         {
             return Transaction(database =>
             {
@@ -147,7 +151,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Configuration.Configuration
 
                 Scoped<AdminAppIdentityDbContext>(identity =>
                 {
-                    var appSettings = new AppSettings { EnableProductImprovementSettings = true };
+                    var appSettings = new AppSettings { EnableProductImprovementSettings = areProductImprovementSettingsEnabled };
                     enableProductImprovement = new ApplicationConfigurationService(database, identity, Options.Create(appSettings))
                         .IsProductImprovementEnabled(out productRegistrationId);
                 });

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Configuration/Configuration/ApplicationConfigurationServiceTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Configuration/Configuration/ApplicationConfigurationServiceTests.cs
@@ -105,6 +105,23 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Configuration.Configuration
             IsProductImprovementEnabled().ShouldBe((false, null));
             Count<ApplicationConfiguration>().ShouldBe(1);
         }
+
+        [Test]
+        public void ShouldDisableProductImprovementAlwaysWhenDisabledInSettings()
+        {
+            EnableProductImprovement(enableProductImprovement: true, productRegistrationId: "", enableProductImprovementSettings: true);
+            IsProductImprovementEnabled().ShouldBe((true, ""));
+            Count<ApplicationConfiguration>().ShouldBe(1);
+
+            EnableProductImprovement(enableProductImprovement: true, productRegistrationId: "", enableProductImprovementSettings: false);
+            IsProductImprovementEnabled().ShouldBe((false, ""));
+            Count<ApplicationConfiguration>().ShouldBe(1);
+
+            EnableProductImprovement(enableProductImprovement: false, productRegistrationId: "", enableProductImprovementSettings: false);
+            IsProductImprovementEnabled().ShouldBe((false, ""));
+            Count<ApplicationConfiguration>().ShouldBe(1);
+        }
+
         private bool AllowUserRegistrations()
         {
             return Transaction(database =>

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Configuration/Configuration/ApplicationConfigurationServiceTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Configuration/Configuration/ApplicationConfigurationServiceTests.cs
@@ -7,6 +7,8 @@ using System;
 using EdFi.Ods.AdminApp.Management.Configuration.Application;
 using EdFi.Ods.AdminApp.Management.Database;
 using EdFi.Ods.AdminApp.Management.Database.Models;
+using EdFi.Ods.AdminApp.Management.Helpers;
+using Microsoft.Extensions.Options;
 using NUnit.Framework;
 using Shouldly;
 using static EdFi.Ods.AdminApp.Management.Tests.Testing;
@@ -100,7 +102,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Configuration.Configuration
 
                 Scoped<AdminAppIdentityDbContext>(identity =>
                 {
-                    allowUserRegistration = new ApplicationConfigurationService(database, identity).AllowUserRegistration();
+                    var appSettings = new AppSettings { EnableProductImprovementSettings = true };
+                    allowUserRegistration = new ApplicationConfigurationService(database, identity, Options.Create(appSettings)).AllowUserRegistration();
                 });
 
                 return allowUserRegistration;
@@ -116,7 +119,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Configuration.Configuration
 
                 Scoped<AdminAppIdentityDbContext>(identity =>
                 {
-                    enableProductImprovement = new ApplicationConfigurationService(database, identity)
+                    var appSettings = new AppSettings { EnableProductImprovementSettings = true };
+                    enableProductImprovement = new ApplicationConfigurationService(database, identity, Options.Create(appSettings))
                         .IsProductImprovementEnabled(out productRegistrationId);
                 });
 
@@ -124,13 +128,16 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Configuration.Configuration
             });
         }
 
-        private void EnableProductImprovement(bool enableProductImprovement, string productRegistrationId)
+        private void EnableProductImprovement(bool enableProductImprovement, string productRegistrationId,
+            bool enableProductImprovementSettings = true)
         {
+            var appSettings = new AppSettings { EnableProductImprovementSettings = enableProductImprovementSettings };
+
             Transaction(database =>
             {
                 Scoped<AdminAppIdentityDbContext>(identity =>
                 {
-                    new ApplicationConfigurationService(database, identity).EnableProductImprovement(
+                    new ApplicationConfigurationService(database, identity, Options.Create(appSettings)).EnableProductImprovement(
                         enableProductImprovement, productRegistrationId);
                 });
             });

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Configuration/Configuration/ApplicationConfigurationServiceTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Configuration/Configuration/ApplicationConfigurationServiceTests.cs
@@ -94,6 +94,17 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Configuration.Configuration
             Count<ApplicationConfiguration>().ShouldBe(1);
         }
 
+        [Test]
+        public void ShouldSetInitialProductImprovementBasedOnSettings()
+        {
+            CompleteFirstTimeSetUpStatus(true);
+            IsProductImprovementEnabled().ShouldBe((true, null));
+            Count<ApplicationConfiguration>().ShouldBe(1);
+
+            CompleteFirstTimeSetUpStatus(false);
+            IsProductImprovementEnabled().ShouldBe((false, null));
+            Count<ApplicationConfiguration>().ShouldBe(1);
+        }
         private bool AllowUserRegistrations()
         {
             return Transaction(database =>
@@ -139,6 +150,19 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Configuration.Configuration
                 {
                     new ApplicationConfigurationService(database, identity, Options.Create(appSettings)).EnableProductImprovement(
                         enableProductImprovement, productRegistrationId);
+                });
+            });
+        }
+
+        private void CompleteFirstTimeSetUpStatus(bool enableProductImprovementSettings)
+        {
+            EnsureZeroApplicationConfiguration();
+            var appSettings = new AppSettings { EnableProductImprovementSettings = enableProductImprovementSettings };
+            Transaction(database =>
+            {
+                Scoped<AdminAppIdentityDbContext>(identity =>
+                {
+                    new ApplicationConfigurationService(database, identity, Options.Create(appSettings)).UpdateFirstTimeSetUpStatus(true);
                 });
             });
         }

--- a/Application/EdFi.Ods.AdminApp.Management/Configuration/Application/ApplicationConfigurationService.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Configuration/Application/ApplicationConfigurationService.cs
@@ -39,7 +39,7 @@ namespace EdFi.Ods.AdminApp.Management.Configuration.Application
         {
             var config = _database.EnsureSingle<ApplicationConfiguration>();
             config.FirstTimeSetUpCompleted = setUpCompleted;
-            config.EnableProductImprovement = true;
+            config.EnableProductImprovement = _appSettings.EnableProductImprovementSettings;
            _database.SaveChanges();
         }
 

--- a/Application/EdFi.Ods.AdminApp.Management/Configuration/Application/ApplicationConfigurationService.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Configuration/Application/ApplicationConfigurationService.cs
@@ -61,7 +61,7 @@ namespace EdFi.Ods.AdminApp.Management.Configuration.Application
         public void EnableProductImprovement(bool enableProductImprovement, string productRegistrationId)
         {
             var config = _database.EnsureSingle<ApplicationConfiguration>();
-            config.EnableProductImprovement = enableProductImprovement;
+            config.EnableProductImprovement = _appSettings.EnableProductImprovementSettings && enableProductImprovement;
             config.ProductRegistrationId = (productRegistrationId ?? "").Trim();
             _database.SaveChanges();
         }

--- a/Application/EdFi.Ods.AdminApp.Management/Configuration/Application/ApplicationConfigurationService.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Configuration/Application/ApplicationConfigurationService.cs
@@ -55,7 +55,7 @@ namespace EdFi.Ods.AdminApp.Management.Configuration.Application
 
             productRegistrationId = config.ProductRegistrationId;
 
-            return enableProductImprovement;
+            return _appSettings.EnableProductImprovementSettings && enableProductImprovement;
         }
 
         public void EnableProductImprovement(bool enableProductImprovement, string productRegistrationId)

--- a/Application/EdFi.Ods.AdminApp.Management/Configuration/Application/ApplicationConfigurationService.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Configuration/Application/ApplicationConfigurationService.cs
@@ -6,6 +6,8 @@
 using System.Linq;
 using EdFi.Ods.AdminApp.Management.Database;
 using EdFi.Ods.AdminApp.Management.Database.Models;
+using EdFi.Ods.AdminApp.Management.Helpers;
+using Microsoft.Extensions.Options;
 
 namespace EdFi.Ods.AdminApp.Management.Configuration.Application
 {
@@ -13,11 +15,13 @@ namespace EdFi.Ods.AdminApp.Management.Configuration.Application
     {
         private readonly AdminAppDbContext _database;
         private readonly AdminAppIdentityDbContext _identity;
+        private readonly AppSettings _appSettings;
 
-        public ApplicationConfigurationService(AdminAppDbContext database, AdminAppIdentityDbContext identity)
+        public ApplicationConfigurationService(AdminAppDbContext database, AdminAppIdentityDbContext identity, IOptions<AppSettings> appSettings)
         {
             _database = database;
             _identity = identity;
+            _appSettings = appSettings.Value;
         }
 
         public bool AllowUserRegistration()

--- a/Application/EdFi.Ods.AdminApp.Management/Helpers/AppSettings.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Helpers/AppSettings.cs
@@ -28,6 +28,7 @@ namespace EdFi.Ods.AdminApp.Management.Helpers
         public string AwsCurrentVersion { get; set; }
         public string Log4NetConfigPath { get; set; }
         public string EncryptionKey { get; set; }
+        public bool EnableProductImprovementSettings { get; set; }
 
         public string GoogleAnalyticsMeasurementId { get; set; }
         public string ProductRegistrationUrl { get; set; }

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ProductImprovementController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ProductImprovementController.cs
@@ -3,13 +3,16 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System;
 using System.Threading.Tasks;
 using EdFi.Ods.AdminApp.Management;
 using Microsoft.AspNetCore.Mvc;
 using EdFi.Ods.AdminApp.Management.Configuration.Application;
+using EdFi.Ods.AdminApp.Management.Helpers;
 using EdFi.Ods.AdminApp.Web.ActionFilters;
 using EdFi.Ods.AdminApp.Web.Infrastructure;
 using EdFi.Ods.AdminApp.Web.Models.ViewModels;
+using Microsoft.Extensions.Options;
 
 namespace EdFi.Ods.AdminApp.Web.Controllers
 {
@@ -19,25 +22,30 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         private readonly ApplicationConfigurationService _applicationConfigurationService;
         private readonly IProductRegistration _productRegistration;
         private readonly AdminAppUserContext _userContext;
-        
+        private readonly AppSettings _appSettings;
+
         public ProductImprovementController(
             ApplicationConfigurationService applicationConfigurationService,
             IProductRegistration productRegistration,
+            IOptions<AppSettings> appSettings,
             AdminAppUserContext userContext)
         {
             _applicationConfigurationService = applicationConfigurationService;
             _productRegistration = productRegistration;
+            _appSettings = appSettings.Value;
             _userContext = userContext;
         }
 
         public ActionResult EditConfiguration()
         {
+            GuardForDisabledConfig();
             return View(GetProductImprovementModel());
         }
 
         [HttpPost]
         public async Task<ActionResult> EditConfiguration(ProductImprovementModel model)
         {
+            GuardForDisabledConfig();
             SaveProductImprovementModel(model);
             await _productRegistration.NotifyWhenEnabled(_userContext.User);
             return RedirectToAction("Index", "Home");
@@ -45,12 +53,14 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
 
         public ActionResult EnableProductImprovementFirstTimeSetup()
         {
+            GuardForDisabledConfig();
             return View(GetProductImprovementModel());
         }
 
         [HttpPost]
         public async Task<ActionResult> EnableProductImprovementFirstTimeSetup(ProductImprovementModel model)
         {
+            GuardForDisabledConfig();
             SaveProductImprovementModel(model);
             await _productRegistration.NotifyWhenEnabled(_userContext.User);
             return RedirectToAction("PostSetup", "Home", new {setupCompleted = true});
@@ -71,6 +81,16 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         private void SaveProductImprovementModel(ProductImprovementModel model)
         {
             _applicationConfigurationService.EnableProductImprovement(model.EnableProductImprovement, model.ProductRegistrationId);
+        }
+
+        private void GuardForDisabledConfig()
+        {
+            if (!_appSettings.EnableProductImprovementSettings)
+            {
+                var message = "Product Improvement Configuration is disabled." +
+                              "Re-Enable in application settings to make adjustments here.";
+                throw new Exception(message);
+            }
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/SetupController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/SetupController.cs
@@ -14,6 +14,7 @@ using EdFi.Ods.AdminApp.Management.Helpers;
 using EdFi.Ods.AdminApp.Web.ActionFilters;
 using EdFi.Ods.AdminApp.Web.Infrastructure;
 using EdFi.Ods.AdminApp.Web.Infrastructure.HangFire;
+using EdFi.Ods.AdminApp.Web.Models.ViewModels;
 using log4net;
 using Microsoft.Extensions.Options;
 
@@ -42,7 +43,11 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
 
         public ActionResult FirstTimeSetup()
         {
-            return View();
+            var model = new FirstTimeSetupModel
+            {
+                AreProductImprovementSettingsEnabled = _appSettings.EnableProductImprovementSettings,
+            };
+            return View(model);
         }
 
         [HttpPost]

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/SetupController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/SetupController.cs
@@ -24,7 +24,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
     public class SetupController : ControllerBase
     {
         private readonly ILog _logger = LogManager.GetLogger(typeof(SetupController));
-      
+
         private readonly ICompleteOdsFirstTimeSetupCommand _completeOdsFirstTimeSetupCommand;
         private readonly ICompleteOdsPostUpdateSetupCommand _completeOdsPostUpdateSetupCommand;
         private readonly ApplicationConfigurationService _applicationConfigurationService;
@@ -66,7 +66,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
                 Response.Cookies.Append("RestartRequired", restartRequired.ToString());
             });
         }
-        
+
         public ActionResult PostUpdateSetup()
         {
             return View();

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/FirstTimeSetupModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/FirstTimeSetupModel.cs
@@ -1,0 +1,11 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.Ods.AdminApp.Web.Models.ViewModels;
+
+public class FirstTimeSetupModel
+{
+    public bool AreProductImprovementSettingsEnabled { get; set; }
+}

--- a/Application/EdFi.Ods.AdminApp.Web/Views/Setup/FirstTimeSetup.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/Setup/FirstTimeSetup.cshtml
@@ -4,7 +4,7 @@ Licensed to the Ed-Fi Alliance under one or more agreements.
 The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 See the LICENSE and NOTICES files in the project root for more information.
 *@
-
+@model EdFi.Ods.AdminApp.Web.Models.ViewModels.FirstTimeSetupModel
 
 @{
     ViewBag.Title = "First Time Setup";
@@ -60,7 +60,15 @@ See the LICENSE and NOTICES files in the project root for more information.
         var handleSuccess = function() {
             $('#finish-setup-link').removeClass('btn-primary btn-danger').addClass('btn-success');
             $('#finish-setup-link').html('Success <span class="padding-left"><i class="fa fa-check-circle"></i></span>');
-            window.location = '@Url.Action("EnableProductImprovementFirstTimeSetup", "ProductImprovement")';
+
+            @if (Model.AreProductImprovementSettingsEnabled)
+            {
+              @: window.location = '@Url.Action("EnableProductImprovementFirstTimeSetup", "ProductImprovement")';
+            }
+            else
+            {
+              @: window.location = '@Url.Action("PostSetup", "Home", new {setupCompleted = true})';
+            }
         };
 
         var handleFailure = function (data) {

--- a/Application/EdFi.Ods.AdminApp.Web/Views/Setup/FirstTimeSetup.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/Setup/FirstTimeSetup.cshtml
@@ -36,7 +36,7 @@ See the LICENSE and NOTICES files in the project root for more information.
                 <strong>Note:</strong> Waiting for setup processes to complete. Will continue re-trying.
             </div>
         </div>
-    </div>    
+    </div>
     <div>
         <a href="#" class="btn btn-primary" id="finish-setup-link">Continue <span class="padding-left"><i class="fa fa-chevron-circle-right"></i></span></a>
     </div>
@@ -74,7 +74,7 @@ See the LICENSE and NOTICES files in the project root for more information.
         var handleFailure = function (data) {
             if (data.responseJSON && data.responseJSON.isTransientError) {
                 $('#transient-error-note').show();
-              
+
                 $.ajax(ajaxSettings)
                     .done(function() {
                         handleSuccess();

--- a/Application/EdFi.Ods.AdminApp.Web/Views/Shared/_Layout.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/Shared/_Layout.cshtml
@@ -76,7 +76,8 @@ See the LICENSE and NOTICES files in the project root for more information.
         <div class="row margin-right-30">
             @if (User.Identity.IsAuthenticated)
             {
-                <div class="col-md-1 col-md-offset-10 nav-links">
+                var offsetClass = AppSettings.Value.EnableProductImprovementSettings ? "col-md-offset-10" : "col-md-offset-11";
+                <div class="col-md-1 @offsetClass nav-links">
                     <a href="@Url.Action("Index", "Home")" class="text-nowrap">
                         <span class="fa fa-home"></span><strong>Home</strong>
                     </a>

--- a/Application/EdFi.Ods.AdminApp.Web/Views/Shared/_Layout.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/Shared/_Layout.cshtml
@@ -7,6 +7,10 @@ See the LICENSE and NOTICES files in the project root for more information.
 
 @using EdFi.Ods.AdminApp.Web.Helpers
 @using EdFi.Ods.AdminApp.Web.Infrastructure
+@using Microsoft.Extensions.Options
+@using EdFi.Ods.AdminApp.Management.Helpers
+
+@inject IOptions<AppSettings> AppSettings
 
 <!DOCTYPE html>
 <html lang="en">
@@ -77,11 +81,14 @@ See the LICENSE and NOTICES files in the project root for more information.
                         <span class="fa fa-home"></span><strong>Home</strong>
                     </a>
                 </div>
-                 <div class="col-md-1 nav-links">
-                     <a href="@Url.Action("EditConfiguration", "ProductImprovement")" class="text-nowrap">
-                         <span class="fa fa-cog"></span><strong>Configuration</strong>
-                     </a>
-                 </div>
+                @if (AppSettings.Value.EnableProductImprovementSettings)
+                {
+                    <div class="col-md-1 nav-links">
+                        <a href="@Url.Action("EditConfiguration", "ProductImprovement")" class="text-nowrap">
+                            <span class="fa fa-cog"></span><strong>Configuration</strong>
+                        </a>
+                    </div>
+                }
             }
         </div>
         <section>

--- a/Application/EdFi.Ods.AdminApp.Web/appsettings.json
+++ b/Application/EdFi.Ods.AdminApp.Web/appsettings.json
@@ -22,6 +22,7 @@
         "PathBase": "",
         "GoogleAnalyticsMeasurementId": "",
         "EncryptionKey": "",
+        "EnableProductImprovementSettings": true,
         "ProductRegistrationUrl": "https://edfi-tools-analytics.azurewebsites.net/data/v1/"
     },
     "ConnectionStrings": {


### PR DESCRIPTION
Introduces a new app settings flag which disables the "Product Improvement" configuration page and sets it to false.

- app settings flag defaults to `true`
- when flag is set to `false`:
  - configuration always returns product improvement is disabled
    - this handles scenario in which config was previously set to true,  before changing the flag
  - bypasses first-time-setup config screen and sets configuration to false during initialization
  - removes "⚙Configuration" link from layout and blocks direct access to page