### PR TITLE
[AA-1374] - Validate ODS/API before trying to communicate with it

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Controllers/EducationOrganizationsControllerTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Controllers/EducationOrganizationsControllerTests.cs
@@ -34,6 +34,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
         private Mock<ITabDisplayService> _tabDisplayService;
         private IInferExtensionDetails _inferExtensionDetails;
         private Mock<IInferExtensionDetails> _mockInferExtensionDetails;
+        private Mock<IOdsApiValidator> _mockOdsApiValidator;
 
         [SetUp]
         public void Init()
@@ -44,6 +45,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             _mockInstanceContext = new Mock<InstanceContext>();
             _tabDisplayService = new Mock<ITabDisplayService>();
             _mockInferExtensionDetails = new Mock<IInferExtensionDetails>();
+            _mockOdsApiValidator = new Mock<IOdsApiValidator>();
             _inferExtensionDetails = new InferExtensionDetails(new Mock<ISimpleGetRequest>().Object);
             MemoryCache.Default.Remove("TpdmExtensionVersion");
         }
@@ -63,7 +65,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             _mockOdsApiFacadeFactory.Setup(x => x.Create())
                 .Returns(Task.FromResult(_mockOdsApiFacade.Object));
             _controller =
-                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails, _mockOdsApiValidator.Object);
 
             // Act
             var result = _controller.AddLocalEducationAgency(addLocalEducationAgencyModel).Result as ContentResult;
@@ -88,7 +90,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             _mockOdsApiFacadeFactory.Setup(x => x.Create())
                 .Returns(Task.FromResult(_mockOdsApiFacade.Object));
             _controller =
-                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails, _mockOdsApiValidator.Object);
 
             // Act
             var result = _controller.AddPostSecondaryInstitution(addPostSecondaryInstitutionModel).Result as ContentResult;
@@ -113,7 +115,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             _mockOdsApiFacadeFactory.Setup(x => x.Create())
                 .Returns(Task.FromResult(_mockOdsApiFacade.Object));
             _controller =
-                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails, _mockOdsApiValidator.Object);
 
             // Act
             var result = _controller.AddSchool(addSchoolModel).Result as ContentResult;
@@ -138,7 +140,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             _mockOdsApiFacadeFactory.Setup(x => x.Create())
                 .Returns(Task.FromResult(_mockOdsApiFacade.Object));
             _controller =
-                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails, _mockOdsApiValidator.Object);
 
             // Act
             var result = _controller.AddPsiSchool(addPsiSchoolModel).Result as ContentResult;
@@ -172,7 +174,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             _mockMapper.Setup(x => x.Map<EditLocalEducationAgencyModel>(It.IsAny<LocalEducationAgency>()))
                 .Returns(editLocalEducationAgencyModel);
             _controller =
-                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails, _mockOdsApiValidator.Object);
 
             // Act
             var result =
@@ -205,7 +207,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             _mockOdsApiFacadeFactory.Setup(x => x.Create())
                 .Returns(Task.FromResult(_mockOdsApiFacade.Object));
             _controller =
-                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails, _mockOdsApiValidator.Object);
 
             // Act
             var result = _controller.EditLocalEducationAgency(editLocalEducationAgencyModel).Result as ContentResult;
@@ -234,7 +236,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             _mockOdsApiFacadeFactory.Setup(x => x.Create())
                 .Returns(Task.FromResult(_mockOdsApiFacade.Object));
             _controller =
-                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails, _mockOdsApiValidator.Object);
 
             // Act
             var result = _controller.EditLocalEducationAgency(editLocalEducationAgencyModel).Result as ContentResult;
@@ -260,7 +262,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             _mockOdsApiFacadeFactory.Setup(x => x.Create())
                 .Returns(Task.FromResult(_mockOdsApiFacade.Object));
             _controller =
-                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails, _mockOdsApiValidator.Object);
 
             // Act
             var result = _controller.EditPostSecondaryInstitution(editPostSecondaryInstitutionModel).Result as ContentResult;
@@ -289,7 +291,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             _mockOdsApiFacadeFactory.Setup(x => x.Create())
                 .Returns(Task.FromResult(_mockOdsApiFacade.Object));
             _controller =
-                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails, _mockOdsApiValidator.Object);
 
             // Act
             var result = _controller.EditPostSecondaryInstitution(editPostSecondaryInstitutionModel).Result as ContentResult;
@@ -322,7 +324,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             _mockOdsApiFacadeFactory.Setup(x => x.Create())
                 .Returns(Task.FromResult(_mockOdsApiFacade.Object));
             _controller =
-                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails, _mockOdsApiValidator.Object);
 
             // Act
             var result = _controller.EditSchoolModal(schoolId).Result as PartialViewResult;
@@ -376,7 +378,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
                 .Returns(new List<SelectOptionModel>
                     {new SelectOptionModel {DisplayText = federalLocaleCode, Value = federalLocaleCodeValue}});
             _controller =
-                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _mockInferExtensionDetails.Object);
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _mockInferExtensionDetails.Object, _mockOdsApiValidator.Object);
 
             // Act
             var result = _controller.EditPsiSchoolModal(schoolId).Result as PartialViewResult;
@@ -431,7 +433,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             _mockOdsApiFacade.Setup(x => x.GetAccreditationStatusOptions()).Returns<List<SelectOptionModel>>(null);
             _mockOdsApiFacade.Setup(x => x.GetFederalLocaleCodes()).Returns<List<SelectOptionModel>>(null);
             _controller =
-                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _mockInferExtensionDetails.Object);
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _mockInferExtensionDetails.Object, _mockOdsApiValidator.Object);
 
             // Act
             var result = _controller.EditPsiSchoolModal(schoolId).Result as PartialViewResult;
@@ -464,7 +466,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             _mockOdsApiFacadeFactory.Setup(x => x.Create())
                 .Returns(Task.FromResult(_mockOdsApiFacade.Object));
             _controller =
-                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails, _mockOdsApiValidator.Object);
 
             // Act
             var result = _controller.EditSchool(editSchoolModel).Result as ContentResult;
@@ -491,7 +493,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             _mockOdsApiFacadeFactory.Setup(x => x.Create())
                 .Returns(Task.FromResult(_mockOdsApiFacade.Object));
             _controller =
-                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails, _mockOdsApiValidator.Object);
 
             // Act
             var result = _controller.EditSchool(editSchoolModel).Result as ContentResult;
@@ -516,7 +518,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             _mockOdsApiFacadeFactory.Setup(x => x.Create())
                 .Returns(Task.FromResult(_mockOdsApiFacade.Object));
             _controller =
-                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails, _mockOdsApiValidator.Object);
 
             // Act
             var result = _controller.EditPsiSchool(editPsiSchoolModel).Result as ContentResult;
@@ -543,7 +545,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             _mockOdsApiFacadeFactory.Setup(x => x.Create())
                 .Returns(Task.FromResult(_mockOdsApiFacade.Object));
             _controller =
-                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails, _mockOdsApiValidator.Object);
 
             // Act
             var result = _controller.EditPsiSchool(editPsiSchoolModel).Result as ContentResult;
@@ -589,7 +591,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
                 .Returns(new List<SelectOptionModel>
                     {new SelectOptionModel {DisplayText = localEducationAgencyCategory, Value = localEducationAgencyCategoryValue}});
             _controller =
-                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails, _mockOdsApiValidator.Object);
 
             // Act
             var result = _controller.LocalEducationAgencyList(1).Result as PartialViewResult;
@@ -669,7 +671,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
                 .Returns(new List<SelectOptionModel>
                     {new SelectOptionModel {DisplayText = federalLocaleCode, Value = federalLocaleCodeValue}});
             _controller =
-                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _mockInferExtensionDetails.Object);
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _mockInferExtensionDetails.Object, _mockOdsApiValidator.Object);
 
             // Act
             var result = _controller.PostSecondaryInstitutionsList(1).Result as PartialViewResult;
@@ -744,7 +746,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
                 .Returns(new List<SelectOptionModel>
                     {new SelectOptionModel {DisplayText = administrativeFundingControl, Value = administrativeFundingControlValue}});         
             _controller =
-                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _mockInferExtensionDetails.Object);
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _mockInferExtensionDetails.Object, _mockOdsApiValidator.Object);
 
             // Act
             var result = _controller.PostSecondaryInstitutionsList(1).Result as PartialViewResult;
@@ -788,7 +790,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             _mockOdsApiFacadeFactory.Setup(x => x.Create())
                 .Returns(Task.FromResult(_mockOdsApiFacade.Object));
             _controller =
-                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails, _mockOdsApiValidator.Object);
 
             // Act
             var result = _controller.DeletePostSecondaryInstitution(deletePostSecondaryInstitutionModel).Result as ContentResult;
@@ -814,7 +816,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             _mockOdsApiFacadeFactory.Setup(x => x.Create())
                 .Returns(Task.FromResult(_mockOdsApiFacade.Object));
             _controller =
-                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails, _mockOdsApiValidator.Object);
 
             // Act
             var result = _controller.DeletePostSecondaryInstitution(deletePostSecondaryInstitutionModel).Result as ContentResult;
@@ -838,7 +840,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             _mockOdsApiFacadeFactory.Setup(x => x.Create())
                 .Returns(Task.FromResult(_mockOdsApiFacade.Object));
             _controller =
-                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails, _mockOdsApiValidator.Object);
 
             // Act
             var result = _controller.DeleteLocalEducationAgency(deleteLocalEducationAgencyModel).Result as ContentResult;
@@ -864,7 +866,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             _mockOdsApiFacadeFactory.Setup(x => x.Create())
                 .Returns(Task.FromResult(_mockOdsApiFacade.Object));
             _controller =
-                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails, _mockOdsApiValidator.Object);
 
             // Act
             var result = _controller.DeleteLocalEducationAgency(deleteLocalEducationAgencyModel).Result as ContentResult;
@@ -888,7 +890,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             _mockOdsApiFacadeFactory.Setup(x => x.Create())
                 .Returns(Task.FromResult(_mockOdsApiFacade.Object));
             _controller =
-                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails, _mockOdsApiValidator.Object);
 
             // Act
             var result = _controller.DeleteSchool(deleteLocalEducationAgencyModel).Result as ContentResult;
@@ -914,7 +916,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Controllers
             _mockOdsApiFacadeFactory.Setup(x => x.Create())
                 .Returns(Task.FromResult(_mockOdsApiFacade.Object));
             _controller =
-                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails);
+                new EducationOrganizationsController(_mockOdsApiFacadeFactory.Object, _mockMapper.Object, _mockInstanceContext.Object, _tabDisplayService.Object, _inferExtensionDetails, _mockOdsApiValidator.Object);
 
             // Act
             var result = _controller.DeleteSchool(deleteLocalEducationAgencyModel).Result as ContentResult;

--- a/Application/EdFi.Ods.AdminApp.Management.UnitTests/Api/OdsApiValidatorTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.UnitTests/Api/OdsApiValidatorTests.cs
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Threading.Tasks;
+using EdFi.Ods.AdminApp.Management.Api;
+using EdFi.Ods.AdminApp.Management.Services;
+using NUnit.Framework;
+using Shouldly;
+
+namespace EdFi.Ods.AdminApp.Management.UnitTests.Api
+{
+    [TestFixture]
+    public class OdsApiValidatorTests
+    {
+        private const string ValidOdsApiUrl = "https://valid/api";
+        private const string InvalidOdsApiUrl = "https://invalid/api";
+
+        class StubGetRequest : ISimpleGetRequest
+        {
+            private readonly string _expectedAddress;
+            private readonly string _jsonResponse;
+
+            public StubGetRequest(string expectedAddress, string jsonResponse)
+            {
+                _expectedAddress = expectedAddress;
+                _jsonResponse = jsonResponse;
+            }
+
+            public Task<string> DownloadString(string address)
+            {
+                address.ShouldBe(_expectedAddress);
+                return Task.FromResult(_jsonResponse);
+            }
+        }
+
+        private static string ExampleOdsRootDocumentV1()
+        {
+            return @"{
+                      ""version"": ""6.0"",
+                      ""informationalVersion"": ""6.0"",
+                      ""suite"": ""3"",
+                      ""build"": ""6.0.1192.0"",
+                      ""apiMode"": ""Sandbox"",
+                      ""dataModels"": [
+                        {
+                          ""name"": ""Ed-Fi"",
+                          ""version"": ""4.0.0-a"",
+                          ""informationalVersion"": ""The Ed-Fi Data Model 4.0a""
+                        },
+                        {
+                          ""name"": ""TPDM"",
+                          ""version"": ""1.1.0"",
+                          ""informationalVersion"": ""TPDM-Core""
+                        }
+                      ],
+                      ""urls"": {
+                        ""dependencies"": ""https://api.ed-fi.org/v6.0/api/metadata/data/v3/dependencies"",
+                        ""openApiMetadata"": ""https://api.ed-fi.org/v6.0/api/metadata/"",
+                        ""oauth"": ""https://api.ed-fi.org/v6.0/api/oauth/token"",
+                        ""dataManagementApi"": ""https://api.ed-fi.org/v6.0/api/data/v3/"",
+                        ""xsdMetadata"": ""https://api.ed-fi.org/v6.0/api/metadata/xsd"",
+                        ""changeQueries"": ""https://api.ed-fi.org/v6.0/api/changeQueries/v1/"",
+                        ""composites"": ""https://api.ed-fi.org/v6.0/api/composites/v1/"",
+                        ""identity"": ""https://api.ed-fi.org/v6.0/api/identity/v2/""
+                      }
+                    }";
+        }
+
+        private static string ExampleOdsRootDocumentV2()
+        {
+            return @"{
+                        ""version"": ""3.2.0"",
+                        ""informationalVersion"": ""3.2.0"",
+                        ""build"": ""3.2.0.4982"",
+                        ""apiMode"": ""Sandbox"",
+                        ""dataModels"": [
+                            { ""name"": ""Ed-Fi"", ""version"": ""3.1.0"" },
+                            { ""name"": ""GrandBend"", ""version"": ""1.0.0"" }
+                        ]
+                    }";
+        }
+
+        private static string ExampleOdsRootDocumentV3()
+        {
+            return @"{
+                    ""version"": ""5.2"",
+                    ""informationalVersion"": ""5.2""
+                   }";
+        }
+
+        private static string ExampleOdsRootDocumentV4()
+        {
+            return @"{
+                    "",""5.2""
+                   }";
+        }
+
+        private static string ExampleOdsRootDocumentV5()
+        {
+            return @"{
+                        ""version"": ""3.2.0"",
+                        ""informationalVersion"": ""3.2.0"",
+                        ""build"": ""3.2.0.4982"",
+                        ""apiMode"": ""Sandbox"",
+                        ""dataModels"": [
+                            { ""name"": ""GrandBend"", ""version"": ""1.0.0"" }
+                        ]
+                    }";
+        }
+
+        private static async Task<OdsApiValidatorResult> OdsApiValidationResult(string odsApiUrl, string rootDocument = null)
+        {
+            var getRootDocument = new StubGetRequest(odsApiUrl, rootDocument);
+
+            var validator = new OdsApiValidator(getRootDocument);
+
+            return await validator.Validate(odsApiUrl);
+        }
+
+        [Test]
+        public async Task ShouldBeValidForValidRootDocument()
+        {
+            var rootDocument = ExampleOdsRootDocumentV2();
+
+            var result = (await OdsApiValidationResult(ValidOdsApiUrl, rootDocument)).IsValidOdsApi;
+
+            result.ShouldBe(true);
+        }
+
+        [Test]
+        public async Task ShouldBeValidForValidRootDocumentWithMinimumRequiredFields()
+        {
+            var rootDocument = ExampleOdsRootDocumentV1();
+
+            var result = (await OdsApiValidationResult(ValidOdsApiUrl, rootDocument)).IsValidOdsApi;
+
+            result.ShouldBe(true);
+        }
+
+        [Test]
+        public async Task ShouldBeInvalidForNoRootDocument()
+        {
+            var result = (await OdsApiValidationResult(InvalidOdsApiUrl)).IsValidOdsApi;
+
+            result.ShouldBe(false);
+        }
+
+        [Test]
+        public async Task ShouldBeInValidForRootDocumentWithMissingFields()
+        {
+            var rootDocument = ExampleOdsRootDocumentV3();
+
+            var result = (await OdsApiValidationResult(InvalidOdsApiUrl, rootDocument)).IsValidOdsApi;
+
+            result.ShouldBe(false);
+        }
+
+        [Test]
+        public async Task ShouldBeInValidForMalformedRootDocument()
+        {
+            var rootDocument = ExampleOdsRootDocumentV4();
+
+            var result = (await OdsApiValidationResult(InvalidOdsApiUrl, rootDocument)).IsValidOdsApi;
+
+            result.ShouldBe(false);
+        }
+
+        [Test]
+        public async Task ShouldBeInValidForRootDocumentWithMissingEdFiDataModel()
+        {
+            var rootDocument = ExampleOdsRootDocumentV5();
+
+            var result = (await OdsApiValidationResult(InvalidOdsApiUrl, rootDocument)).IsValidOdsApi;
+
+            result.ShouldBe(false);
+        }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiValidator.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiValidator.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using EdFi.Ods.AdminApp.Management.ErrorHandling;
 using EdFi.Ods.AdminApp.Management.Services;
@@ -50,11 +51,23 @@ namespace EdFi.Ods.AdminApp.Management.Api
                         IsValidOdsApi = true
                     };
 
-                return InvalidOdsApiValidatorResult();
+                return InvalidOdsApiValidatorResult("The API provided does not have a valid root JSON document.");
             }
-            catch (Exception)
+            catch (InvalidOperationException exception)
             {
-                return InvalidOdsApiValidatorResult();
+                return InvalidOdsApiValidatorResult(exception.Message);
+            }
+            catch (JsonException exception)
+            {
+                return InvalidOdsApiValidatorResult($"The API provided does not have a valid root JSON document. JSON Parser Exception encountered: {exception.Message}");
+            }
+            catch (HttpRequestException exception)
+            {
+                return InvalidOdsApiValidatorResult(exception.Message, exception.StatusCode??HttpStatusCode.ServiceUnavailable);
+            }
+            catch (Exception exception)
+            {
+                return InvalidOdsApiValidatorResult(exception.Message);
             }
 
             string GetSchemaJson() => @"{
@@ -135,14 +148,23 @@ namespace EdFi.Ods.AdminApp.Management.Api
                               ]
                          }";
 
-            OdsApiValidatorResult InvalidOdsApiValidatorResult() => new()
+            OdsApiValidatorResult InvalidOdsApiValidatorResult(string exceptionMessage, HttpStatusCode statusCode = HttpStatusCode.ServiceUnavailable)
             {
-                IsValidOdsApi = false,
-                Exception = new OdsApiConnectionException(
-                        HttpStatusCode.BadRequest, "Invalid ODS API configured.",
-                        $"Invalid ODS API configured. Please verify that the Production ODS API Url ({apiServerUrl})) is configured correctly.")
-                { AllowFeedback = false }
-            };
+                var message =
+                    $"Invalid ODS API configured. Please verify that the Production ODS API Url ({apiServerUrl})) is configured correctly.";
+                if (!string.IsNullOrEmpty(exceptionMessage))
+                {
+                    message += $"Error Details: {exceptionMessage}";
+                }
+                
+                return new OdsApiValidatorResult
+                {
+                    IsValidOdsApi = false,
+                    Exception = new OdsApiConnectionException(
+                            statusCode, "Invalid ODS API configured.", message)
+                        { AllowFeedback = false }
+                };
+            }
         }
 
         private static JObject ParseJson(string contentAsString)

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiValidator.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiValidator.cs
@@ -96,7 +96,7 @@ namespace EdFi.Ods.AdminApp.Management.Api
                                       ""properties"": {
                                         ""name"": {
                                           ""type"": ""string"",
-                                          ""pattern"": ""Ed-Fi""  
+                                          ""pattern"": ""Ed-Fi""
                                         },
                                         ""version"": {
                                           ""type"": ""string""
@@ -156,7 +156,7 @@ namespace EdFi.Ods.AdminApp.Management.Api
                 {
                     message += $" Error Details: {exceptionMessage}";
                 }
-                
+
                 return new OdsApiValidatorResult
                 {
                     IsValidOdsApi = false,

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiValidator.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiValidator.cs
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using EdFi.Ods.AdminApp.Management.ErrorHandling;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace EdFi.Ods.AdminApp.Management.Api
+{
+    public interface IOdsApiValidator
+    {
+        Task<OdsApiValidatorResult> Validate(string apiServerUrl);
+    }
+
+    public class OdsApiValidatorResult
+    {
+        public bool IsValidOdsApi { get; set; }
+
+        public Exception Exception { get; set; }
+    }
+
+    public class OdsApiValidator : IOdsApiValidator
+    {
+        private readonly IHttpClientFactory _clientFactory;
+
+        public OdsApiValidator(IHttpClientFactory clientFactory)
+        {
+            _clientFactory = clientFactory;
+        }
+
+        public async Task<OdsApiValidatorResult> Validate(string apiServerUrl)
+        {
+            var httpClient = _clientFactory.CreateClient();
+
+            try
+            {
+                using (var response = await httpClient.GetAsync(apiServerUrl))
+                {
+                    using (var content = response.Content)
+                    {
+                        var contentAsString = await content.ReadAsStringAsync();
+
+                        var schemaJson = GetSchemaJson();
+
+                        var schema = await NJsonSchema.JsonSchema.FromJsonAsync(schemaJson);
+
+                        var parsedContent = TryParseJson(contentAsString);
+
+                        if (parsedContent == null)
+                        {
+                            return InvalidOdsApiValidatorResult();
+                        }
+
+                        var errors = schema.Validate(parsedContent);
+                        if (errors.Count == 0)
+                            return new OdsApiValidatorResult
+                            {
+                                IsValidOdsApi = true
+                            };
+                    }
+                }
+
+                return InvalidOdsApiValidatorResult();
+            }
+            catch (Exception)
+            {
+                return InvalidOdsApiValidatorResult();
+            }
+
+            string GetSchemaJson() => @"{
+                              ""type"": ""object"",
+                              ""properties"": {
+                                ""version"": {
+                                  ""type"": ""string""
+                                },
+                                ""informationalVersion"": {
+                                  ""type"": ""string""
+                                },
+                                ""suite"": {
+                                  ""type"": ""string""
+                                },
+                                ""build"": {
+                                  ""type"": ""string""
+                                },
+                                ""apiMode"": {
+                                  ""type"": ""string""
+                                },
+                                ""dataModels"": {
+                                  ""type"": ""array"",
+                                  ""items"": [
+                                    {
+                                      ""type"": ""object"",
+                                      ""properties"": {
+                                        ""name"": {
+                                          ""type"": ""string""
+                                        },
+                                        ""version"": {
+                                          ""type"": ""string""
+                                        },
+                                        ""informationalVersion"": {
+                                          ""type"": ""string""
+                                        }
+                                      },
+                                      ""required"": [
+                                        ""name"",
+                                        ""version""
+                                      ]
+                                    },
+                                    {
+                                      ""type"": ""object"",
+                                      ""properties"": {
+                                        ""name"": {
+                                          ""type"": ""string""
+                                        },
+                                        ""version"": {
+                                          ""type"": ""string""
+                                        },
+                                        ""informationalVersion"": {
+                                          ""type"": ""string""
+                                        }
+                                      },
+                                      ""required"": [
+                                        ""name"",
+                                        ""version""
+                                      ]
+                                    }
+                                  ]
+                                },
+                                ""urls"": {
+                                  ""type"": ""object"",
+                                  ""properties"": {
+                                    ""dependencies"": {
+                                      ""type"": ""string""
+                                    },
+                                    ""openApiMetadata"": {
+                                      ""type"": ""string""
+                                    },
+                                    ""oauth"": {
+                                      ""type"": ""string""
+                                    },
+                                    ""dataManagementApi"": {
+                                      ""type"": ""string""
+                                    },
+                                    ""xsdMetadata"": {
+                                      ""type"": ""string""
+                                    }
+                                  },
+                                  ""required"": [
+                                    ""dependencies"",
+                                    ""openApiMetadata"",
+                                    ""oauth"",
+                                    ""dataManagementApi"",
+                                    ""xsdMetadata""
+                                  ]
+                                }
+                              },
+                              ""required"": [
+                                ""version"",
+                                ""informationalVersion"",
+                                ""build"",
+                                ""apiMode""
+                              ]
+                         }";
+
+            OdsApiValidatorResult InvalidOdsApiValidatorResult() => new()
+            {
+                IsValidOdsApi = false,
+                Exception = new OdsApiConnectionException(
+                        HttpStatusCode.BadRequest, "Invalid ODS API configured.",
+                        $"Invalid ODS API configured. Please verify that the Production ODS API Url ({apiServerUrl})) is configured correctly.")
+                { AllowFeedback = false }
+            };
+        }
+
+        private static JObject TryParseJson(string contentAsString)
+        {
+            if (string.IsNullOrEmpty(contentAsString))
+                return null;
+
+            try
+            {
+                return JObject.Parse(contentAsString);
+            }
+            catch (JsonException)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiValidator.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiValidator.cs
@@ -41,12 +41,7 @@ namespace EdFi.Ods.AdminApp.Management.Api
 
                 var schema = await NJsonSchema.JsonSchema.FromJsonAsync(schemaJson);
 
-                var parsedContent = TryParseJson(contentAsString);
-
-                if (parsedContent == null)
-                {
-                    return InvalidOdsApiValidatorResult();
-                }
+                var parsedContent = ParseJson(contentAsString);
 
                 var errors = schema.Validate(parsedContent);
                 if (errors.Count == 0)
@@ -150,19 +145,11 @@ namespace EdFi.Ods.AdminApp.Management.Api
             };
         }
 
-        private static JObject TryParseJson(string contentAsString)
+        private static JObject ParseJson(string contentAsString)
         {
-            if (string.IsNullOrEmpty(contentAsString))
-                return null;
-
-            try
-            {
-                return JObject.Parse(contentAsString);
-            }
-            catch (JsonException)
-            {
-                return null;
-            }
+            return string.IsNullOrEmpty(contentAsString)
+                ? null
+                : JObject.Parse(contentAsString);
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiValidator.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/OdsApiValidator.cs
@@ -151,10 +151,10 @@ namespace EdFi.Ods.AdminApp.Management.Api
             OdsApiValidatorResult InvalidOdsApiValidatorResult(string exceptionMessage, HttpStatusCode statusCode = HttpStatusCode.ServiceUnavailable)
             {
                 var message =
-                    $"Invalid ODS API configured. Please verify that the Production ODS API Url ({apiServerUrl})) is configured correctly.";
+                    $"Invalid ODS API configured. Please verify that the Production ODS API Url ({apiServerUrl}) is configured correctly.";
                 if (!string.IsNullOrEmpty(exceptionMessage))
                 {
-                    message += $"Error Details: {exceptionMessage}";
+                    message += $" Error Details: {exceptionMessage}";
                 }
                 
                 return new OdsApiValidatorResult

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="NJsonSchema" Version="10.7.2" />
     <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="RestSharp" Version="106.12.0" />
   </ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/EducationOrganizationsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/EducationOrganizationsController.cs
@@ -32,21 +32,30 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         private readonly InstanceContext _instanceContext;
         private readonly ITabDisplayService _tabDisplayService;
         private readonly IInferExtensionDetails _inferExtensionDetails;
+        private readonly IOdsApiValidator _odsApiValidator;
 
         public EducationOrganizationsController(IOdsApiFacadeFactory odsApiFacadeFactory
             , IMapper mapper, InstanceContext instanceContext, ITabDisplayService tabDisplayService
-            , IInferExtensionDetails inferExtensionDetails)
+            , IInferExtensionDetails inferExtensionDetails, IOdsApiValidator odsApiValidator)
         {
             _odsApiFacadeFactory = odsApiFacadeFactory;
             _mapper = mapper;
             _instanceContext = instanceContext;
             _tabDisplayService = tabDisplayService;
             _inferExtensionDetails = inferExtensionDetails;
+            _odsApiValidator = odsApiValidator;
         }
 
         [AddTelemetry("Local Education Agencies Index", TelemetryType.View)]
         public async Task<ActionResult> LocalEducationAgencies()
         {
+            var validatorResult = await _odsApiValidator.Validate(CloudOdsAdminAppSettings.AppSettings.ProductionApiUrl);
+            
+            if (!validatorResult.IsValidOdsApi)
+            {
+                throw validatorResult.Exception;
+            }
+
             var model = new EducationOrganizationsIndexModel
             {
                 OdsInstanceSettingsTabEnumerations =
@@ -63,6 +72,13 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         [AddTelemetry("Post-Secondary Institutions Index", TelemetryType.View)]
         public async Task<ActionResult> PostSecondaryInstitutions()
         {
+            var validatorResult = await _odsApiValidator.Validate(CloudOdsAdminAppSettings.AppSettings.ProductionApiUrl);
+            
+            if (!validatorResult.IsValidOdsApi)
+            {
+                throw validatorResult.Exception;
+            }
+
             var model = new EducationOrganizationsIndexModel
             {
                 OdsInstanceSettingsTabEnumerations =


### PR DESCRIPTION
**Description**
- Added OdsApiValidator.cs to act as the validator service for ODS API and perform a JSON schema check for the configured ODS API Url.Added NJsonSchema package for JSON schema validation.
- Used IOdsApiValidator to validate the API before trying to communicate with the API using a client.
- Added unit tests for OdsApiValidator.cs.