### PR TITLE
[AA-1507] - Remove hard-coded claimset names and use database flags

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/AddClaimSetCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/AddClaimSetCommandTests.cs
@@ -41,6 +41,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 
             var addedClaimSet = Transaction(securityContext => securityContext.ClaimSets.Single(x => x.ClaimSetId == addedClaimSetId));
             addedClaimSet.ClaimSetName.ShouldBe(newClaimSet.ClaimSetName);
+            addedClaimSet.ForApplicationUseOnly.ShouldBe(false);
+            addedClaimSet.IsEdfiPreset.ShouldBe(false);
         }
 
         [Test]

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/CopyClaimSetCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/CopyClaimSetCommandTests.cs
@@ -49,6 +49,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 
             var copiedClaimSet = Transaction(securityContext => securityContext.ClaimSets.Single(x => x.ClaimSetId == copyClaimSetId));
             copiedClaimSet.ClaimSetName.ShouldBe(newClaimSet.Object.Name);
+            copiedClaimSet.ForApplicationUseOnly.ShouldBe(false);
+            copiedClaimSet.IsEdfiPreset.ShouldBe(false);
 
             var results = Scoped<IGetResourcesByClaimSetIdQuery, Management.ClaimSetEditor.ResourceClaim[]>(
                 query => query.AllResources(copiedClaimSet.ClaimSetId).ToArray());

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetClaimSetByIdQueryTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetClaimSetByIdQueryTests.cs
@@ -25,7 +25,13 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             };
             Save(testApplication);
 
-            var testClaimSet = new ClaimSet {ClaimSetName = "TestClaimSet", Application = testApplication};
+            var testClaimSet = new ClaimSet
+            {
+                ClaimSetName = "TestClaimSet",
+                Application = testApplication,
+                ForApplicationUseOnly = false,
+                IsEdfiPreset = false
+            };
             Save(testClaimSet);
 
             Scoped<IGetClaimSetByIdQuery>(query =>
@@ -34,6 +40,49 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 
                 result.Name.ShouldBe(testClaimSet.ClaimSetName);
                 result.Id.ShouldBe(testClaimSet.ClaimSetId);
+                result.IsEditable.ShouldBe(true);
+            });
+        }
+
+        [Test]
+        public void ShouldGetNonEditableClaimSetById()
+        {
+            var testApplication = new Application
+            {
+                ApplicationName = $"Test Application {DateTime.Now:O}"
+            };
+            Save(testApplication);
+
+            var systemReservedClaimSet = new ClaimSet
+            {
+                ClaimSetName = "SystemReservedClaimSet",
+                Application = testApplication,
+                ForApplicationUseOnly = true
+            };
+            Save(systemReservedClaimSet);
+
+            var edfiPresetClaimSet = new ClaimSet
+            {
+                ClaimSetName = "EdfiPresetClaimSet",
+                Application = testApplication,
+                ForApplicationUseOnly = false,
+                IsEdfiPreset = true
+            };
+            Save(edfiPresetClaimSet);
+
+            Scoped<IGetClaimSetByIdQuery>(query =>
+            {
+                var result = query.Execute(systemReservedClaimSet.ClaimSetId);
+
+                result.Name.ShouldBe(systemReservedClaimSet.ClaimSetName);
+                result.Id.ShouldBe(systemReservedClaimSet.ClaimSetId);
+                result.IsEditable.ShouldBe(false);
+
+                result = query.Execute(edfiPresetClaimSet.ClaimSetId);
+
+                result.Name.ShouldBe(edfiPresetClaimSet.ClaimSetName);
+                result.Id.ShouldBe(edfiPresetClaimSet.ClaimSetId);
+                result.IsEditable.ShouldBe(false);
             });
         }
     }

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetClaimSetsByApplicationNameQueryTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetClaimSetsByApplicationNameQueryTests.cs
@@ -31,7 +31,9 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             Save(new ClaimSet
             {
                 ClaimSetName = CloudOdsAdminApp.InternalAdminAppClaimSet,
-                Application = testApplication
+                Application = testApplication,
+                ForApplicationUseOnly = true,
+                IsEdfiPreset = true
             });
 
             Scoped<IGetClaimSetsByApplicationNameQuery>(query =>
@@ -52,13 +54,17 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             Save(new ClaimSet
             {
                 ClaimSetName = "Bootstrap Descriptors and EdOrgs",
-                Application = testApplication
+                Application = testApplication,
+                ForApplicationUseOnly = true,
+                IsEdfiPreset = true
             });
 
             Save(new ClaimSet
             {
                 ClaimSetName = CloudOdsAdminApp.InternalAdminAppClaimSet,
-                Application = testApplication
+                Application = testApplication,
+                ForApplicationUseOnly = true,
+                IsEdfiPreset = true
             });
 
             Scoped<IGetClaimSetsByApplicationNameQuery>(query =>
@@ -110,7 +116,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             Save(new ClaimSet
             {
                 ClaimSetName = "SIS Vendor",
-                Application = testApplication
+                Application = testApplication,
+                IsEdfiPreset = true
             });
 
             Scoped<IGetClaimSetsByApplicationNameQuery>(query =>

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Configuration/Claims/CloudOdsClaimSetConfiguratorTester.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Configuration/Claims/CloudOdsClaimSetConfiguratorTester.cs
@@ -88,6 +88,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Configuration.Claims
             configurator.ApplyConfiguration(testClaimSet);
 
             var claimSet = Transaction(securityContext => securityContext.ClaimSets.Single(cs => cs.ClaimSetName == testClaimSet.ClaimSetName));
+            claimSet.ForApplicationUseOnly.ShouldBe(false);
+            claimSet.IsEdfiPreset.ShouldBe(false);
 
             Transaction(securityContext =>
             {

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Queries/GetClaimSetNamesQueryTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Queries/GetClaimSetNamesQueryTests.cs
@@ -46,13 +46,61 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Database.Queries
             claimSetNames.ShouldContain(claimSet2.ClaimSetName);
         }
 
+        [Test]
+        public void Should_Retreive_ClaimSetNames_Excluding_SystemReserved_ClaimSets()
+        {
+            var application = new Application
+            {
+                ApplicationName = $"Test Application {DateTime.Now:O}"
+            };
+            Save(application);
+
+            var systemReservedClaimSet = GetClaimSet(application, systemReserved:true);
+            var nonSystemReservedClaimSet = GetClaimSet(application, systemReserved:false);
+            Save(systemReservedClaimSet, nonSystemReservedClaimSet);
+
+            var claimSetNames = Scoped<ISecurityContext, string[]>(securityContext =>
+            {
+                var query = new GetClaimSetNamesQuery(securityContext);
+                return query.Execute(excludeSystemReservedClaimSets:true).ToArray();
+            });
+
+            claimSetNames.ShouldNotContain(systemReservedClaimSet.ClaimSetName);
+            claimSetNames.ShouldContain(nonSystemReservedClaimSet.ClaimSetName);
+        }
+
+        [Test]
+        public void Should_Retreive_ClaimSetNames_Excluding_Preset_ClaimSets()
+        {
+            var application = new Application
+            {
+                ApplicationName = $"Test Application {DateTime.Now:O}"
+            };
+            Save(application);
+
+            var edfiPresetClaimSet = GetClaimSet(application, edfiPreset:true);
+            var nonEdfiPresetClaimSet = GetClaimSet(application, edfiPreset:false);
+            Save(edfiPresetClaimSet, nonEdfiPresetClaimSet);
+
+            var claimSetNames = Scoped<ISecurityContext, string[]>(securityContext =>
+            {
+                var query = new GetClaimSetNamesQuery(securityContext);
+                return query.Execute(excludeEdFiPresetClaimSets:true).ToArray();
+            });
+
+            claimSetNames.ShouldNotContain(edfiPresetClaimSet.ClaimSetName);
+            claimSetNames.ShouldContain(nonEdfiPresetClaimSet.ClaimSetName);
+        }
+
         private static int _claimSetId = 0;
-        private ClaimSet GetClaimSet(Application application)
+        private ClaimSet GetClaimSet(Application application, bool systemReserved = false, bool edfiPreset = false)
         {
             return new ClaimSet
             {
                 Application = application,
-                ClaimSetName = $"Test Claim Set {_claimSetId++} - {DateTime.Now:O}"
+                ClaimSetName = $"Test Claim Set {_claimSetId++} - {DateTime.Now:O}",
+                ForApplicationUseOnly = systemReserved,
+                IsEdfiPreset = edfiPreset
             };
         }
     }

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/AddClaimSetCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/AddClaimSetCommand.cs
@@ -22,7 +22,9 @@ namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
             var newClaimSet = new Security.DataAccess.Models.ClaimSet
             {
                 ClaimSetName = claimSet.ClaimSetName,
-                Application = _context.Applications.Single()
+                Application = _context.Applications.Single(),
+                IsEdfiPreset = false,
+                ForApplicationUseOnly = false
             };
             _context.ClaimSets.Add(newClaimSet);
             _context.SaveChanges();

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/CopyClaimSetCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/CopyClaimSetCommand.cs
@@ -25,7 +25,9 @@ namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
             var newClaimSet = new Security.DataAccess.Models.ClaimSet
             {
                 ClaimSetName = claimSet.Name,
-                Application = _context.Applications.Single()
+                Application = _context.Applications.Single(),
+                IsEdfiPreset = false,
+                ForApplicationUseOnly = false
             };
 
             var originalResourceClaims =

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/GetClaimSetByIdQuery.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/GetClaimSetByIdQuery.cs
@@ -5,7 +5,6 @@
 
 using System.Linq;
 using EdFi.Security.DataAccess.Contexts;
-using static EdFi.Ods.AdminApp.Management.ClaimSetEditor.GetClaimSetsByApplicationNameQuery;
 
 namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
 {
@@ -27,7 +26,7 @@ namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
             {
                 Id = securityContextClaimSet.ClaimSetId,
                 Name = securityContextClaimSet.ClaimSetName,
-                IsEditable = !DefaultClaimSets.Contains(securityContextClaimSet.ClaimSetName)
+                IsEditable = !securityContextClaimSet.ForApplicationUseOnly && !securityContextClaimSet.IsEdfiPreset
             };
         }
     }

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/GetClaimSetsByApplicationNameQuery.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/GetClaimSetsByApplicationNameQuery.cs
@@ -12,19 +12,6 @@ namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
 {
     public class GetClaimSetsByApplicationNameQuery : IGetClaimSetsByApplicationNameQuery
     {
-        public static readonly string[] DefaultClaimSets =
-        {
-            "SIS Vendor",
-            "Ed-Fi Sandbox",
-            "Roster Vendor",
-            "Assessment Vendor",
-            "Assessment Read",
-            "District Hosted SIS Vendor",
-            "AB Connect",
-            "Bootstrap Descriptors and EdOrgs",
-            "Education Preparation Program"
-        };
-
         private readonly ISecurityContext _securityContext;
         private readonly IUsersContext _usersContext;
 

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/GetClaimSetsByApplicationNameQuery.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/GetClaimSetsByApplicationNameQuery.cs
@@ -46,13 +46,14 @@ namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
         private ClaimSet[] GetClaimSetsByApplicationName(string applicationName)
         {
             return _securityContext.ClaimSets
-                .Where(x => !CloudOdsAdminApp.SystemReservedClaimSets.Contains(x.ClaimSetName))
+                .Where(x => !x.ForApplicationUseOnly)
                 .Where(x => x.Application.ApplicationName == applicationName)
                 .OrderBy(x => x.ClaimSetName)
                 .Select(x => new ClaimSet
                 {
                     Id = x.ClaimSetId,
-                    Name = x.ClaimSetName
+                    Name = x.ClaimSetName,
+                    IsEditable = !x.IsEdfiPreset
                 }).ToArray();
         }
 
@@ -75,7 +76,6 @@ namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
                 var applicationsCount = applicationsCounts
                     .SingleOrDefault(x => x.ClaimSetName == claimSet.Name)
                     ?.ApplicationsCount;
-                claimSet.IsEditable = !DefaultClaimSets.Contains(claimSet.Name);
                 claimSet.ApplicationsCount = applicationsCount.GetValueOrDefault();
             }
         }

--- a/Application/EdFi.Ods.AdminApp.Management/CloudOdsAdminApp.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/CloudOdsAdminApp.cs
@@ -12,11 +12,5 @@ namespace EdFi.Ods.AdminApp.Management
         public const string VendorName = "EdFi";
         public const string VendorNamespacePrefix = "http://ed-fi.org";
         public const string InternalAdminAppClaimSet = "Ed-Fi ODS Admin App";
-
-        public static readonly string[] SystemReservedClaimSets =
-        {
-            InternalAdminAppClaimSet,
-            "Bootstrap Descriptors and EdOrgs"
-        };
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management/Configuration/Claims/CloudOdsClaimSetConfigurator.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Configuration/Claims/CloudOdsClaimSetConfigurator.cs
@@ -40,7 +40,9 @@ namespace EdFi.Ods.AdminApp.Management.Configuration.Claims
             var claimSet = new ClaimSet
             {
                 Application = apiApplication,
-                ClaimSetName = configuration.ClaimSetName
+                ClaimSetName = configuration.ClaimSetName,
+                IsEdfiPreset = false,
+                ForApplicationUseOnly = false
             };
 
             _securityContext.ClaimSets.Add(claimSet);

--- a/Application/EdFi.Ods.AdminApp.Management/Database/Queries/GetClaimSetNamesQuery.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/Queries/GetClaimSetNamesQuery.cs
@@ -18,9 +18,21 @@ namespace EdFi.Ods.AdminApp.Management.Database.Queries
             _securityContext = securityContext;
         }
 
-        public IEnumerable<string> Execute()
+        public IEnumerable<string> Execute(bool excludeSystemReservedClaimSets = false, bool excludeEdFiPresetClaimSets = false)
         {
-            return _securityContext.ClaimSets
+            var claimSets = _securityContext.ClaimSets.AsEnumerable();
+
+            if (excludeSystemReservedClaimSets)
+            {
+                claimSets = claimSets.Where(x => !x.ForApplicationUseOnly);
+            }
+
+            if (excludeEdFiPresetClaimSets)
+            {
+                claimSets = claimSets.Where(x => !x.IsEdfiPreset);
+            }
+
+            return claimSets
                 .Select(x => x.ClaimSetName)
                 .Distinct()
                 .OrderBy(x => x)

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="dbup-postgresql" Version="4.5.0" />
     <PackageReference Include="dbup-sqlserver" Version="4.5.0" />
 
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="6.0.12" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.0.16" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="6.1.13" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.1.19" />
 
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.3" />
     <PackageReference Include="Flurl" Version="3.0.4" />

--- a/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
+++ b/Application/EdFi.Ods.AdminApp.Management/EdFi.Ods.AdminApp.Management.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="dbup-postgresql" Version="4.5.0" />
     <PackageReference Include="dbup-sqlserver" Version="4.5.0" />
 
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="6.1.13" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="6.0.12" />
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.1.19" />
 
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.3" />

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ApplicationController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ApplicationController.cs
@@ -264,7 +264,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
 
         private List<string> GetClaimSetNames()
         {
-            return _getClaimSetNamesQuery.Execute().Except(CloudOdsAdminApp.SystemReservedClaimSets).ToList();
+            return _getClaimSetNamesQuery.Execute(excludeSystemReservedClaimSets:true).ToList();
         }
 
         private static string GetApiUrlForDisplay(string apiUrl)


### PR DESCRIPTION
**Description**
- Upgraded Admin.DataAccess and Security.DataAccess packages to the latest versions.
- Updated Execute for GetClaimSetNamesQuery to include optional flags to exclude System Reserved and EdFi Preset claimsets. Added additional tests to validate the newly added flags. Updated the corresponding usage of the Execute method to avoid using the hardcoded SystemReservedClaimSets constant.
- Updated GetClaimSetsByApplicationNameQuery, GetClaimSetByIdQuery, AddClaimSetCommand and CopyClaimSetCommand   to use the new database flags instead of the hardcoded SystemReservedClaimSets and DefaultClaimSets constants. Updated the corresponding tests accordingly.
- Updated CloudOdsClaimSetConfigurator to explicitly set the new database flags while creating a claimset.
- Removed the unused hardcoded SystemReservedClaimSets and DefaultClaimSets constants.