### PR TITLE
Potential fix for code scanning alert no. 222: Incomplete string escaping or encoding

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Web/wwwroot/Scripts/site-form-handlers.js
+++ b/Application/EdFi.Ods.AdminApp.Web/wwwroot/Scripts/site-form-handlers.js
@@ -170,8 +170,8 @@ var highlightFields = function (response) {
     $(".form-group").removeClass("has-error");
 
     $.each(response, function (propName, val) {
-        var nameSelector = '[name = "' + propName.replace(/(:|\.|\[|\])/g, "\\$1") + '"]';
-        var idSelector = '#' + propName.replace(/(:|\.|\[|\])/g, "\\$1");
+        var nameSelector = '[name = "' + propName.replace(/([:\\.\\[\\]\\\\])/g, "\\$1") + '"]';
+        var idSelector = '#' + propName.replace(/([:\\.\\[\\]\\\\])/g, "\\$1");
         var element = $(nameSelector) || $(idSelector);
 
         if (val.Errors.length > 0) {


### PR DESCRIPTION
Potential fix for [https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-AdminApp/security/code-scanning/222](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-AdminApp/security/code-scanning/222)

To fix the issue, the regular expression used in `replace` should be updated to include backslashes (`\`) as part of the characters to escape. This ensures that all special characters, including backslashes, are properly escaped when constructing jQuery selectors. The updated regular expression will replace `(:|\.|\[|\])` with `([:\\.\\[\\]\\\\])`, where `\\\\` represents an escaped backslash.

The fix involves modifying line 174 to use the updated regular expression. No additional imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
