### PR TITLE
[ODST-216] - Upgrade AutoMapper and Fix for LocalEducationAgencyReferenceResolver issue

### DIFF
--- a/Application/EdFi.Ods.Admin.Api/EdFi.Ods.Admin.Api.csproj
+++ b/Application/EdFi.Ods.Admin.Api/EdFi.Ods.Admin.Api.csproj
@@ -14,8 +14,8 @@
 
   <ItemGroup>
     <PackageReference Include="Asp.Versioning.Http" Version="6.0.0-preview.3" />
-    <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
+    <PackageReference Include="AutoMapper" Version="11.0.1" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
     <PackageReference Include="FluentValidation" Version="10.4.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.4.0" />
     <PackageReference Include="log4net" Version="2.0.13" />

--- a/Application/EdFi.Ods.AdminApp.Management/Api/Automapper/AdminManagementMappingProfile.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/Automapper/AdminManagementMappingProfile.cs
@@ -106,7 +106,8 @@ namespace EdFi.Ods.AdminApp.Management.Api.Automapper
                 .ForCtorParam("nameOfInstitution", opt => opt.MapFrom(src => src.Name))
                 .ForCtorParam("addresses", opt => opt.MapFrom(AddressResolver))
                 .ForCtorParam("educationOrganizationCategories", opt => opt.MapFrom(EducationOrganizationCategoryResolver.Resolve))
-                .ForCtorParam("gradeLevels", opt => opt.MapFrom(SchoolGradeLevelResolver.Resolve));
+                .ForCtorParam("gradeLevels", opt => opt.MapFrom(SchoolGradeLevelResolver.Resolve))
+                .ForCtorParam("localEducationAgencyReference", opt => opt.MapFrom(LocalEducationAgencyReferenceResolver.Resolve));
 
             CreateMap<PsiSchool, EdFiSchool>()
                 .ForMember(dst => dst.Id, opt => opt.MapFrom(src => src.Id))
@@ -125,7 +126,8 @@ namespace EdFi.Ods.AdminApp.Management.Api.Automapper
                 .ForCtorParam("nameOfInstitution", opt => opt.MapFrom(src => src.Name))
                 .ForCtorParam("addresses", opt => opt.MapFrom(AddressResolver))
                 .ForCtorParam("educationOrganizationCategories", opt => opt.MapFrom(EducationOrganizationCategoryResolver.Resolve))
-                .ForCtorParam("gradeLevels", opt => opt.MapFrom(SchoolGradeLevelResolver.Resolve));
+                .ForCtorParam("gradeLevels", opt => opt.MapFrom(SchoolGradeLevelResolver.Resolve))
+                .ForCtorParam("localEducationAgencyReference", opt => opt.MapFrom(LocalEducationAgencyReferenceResolver.Resolve));
 
 
             CreateMap<LocalEducationAgency, EdFiLocalEducationAgency>()
@@ -141,7 +143,8 @@ namespace EdFi.Ods.AdminApp.Management.Api.Automapper
                 .ForCtorParam("categories", opt => opt.MapFrom(EducationOrganizationCategoryResolver.Resolve))
                 .ForCtorParam("localEducationAgencyId", opt => opt.MapFrom(src => src.LocalEducationAgencyId))
                 .ForCtorParam("localEducationAgencyCategoryDescriptor", opt => opt.MapFrom(src => src.LocalEducationAgencyCategoryType))
-                .ForCtorParam("nameOfInstitution", opt => opt.MapFrom(src => src.Name));
+                .ForCtorParam("nameOfInstitution", opt => opt.MapFrom(src => src.Name))
+                .ForCtorParam("stateEducationAgencyReference", opt => opt.MapFrom(StateEducationAgencyReferenceResolver.Resolve));
 
             CreateMap<PostSecondaryInstitution, EdFiPostSecondaryInstitution>()
                 .ForMember(dst => dst.Id, opt => opt.MapFrom(src => src.Id))

--- a/Application/EdFi.Ods.AdminApp.Management/Api/Automapper/LocalEducationAgencyReferenceResolver.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/Automapper/LocalEducationAgencyReferenceResolver.cs
@@ -18,5 +18,12 @@ namespace EdFi.Ods.AdminApp.Management.Api.Automapper
 
             return id != null ? new EdFiLocalEducationAgencyReference(id) :  null;
         }
+
+        public static EdFiLocalEducationAgencyReference Resolve(School source, ResolutionContext context)
+        {
+            var id = source.LocalEducationAgencyId;
+
+            return id != null ? new EdFiLocalEducationAgencyReference(id) : null;
+        }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management/Api/Automapper/StateEducationAgencyReferenceResolver.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/Automapper/StateEducationAgencyReferenceResolver.cs
@@ -19,5 +19,12 @@ namespace EdFi.Ods.AdminApp.Management.Api.Automapper
 
             return id != null ? new EdFiStateEducationAgencyReference(id) : null;
         }
+
+        public static EdFiStateEducationAgencyReference Resolve(LocalEducationAgency source, ResolutionContext context)
+        {
+            var id = source.StateOrganizationId;
+
+            return id != null ? new EdFiStateEducationAgencyReference(id) : null;
+        }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.2" />
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="6.0.2" />
-    <PackageReference Include="AutoMapper" Version="10.1.1" />
+    <PackageReference Include="AutoMapper" Version="11.0.1" />
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="dbup-core" Version="4.5.0" />
     <PackageReference Include="dbup-postgresql" Version="4.5.0" />

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -26,8 +26,8 @@
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="27.2.1" />
-    <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
+    <PackageReference Include="AutoMapper" Version="11.0.1" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
     <PackageReference Include="EdFi.Admin.LearningStandards.Core" Version="1.2.27" />
     <PackageReference Include="EdFi.Suite3.LoadTools" Version="5.4.12" />
     <PackageReference Include="FluentValidation" Version="10.4.0" />


### PR DESCRIPTION
**NOTE: This is related to the temporary fix introduced in [ODST-214](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-AdminApp/pull/332) and so warrants a test to the issue highlighted in that ticket as well.**
**Description**
- Upgraded AutoMapper (to the latest 11.0.1) and AutoMapper.Extensions.Microsoft.DependencyInjection (to the latest 11.0.0) packages.
- Added static Resolve() overloads for LocalEducationAgencyReferenceResolver and StateEducationAgencyReferenceResolver.
- Added missing "CtorParam" mapping configuration to fix the Resolver not being called issues.