### PR TITLE
[AA-1783] Replace Auto-Validation in FluentValidation for .NET 8 and Display Updated ValidationSummaryReplace Auto-Validation in FluentValidation for .NET 8 and Display Updated ValidationSummary

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web/ActionFilters/FluentValidationManualFilter.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/ActionFilters/FluentValidationManualFilter.cs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentValidation;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EdFi.Ods.AdminApp.Web.ActionFilters
+{
+    public class FluentValidationManualFilter : IAsyncActionFilter
+    {
+        public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+        {
+            foreach (var arg in context.ActionArguments)
+            {
+                if (arg.Value == null)
+                {
+                    continue;
+                }
+                var validatorType = typeof(IValidator<>).MakeGenericType(arg.Value.GetType());
+                var validator = context.HttpContext.RequestServices.GetService(validatorType) as IValidator;
+                if (validator == null)
+                {
+                    continue;
+                }
+                var validationContext = new ValidationContext<object>(arg.Value);
+                var result = await validator.ValidateAsync(validationContext);
+                if (!result.IsValid)
+                {
+                    foreach (var error in result.Errors)
+                    {
+                        context.ModelState.TryAddModelError(error.PropertyName, error.ErrorMessage);
+                    }
+                }
+            }
+            // Stop the pipeline if validation failed
+           /* if (!context.ModelState.IsValid)
+            {
+                // Optionally, set a result here (e.g., BadRequestObjectResult for APIs)
+                // For MVC, just return and let existing filters handle the response
+                return;
+            }*/
+            await next();
+        }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Web/ActionFilters/FluentValidationManualFilter.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/ActionFilters/FluentValidationManualFilter.cs
@@ -6,10 +6,13 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using EdFi.Ods.AdminApp.Web.Helpers;
 using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
 
 namespace EdFi.Ods.AdminApp.Web.ActionFilters
 {
@@ -40,12 +43,30 @@ namespace EdFi.Ods.AdminApp.Web.ActionFilters
                 }
             }
             // Stop the pipeline if validation failed
-           /* if (!context.ModelState.IsValid)
+            if (!context.ModelState.IsValid)
             {
-                // Optionally, set a result here (e.g., BadRequestObjectResult for APIs)
-                // For MVC, just return and let existing filters handle the response
+                // Handle AJAX requests
+                if (context.HttpContext.Request.IsAjaxRequest())
+                {
+                    var jsonSerializerSettings = new JsonSerializerSettings
+                    {
+                        ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+                    };
+
+                    var contentResult = new ContentResult
+                    {
+                        Content = JsonConvert.SerializeObject(context.ModelState, jsonSerializerSettings),
+                        ContentType = "application/json",
+                        StatusCode = 400,
+                    };
+
+                    context.Result = contentResult;
+                    return;
+                }
+
+                // For non-AJAX requests, let existing filters handle the response
                 return;
-            }*/
+            }
             await next();
         }
     }

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ApplicationController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ApplicationController.cs
@@ -158,7 +158,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
 
         [HttpPost]
         //[AddTelemetry("Add Application")]
-        public async Task<ActionResult> Add(AddApplicationModel model)
+        public ActionResult Add(AddApplicationModel model)
         {
             var result = _addApplicationCommand.Execute(model);
 

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ApplicationController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ApplicationController.cs
@@ -3,11 +3,6 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
 using AutoMapper;
 using EdFi.Ods.AdminApp.Management;
 using EdFi.Ods.AdminApp.Management.Api;
@@ -20,6 +15,12 @@ using EdFi.Ods.AdminApp.Web.Helpers;
 using EdFi.Ods.AdminApp.Web.Infrastructure;
 using EdFi.Ods.AdminApp.Web.Models.ViewModels;
 using EdFi.Ods.AdminApp.Web.Models.ViewModels.Application;
+using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace EdFi.Ods.AdminApp.Web.Controllers
 {
@@ -157,8 +158,24 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
 
         [HttpPost]
         //[AddTelemetry("Add Application")]
-        public ActionResult Add(AddApplicationModel model)
+        public async Task<ActionResult> Add(AddApplicationModel model)
         {
+
+            if (!ModelState.IsValid)
+            {
+                if (Request.IsAjaxRequest())
+                {
+                    return new ContentResult
+                    {
+                        Content = JsonConvert.SerializeObject(
+                            ModelState,
+                            new JsonSerializerSettings { ReferenceLoopHandling = ReferenceLoopHandling.Ignore }),
+                        ContentType = "application/json",
+                        StatusCode = 400
+                    };
+                }
+            }
+
             var result = _addApplicationCommand.Execute(model);
 
             var apiUrl = CloudOdsApiConnectionInformationProvider.GetConnectionInformationForEnvironment(

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ApplicationController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ApplicationController.cs
@@ -160,22 +160,6 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
         //[AddTelemetry("Add Application")]
         public async Task<ActionResult> Add(AddApplicationModel model)
         {
-
-            if (!ModelState.IsValid)
-            {
-                if (Request.IsAjaxRequest())
-                {
-                    return new ContentResult
-                    {
-                        Content = JsonConvert.SerializeObject(
-                            ModelState,
-                            new JsonSerializerSettings { ReferenceLoopHandling = ReferenceLoopHandling.Ignore }),
-                        ContentType = "application/json",
-                        StatusCode = 400
-                    };
-                }
-            }
-
             var result = _addApplicationCommand.Execute(model);
 
             var apiUrl = CloudOdsApiConnectionInformationProvider.GetConnectionInformationForEnvironment(

--- a/Application/EdFi.Ods.AdminApp.Web/Startup.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Startup.cs
@@ -86,6 +86,7 @@ namespace EdFi.Ods.AdminApp.Web
                         options.Filters.Add<JsonValidationFilter>();
                         options.Filters.Add<SetupRequiredFilter>();
                         options.Filters.Add<InstanceContextFilter>();
+                        options.Filters.Add<FluentValidationManualFilter>();
                     });
 
             // FluentValidation 12 configuration


### PR DESCRIPTION
- Add a Filter to run existing validators
- Return updated ModelState with any validation error
- Update the return to enable Validation Summary messages for modals
![image](https://github.com/user-attachments/assets/034643f7-b572-4993-b2ae-c5b372e5257a)