### PR TITLE
[AA-1597] - Edit Claim Set flow should not work for Ed-Fi presets/ System-Reserved claimsets

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/EditClaimSetCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/EditClaimSetCommandTests.cs
@@ -115,5 +115,120 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             });
         }
 
+        [Test]
+        public void ShouldNotEditClaimSetIfNotAnExistingId()
+        {
+            EnsureZeroClaimSets();
+
+            var editModel = new EditClaimSetModel
+            {
+                ClaimSetName = "Not Existing ClaimSet",
+                ClaimSetId = 1
+            };
+
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var validator = new EditClaimSetModelValidator(securityContext);
+                var validationResults = validator.Validate(editModel);
+                validationResults.IsValid.ShouldBe(false);
+                validationResults.Errors.Single().ErrorMessage.ShouldBe("No such claim set exists in the database");
+            });
+
+            void EnsureZeroClaimSets()
+            {
+                Scoped<ISecurityContext>(database =>
+                {
+                    foreach (var entity in database.ClaimSets)
+                        database.ClaimSets.Remove(entity);
+                    database.SaveChanges();
+                });
+            }
+        }
+
+        [Test]
+        public void ShouldNotEditClaimSetIfNotEditable()
+        {
+            var testApplication = new Application
+            {
+                ApplicationName = $"Test Application {DateTime.Now:O}"
+            };
+            Save(testApplication);
+
+            var systemReservedClaimSet = new ClaimSet
+            {
+                ClaimSetName = "SystemReservedClaimSet",
+                Application = testApplication,
+                ForApplicationUseOnly = true
+            };
+            Save(systemReservedClaimSet);
+
+            var edfiPresetClaimSet = new ClaimSet
+            {
+                ClaimSetName = "EdfiPresetClaimSet",
+                Application = testApplication,
+                ForApplicationUseOnly = false,
+                IsEdfiPreset = true
+            };
+            Save(edfiPresetClaimSet);
+
+            var systemReservedAndEdfiPresetClaimSet = new ClaimSet
+            {
+                ClaimSetName = "SystemReservedAndEdfiPresetClaimSet",
+                Application = testApplication,
+                ForApplicationUseOnly = true,
+                IsEdfiPreset = true
+            };
+            Save(systemReservedAndEdfiPresetClaimSet);
+
+            var editableClaimSet = new ClaimSet
+            {
+                ClaimSetName = "EditableClaimSet",
+                Application = testApplication,
+                ForApplicationUseOnly = false,
+                IsEdfiPreset = false
+            };
+            Save(editableClaimSet);
+
+            var systemReservedClaimSetEditModel = new EditClaimSetModel
+            {
+                ClaimSetName = systemReservedClaimSet.ClaimSetName, ClaimSetId = systemReservedClaimSet.ClaimSetId
+            };
+
+            var edfiPresetClaimSetEditModel = new EditClaimSetModel
+            {
+                ClaimSetName = systemReservedClaimSet.ClaimSetName, ClaimSetId = systemReservedClaimSet.ClaimSetId
+            };
+
+            var systemReservedAndEdfiPresetClaimSetEditModel = new EditClaimSetModel
+            {
+                ClaimSetName = systemReservedAndEdfiPresetClaimSet.ClaimSetName, ClaimSetId = systemReservedAndEdfiPresetClaimSet.ClaimSetId
+            };
+
+            var editableClaimSetEditModel = new EditClaimSetModel
+            {
+                ClaimSetName = editableClaimSet.ClaimSetName, ClaimSetId = editableClaimSet.ClaimSetId
+            };
+
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var validator = new EditClaimSetModelValidator(securityContext);
+                var validationResults = validator.Validate(systemReservedClaimSetEditModel);
+                validationResults.IsValid.ShouldBe(false);
+                validationResults.Errors.Single().ErrorMessage.ShouldBe("Only user created claim sets can be edited");
+
+                validationResults = validator.Validate(edfiPresetClaimSetEditModel);
+                validationResults.IsValid.ShouldBe(false);
+                validationResults.Errors.Single().ErrorMessage.ShouldBe("Only user created claim sets can be edited");
+
+                validationResults = validator.Validate(systemReservedAndEdfiPresetClaimSetEditModel);
+                validationResults.IsValid.ShouldBe(false);
+                validationResults.Errors.Single().ErrorMessage.ShouldBe("Only user created claim sets can be edited");
+
+                validationResults = validator.Validate(editableClaimSetEditModel);
+                validationResults.IsValid.ShouldBe(true);
+                validationResults.Errors.ShouldBeEmpty();
+            });
+        }
+
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/GetClaimSetByIdQuery.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/GetClaimSetByIdQuery.cs
@@ -4,6 +4,8 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Linq;
+using System.Net;
+using EdFi.Ods.AdminApp.Management.ErrorHandling;
 using EdFi.Security.DataAccess.Contexts;
 
 namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
@@ -20,13 +22,21 @@ namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
         public ClaimSet Execute(int claimSetId)
         {
             var securityContextClaimSet = _securityContext.ClaimSets
-                .Single(x => x.ClaimSetId == claimSetId);
+                .SingleOrDefault(x => x.ClaimSetId == claimSetId);
 
-            return new ClaimSet
+            if (securityContextClaimSet != null)
             {
-                Id = securityContextClaimSet.ClaimSetId,
-                Name = securityContextClaimSet.ClaimSetName,
-                IsEditable = !securityContextClaimSet.ForApplicationUseOnly && !securityContextClaimSet.IsEdfiPreset
+                return new ClaimSet
+                {
+                    Id = securityContextClaimSet.ClaimSetId,
+                    Name = securityContextClaimSet.ClaimSetName,
+                    IsEditable = !securityContextClaimSet.ForApplicationUseOnly && !securityContextClaimSet.IsEdfiPreset
+                };
+            }
+
+            throw new AdminAppException("No such claim set exists in the database.")
+            {
+                StatusCode = HttpStatusCode.NotFound
             };
         }
     }

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ClaimSetsController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ClaimSetsController.cs
@@ -6,15 +6,16 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using EdFi.Ods.AdminApp.Management;
 using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
 using EdFi.Ods.AdminApp.Management.Database.Models;
 using EdFi.Ods.AdminApp.Management.Database.Queries;
+using EdFi.Ods.AdminApp.Management.ErrorHandling;
 using EdFi.Ods.AdminApp.Web.ActionFilters;
 using EdFi.Ods.AdminApp.Web.Display.TabEnumeration;
-using EdFi.Ods.AdminApp.Web.Helpers;
 using EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets;
 using Newtonsoft.Json;
 using static EdFi.Ods.AdminApp.Web.Infrastructure.ResourceClaimSelectListBuilder;
@@ -187,6 +188,15 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         private EditClaimSetModel GetEditClaimSetModel(int claimSetId)
         {
             var existingClaimSet = _getClaimSetByIdQuery.Execute(claimSetId);
+
+            if (!existingClaimSet.IsEditable)
+            {
+                throw new AdminAppException("Only user created claim sets can be edited")
+                {
+                    StatusCode = HttpStatusCode.MethodNotAllowed
+                };
+            }
+
             var allResourceClaims = _getResourceClaimsQuery.Execute().ToList();
 
             return new EditClaimSetModel

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/EditClaimSetModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/EditClaimSetModel.cs
@@ -34,11 +34,20 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
                 .NotEmpty()
                 .Must(BeAUniqueName)
                 .WithMessage("A claim set with this name already exists in the database. Please enter a unique name.")
-                .When(NameIsChanged);
+                .When(m => BeAnExistingClaimSet(m.ClaimSetId) && NameIsChanged(m));
 
             RuleFor(m => m.ClaimSetName)
                 .MaximumLength(255)
                 .WithMessage("The claim set name must be less than 255 characters.");
+
+            RuleFor(m => m.ClaimSetId).NotEmpty()
+                .Must(BeAnExistingClaimSet)
+                .WithMessage("No such claim set exists in the database");
+
+            RuleFor(m => m.ClaimSetId)
+                .Must(BeAnEditableClaimSet)
+                .WithMessage("Only user created claim sets can be edited")
+                .When(m => BeAnExistingClaimSet(m.ClaimSetId));
         }
 
         private bool NameIsChanged(EditClaimSetModel model)
@@ -49,6 +58,17 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
         private bool BeAUniqueName(string newName)
         {
             return !_securityContext.ClaimSets.Any(x => x.ClaimSetName == newName);
+        }
+
+        private bool BeAnExistingClaimSet(int id)
+        {
+            return _securityContext.ClaimSets.SingleOrDefault(x => x.ClaimSetId == id) != null;
+        }
+
+        private bool BeAnEditableClaimSet(int id)
+        {
+            var claimSet = _securityContext.ClaimSets.Single(x => x.ClaimSetId == id);
+            return !claimSet.ForApplicationUseOnly && !claimSet.IsEdfiPreset;
         }
     }
 }


### PR DESCRIPTION
**Description**
- Added a check to ensure that the claimset being edited is editable and throw an exception if it's not.
- Refactored GetClaimSetByIdQuery to check if the claimset exists and throw an exception if it does not exist. Added associated unit test.
- Refactored EditClaimSetModel to add validations to check if the claimset exists and is editable. Added associated unit tests for the same.