### PR TITLE
[ODST-214] - Fixes created school within some LEA not being displayed under that LEA

### DIFF
--- a/Application/EdFi.Ods.Admin.Api/EdFi.Ods.Admin.Api.csproj
+++ b/Application/EdFi.Ods.Admin.Api/EdFi.Ods.Admin.Api.csproj
@@ -14,8 +14,8 @@
 
   <ItemGroup>
     <PackageReference Include="Asp.Versioning.Http" Version="6.0.0-preview.3" />
-    <PackageReference Include="AutoMapper" Version="11.0.1" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
+    <PackageReference Include="AutoMapper" Version="10.1.1" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
     <PackageReference Include="FluentValidation" Version="10.4.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.4.0" />
     <PackageReference Include="log4net" Version="2.0.13" />

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.2" />
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="6.0.2" />
-    <PackageReference Include="AutoMapper" Version="11.0.1" />
+    <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="dbup-core" Version="4.5.0" />
     <PackageReference Include="dbup-postgresql" Version="4.5.0" />

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -26,8 +26,8 @@
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="27.2.1" />
-    <PackageReference Include="AutoMapper" Version="11.0.1" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
+    <PackageReference Include="AutoMapper" Version="10.1.1" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
     <PackageReference Include="EdFi.Admin.LearningStandards.Core" Version="1.2.27" />
     <PackageReference Include="EdFi.Suite3.LoadTools" Version="5.4.12" />
     <PackageReference Include="FluentValidation" Version="10.4.0" />


### PR DESCRIPTION
**Description**
Downgraded AutoMapper (from 11.0.1 to 10.1.1) and AutoMapper.Extensions.Microsoft.DependencyInjection (from 11.0.0 to 8.1.1) packages as a temporary fix to the issue with LocalEducationAgencyReferenceResolver not being called during mapping.