### PR TITLE
[AA-1594] - Re-associate applications with renamed Claimsets

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/EditClaimSetCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/EditClaimSetCommandTests.cs
@@ -5,11 +5,13 @@
 
 using System;
 using System.Linq;
+using EdFi.Admin.DataAccess.Contexts;
 using NUnit.Framework;
 using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
 using Shouldly;
 using ClaimSet = EdFi.Security.DataAccess.Models.ClaimSet;
 using Application = EdFi.Security.DataAccess.Models.Application;
+using VendorApplication = EdFi.Admin.DataAccess.Models.Application;
 using EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets;
 using EdFi.Security.DataAccess.Contexts;
 using static EdFi.Ods.AdminApp.Management.Tests.Testing;
@@ -33,14 +35,87 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 
             var editModel = new EditClaimSetModel {ClaimSetName = "TestClaimSetEdited", ClaimSetId = alreadyExistingClaimSet.ClaimSetId};
 
-            Scoped<ISecurityContext>(securityContext =>
+            Scoped<IUsersContext>(usersContext =>
             {
-                var command = new EditClaimSetCommand(securityContext);
+                var command = new EditClaimSetCommand(TestContext, usersContext);
                 command.Execute(editModel);
             });
 
             var editedClaimSet = Transaction(securityContext => securityContext.ClaimSets.Single(x => x.ClaimSetId == alreadyExistingClaimSet.ClaimSetId));
             editedClaimSet.ClaimSetName.ShouldBe(editModel.ClaimSetName);
+        }
+
+        [Test]
+        public void ShouldEditClaimSetWithVendorApplications()
+        {
+            var testApplication = new Application
+            {
+                ApplicationName = $"Test Application {DateTime.Now:O}"
+            };
+            Save(testApplication);
+
+            var claimSetToBeEdited = new ClaimSet { ClaimSetName = $"TestClaimSet{Guid.NewGuid():N}", Application = testApplication };
+            Save(claimSetToBeEdited);
+            SetupVendorApplicationsForClaimSet(claimSetToBeEdited);
+
+            var claimSetNotToBeEdited = new ClaimSet { ClaimSetName = $"TestClaimSet{Guid.NewGuid():N}", Application = testApplication };
+            Save(claimSetNotToBeEdited);
+            SetupVendorApplicationsForClaimSet(claimSetNotToBeEdited);
+
+            var editModel = new EditClaimSetModel { ClaimSetName = "TestClaimSetEdited", ClaimSetId = claimSetToBeEdited.ClaimSetId };
+
+            Scoped<IUsersContext>(usersContext =>
+            {
+                var command = new EditClaimSetCommand(TestContext, usersContext);
+                command.Execute(editModel);
+            });
+
+            var editedClaimSet = Transaction(securityContext => securityContext.ClaimSets.Single(x => x.ClaimSetId == claimSetToBeEdited.ClaimSetId));
+            editedClaimSet.ClaimSetName.ShouldBe(editModel.ClaimSetName);
+            AssertApplicationsForClaimSet(claimSetToBeEdited.ClaimSetId, editModel.ClaimSetName);
+
+
+            var unEditedClaimSet = Transaction(securityContext => securityContext.ClaimSets.Single(x => x.ClaimSetId == claimSetNotToBeEdited.ClaimSetId));
+            unEditedClaimSet.ClaimSetName.ShouldBe(claimSetNotToBeEdited.ClaimSetName);
+            AssertApplicationsForClaimSet(claimSetNotToBeEdited.ClaimSetId, claimSetNotToBeEdited.ClaimSetName);
+        }
+
+        private void SetupVendorApplicationsForClaimSet(ClaimSet testClaimSet, int applicationCount = 5)
+        {
+            Scoped<IUsersContext>(usersContext =>
+            {
+                foreach (var _ in Enumerable.Range(1, applicationCount))
+                {
+                    usersContext.Applications.Add(new VendorApplication
+                    {
+                        ApplicationName = $"TestAppVendorName{Guid.NewGuid():N}",
+                        ClaimSetName = testClaimSet.ClaimSetName,
+                        OperationalContextUri = OperationalContext.DefaultOperationalContextUri
+                    });
+                }
+                usersContext.SaveChanges();
+            });
+        }
+
+        private void AssertApplicationsForClaimSet(int claimSetId, string claimSetNameToAssert)
+        {
+            var results = Scoped<IGetApplicationsByClaimSetIdQuery, Management.ClaimSetEditor.Application[]>(
+                query => query.Execute(claimSetId).ToArray());
+
+            Scoped<IUsersContext>(
+                usersContext =>
+                {
+                    var testApplications =
+                        usersContext.Applications.Where(x => x.ClaimSetName == claimSetNameToAssert).Select(
+                            x => new Application
+                            {
+                                ApplicationName = x.ApplicationName,
+                                ApplicationId = x.ApplicationId
+                            }).ToArray();
+
+                    results.Length.ShouldBe(testApplications.Length);
+                    results.Select(x => x.Name).ShouldBe(testApplications.Select(x => x.ApplicationName), true);
+                });
         }
 
         [Test]

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/EditClaimSetCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/EditClaimSetCommandTests.cs
@@ -72,12 +72,12 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 
             var editedClaimSet = Transaction(securityContext => securityContext.ClaimSets.Single(x => x.ClaimSetId == claimSetToBeEdited.ClaimSetId));
             editedClaimSet.ClaimSetName.ShouldBe(editModel.ClaimSetName);
-            AssertApplicationsForClaimSet(claimSetToBeEdited.ClaimSetId, editModel.ClaimSetName);
+            AssertVendorApplicationsForClaimSet(claimSetToBeEdited.ClaimSetId, editModel.ClaimSetName);
 
 
             var unEditedClaimSet = Transaction(securityContext => securityContext.ClaimSets.Single(x => x.ClaimSetId == claimSetNotToBeEdited.ClaimSetId));
             unEditedClaimSet.ClaimSetName.ShouldBe(claimSetNotToBeEdited.ClaimSetName);
-            AssertApplicationsForClaimSet(claimSetNotToBeEdited.ClaimSetId, claimSetNotToBeEdited.ClaimSetName);
+            AssertVendorApplicationsForClaimSet(claimSetNotToBeEdited.ClaimSetId, claimSetNotToBeEdited.ClaimSetName);
         }
 
         private void SetupVendorApplicationsForClaimSet(ClaimSet testClaimSet, int applicationCount = 5)
@@ -97,7 +97,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             });
         }
 
-        private void AssertApplicationsForClaimSet(int claimSetId, string claimSetNameToAssert)
+        private void AssertVendorApplicationsForClaimSet(int claimSetId, string claimSetNameToAssert)
         {
             var results = Scoped<IGetApplicationsByClaimSetIdQuery, Management.ClaimSetEditor.Application[]>(
                 query => query.Execute(claimSetId).ToArray());
@@ -106,12 +106,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
                 usersContext =>
                 {
                     var testApplications =
-                        usersContext.Applications.Where(x => x.ClaimSetName == claimSetNameToAssert).Select(
-                            x => new Application
-                            {
-                                ApplicationName = x.ApplicationName,
-                                ApplicationId = x.ApplicationId
-                            }).ToArray();
+                        usersContext.Applications.Where(x => x.ClaimSetName == claimSetNameToAssert).ToArray();
 
                     results.Length.ShouldBe(testApplications.Length);
                     results.Select(x => x.Name).ShouldBe(testApplications.Select(x => x.ApplicationName), true);

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetApplicationsByClaimSetIdQueryTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetApplicationsByClaimSetIdQueryTests.cs
@@ -37,11 +37,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
                 Scoped<IUsersContext>(usersContext =>
                 {
                     var testApplications =
-                        usersContext.Applications.Where(x => x.ClaimSetName == testClaimSet.ClaimSetName).Select(x => new Application
-                        {
-                            ApplicationName = x.ApplicationName,
-                            ApplicationId = x.ApplicationId
-                        }).ToArray();
+                        usersContext.Applications.Where(x => x.ClaimSetName == testClaimSet.ClaimSetName).ToArray();
                     results.Length.ShouldBe(testApplications.Length);
                     results.Select(x => x.Name).ShouldBe(testApplications.Select(x => x.ApplicationName), true);
                 });

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/EditClaimSetCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/EditClaimSetCommand.cs
@@ -4,27 +4,45 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Linq;
+using EdFi.Admin.DataAccess.Contexts;
 using EdFi.Security.DataAccess.Contexts;
 
 namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
 {
     public class EditClaimSetCommand
     {
-        private readonly ISecurityContext _context;
+        private readonly ISecurityContext _securityContext;
+        private readonly IUsersContext _usersContext;
 
-        public EditClaimSetCommand(ISecurityContext context)
+        public EditClaimSetCommand(ISecurityContext securityContext, IUsersContext usersContext)
         {
-            _context = context;
+            _securityContext = securityContext;
+            _usersContext = usersContext;
         }
 
         public int Execute(IEditClaimSetModel claimSet)
         {
-            var existingClaimSet = _context.ClaimSets.Single(x => x.ClaimSetId == claimSet.ClaimSetId);
+            var existingClaimSet = _securityContext.ClaimSets.Single(x => x.ClaimSetId == claimSet.ClaimSetId);
             existingClaimSet.ClaimSetName = claimSet.ClaimSetName;
 
-            _context.SaveChanges();
+            ReAssociateApplicationsToRenamedClaimSet(existingClaimSet.ClaimSetName, claimSet.ClaimSetName);
+
+            _securityContext.SaveChanges();
 
             return existingClaimSet.ClaimSetId;
+        }
+
+        private void ReAssociateApplicationsToRenamedClaimSet(string existingClaimSetName, string newClaimSetName)
+        {
+            var associatedApplications = _usersContext.Applications
+                .Where(x => x.ClaimSetName == existingClaimSetName);
+
+            foreach (var application in associatedApplications)
+            {
+                application.ClaimSetName = newClaimSetName;
+            }
+
+            _usersContext.SaveChanges();
         }
     }
 

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/EditClaimSetCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/EditClaimSetCommand.cs
@@ -23,26 +23,25 @@ namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
         public int Execute(IEditClaimSetModel claimSet)
         {
             var existingClaimSet = _securityContext.ClaimSets.Single(x => x.ClaimSetId == claimSet.ClaimSetId);
-            existingClaimSet.ClaimSetName = claimSet.ClaimSetName;
 
             ReAssociateApplicationsToRenamedClaimSet(existingClaimSet.ClaimSetName, claimSet.ClaimSetName);
+            existingClaimSet.ClaimSetName = claimSet.ClaimSetName;
 
             _securityContext.SaveChanges();
+            _usersContext.SaveChanges();
 
             return existingClaimSet.ClaimSetId;
-        }
 
-        private void ReAssociateApplicationsToRenamedClaimSet(string existingClaimSetName, string newClaimSetName)
-        {
-            var associatedApplications = _usersContext.Applications
-                .Where(x => x.ClaimSetName == existingClaimSetName);
-
-            foreach (var application in associatedApplications)
+            void ReAssociateApplicationsToRenamedClaimSet(string existingClaimSetName, string newClaimSetName)
             {
-                application.ClaimSetName = newClaimSetName;
-            }
+                var associatedApplications = _usersContext.Applications
+                    .Where(x => x.ClaimSetName == existingClaimSetName);
 
-            _usersContext.SaveChanges();
+                foreach (var application in associatedApplications)
+                {
+                    application.ClaimSetName = newClaimSetName;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
**Description**
- Added logic to re-associate applications to the renamed claimset.
- Added additional EditClaimSetCommand test to check vendor applications state after editing claimset.