### PR TITLE
[AA-1628] Fix Test Report Paths + Optimize (Unforked)

### DIFF
--- a/.github/workflows/after-pullrequest.yml
+++ b/.github/workflows/after-pullrequest.yml
@@ -21,6 +21,6 @@ jobs:
         with:
           artifact: csharp-tests
           name: C# Unit Test Results
-          path: "*.trx"
+          path: "**/*.trx"
           reporter: dotnet-trx
           fail-on-error: false

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -53,11 +53,11 @@ jobs:
         if: success()
         run: ./build.ps1 -Command UnitTest -Configuration Debug
 
-      - name: Upload Test Results
+      - name: Upload Test Results as Artifact
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: csharp-tests
-          path: TestResults/unit-tests.trx
+          path: "**/*.trx"
           retention-days: 5
 
       - name: Dependency Review ("Dependabot on PR")

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -69,10 +69,7 @@ jobs:
         with:
           languages: csharp
 
-      # Must build the software after initialization of CodeQL; something about
-      # CodeQL initialization causes the resulting build to fail unit tests.
-      # Therefore rebuilding here, even though also built above.
-      - name: Build
+      - name: Rebuild for CodeQL
         run: ./build.ps1 -Command Build -Configuration Debug
 
       - name: Perform CodeQL Analysis

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -31,8 +31,8 @@ jobs:
     with:
       config-file-path: ./.github/workflows/bidi-config.json
 
-  run-cs-tests:
-    name: Run C# Tests
+  build-and-test:
+    name: Build and Test
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -53,7 +53,7 @@ jobs:
         if: success()
         run: ./build.ps1 -Command UnitTest -Configuration Debug
 
-      - name: Upload Test Results as Artifact
+      - name: Upload Results as Workflow Artifact
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: csharp-tests

--- a/build.ps1
+++ b/build.ps1
@@ -244,7 +244,8 @@ function RunTests {
         Invoke-Execute {
             dotnet test $_ `
                 --logger "trx;LogFileName=$($_).trx" `
-                --nologo
+                --nologo `
+                --no-build
         }
     }
 }


### PR DESCRIPTION
Fixes to the OnPullRequest workflow found during improvements spike. Recreated from #363 commits directly for this repo instead of a fork in an attempt to get checks to pass correctly.

- fix C# test report paths to correctly capture artifact
- fix unit tests to not rebuild
- other cleanup:
  - shorten or change names for "check" readability
  - remove comments

The test reporter fix won't work until it's merged into main, since it happens after the pull request. I wonder if it is possible to determine if the PR source is from a fork, so we can take different paths for forks vs. not (not that it would help here)