### PR TITLE
[AA-1801] Trim leading and trailing spaces in claim set names to ensure proper validation of existing claim sets

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/SharingModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/SharingModel.cs
@@ -49,7 +49,13 @@ namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
 
     public class SharingClaimSet
     {
-        public string Name { get; set; }
+        private string _name;
+        
+        public string Name 
+        { 
+            get => _name; 
+            set => _name = value?.Trim(); 
+        }
         public List<JObject> ResourceClaims { get; set; }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/AddClaimSetModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/AddClaimSetModel.cs
@@ -12,7 +12,13 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
 {
     public class AddClaimSetModel : IAddClaimSetModel
     {
-        public string ClaimSetName { get; set; }
+        private string _claimSetName;
+        
+        public string ClaimSetName 
+        { 
+            get => _claimSetName; 
+            set => _claimSetName = value?.Trim(); 
+        }
     }
 
     public class AddClaimSetModelValidator : AbstractValidator<AddClaimSetModel>
@@ -34,7 +40,8 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
 
         private bool BeAUniqueName(string newName)
         {
-            return _getAllClaimSetsQuery.Execute().All(x => x.Name != newName);
+            var trimmedName = newName?.Trim();
+            return _getAllClaimSetsQuery.Execute().All(x => x.Name?.Trim() != trimmedName);
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/ClaimSetFileImportModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/ClaimSetFileImportModel.cs
@@ -108,8 +108,9 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
 
                 bool IsAnExistingClaimSetName(string sharingClaimSetName)
                 {
+                    var trimmedName = sharingClaimSetName?.Trim();
                     var claimSets = getAllClaimSetsQuery.Execute().ToList();
-                    return claimSets.Any(x => x.Name == sharingClaimSetName);
+                    return claimSets.Any(x => x.Name?.Trim() == trimmedName);
                 }
             }
         }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/CopyClaimSetModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/CopyClaimSetModel.cs
@@ -12,7 +12,13 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
 {
     public class CopyClaimSetModel : ICopyClaimSetModel
     {
-        public string Name { get; set; }
+        private string _name;
+        
+        public string Name 
+        { 
+            get => _name; 
+            set => _name = value?.Trim(); 
+        }
         public int OriginalId { get; set; }
         public string OriginalName { get; set; }
     }
@@ -34,7 +40,8 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
 
         private bool BeAUniqueName(string newName)
         {
-            return _getAllClaimSetsQuery.Execute().All(x => x.Name != newName);
+            var trimmedName = newName?.Trim();
+            return _getAllClaimSetsQuery.Execute().All(x => x.Name?.Trim() != trimmedName);
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/EditClaimSetModel.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Models/ViewModels/ClaimSets/EditClaimSetModel.cs
@@ -16,7 +16,13 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
 {
     public class EditClaimSetModel : IEditClaimSetModel
     {
-        public string ClaimSetName { get; set; }
+        private string _claimSetName;
+        
+        public string ClaimSetName 
+        { 
+            get => _claimSetName; 
+            set => _claimSetName = value?.Trim(); 
+        }
         public int ClaimSetId { get; set; }
         public IEnumerable<VendorApplication> Applications { get; set; }
         public IEnumerable<ResourceClaim> ResourceClaims { get; set; }
@@ -59,7 +65,8 @@ namespace EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets
 
         private bool BeAUniqueName(string newName)
         {
-            return _getAllClaimSetsQuery.Execute().All(x => x.Name != newName);
+            var trimmedName = newName?.Trim();
+            return _getAllClaimSetsQuery.Execute().All(x => x.Name?.Trim() != trimmedName);
         }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_AddClaimSet.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_AddClaimSet.cshtml
@@ -14,7 +14,7 @@ See the LICENSE and NOTICES files in the project root for more information.
     @Html.AntiForgeryToken()
     <div id="add-claim-set-validation-summary" class="validationSummary alert alert-danger" hidden></div>
     <div class="form-group row">        
-        @Html.InputBlock(m => m.ClaimSetName, inputModifier: x => x.Attr("maxlength", 255))
+        @Html.InputBlock(m => m.ClaimSetName, inputModifier: x => x.Attr("maxlength", 255).Attr("id", "claimset-name-input"))
     </div>
     <br />
     <div class="padding-top-5">
@@ -25,6 +25,13 @@ See the LICENSE and NOTICES files in the project root for more information.
 <script type="text/javascript">
     $('#add-claim-set-form').submit(function (e) {
         e.preventDefault();
+        
+        // Trim the ClaimSetName input before submitting
+        var claimsetNameInput = $('#claimset-name-input');
+        if (claimsetNameInput.length) {
+            claimsetNameInput.val(claimsetNameInput.val().trim());
+        }
+        
         var successAdditionalBehavior = function() {
             ClaimSetToastrMessage("New Claimset added successfully", true);
             ClaimSetWarningMessage(true);

--- a/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_CopyClaimSetModal.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_CopyClaimSetModal.cshtml
@@ -19,11 +19,11 @@ See the LICENSE and NOTICES files in the project root for more information.
                 <div class="padding-bottom-10">
                     Do you want to make a copy of the claimset - <b>@Model.OriginalName</b>?
                 </div>
-                @using (Html.BeginForm("CopyClaimSet", "ClaimSets", FormMethod.Post, new { data_tab_claimset = true }))
+                @using (Html.BeginForm("CopyClaimSet", "ClaimSets", FormMethod.Post, new { data_tab_claimset = true, @id = "copy-claim-set-form" }))
                 {
                     @Html.Input(m => m.OriginalId).Hide()
                     @Html.ValidationBlock()
-                    @Html.InputBlock(m => m.Name, inputModifier: x => x.Attr("maxlength", 255))
+                    @Html.InputBlock(m => m.Name, inputModifier: x => x.Attr("maxlength", 255).Attr("id", "copy-claimset-name-input"))
                 }
             </div>
             <div class="modal-footer">
@@ -33,3 +33,16 @@ See the LICENSE and NOTICES files in the project root for more information.
         </div>
     </div>
 </div>
+
+<script type="text/javascript">
+    $(document).ready(function() {
+        // Handle form submission for copy claim set modal
+        $('#copy-claim-set-form').submit(function(e) {
+            // Trim the Name input before submitting
+            var copyClaimsetNameInput = $('#copy-claimset-name-input');
+            if (copyClaimsetNameInput.length) {
+                copyClaimsetNameInput.val(copyClaimsetNameInput.val().trim());
+            }
+        });
+    });
+</script>

--- a/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_EditClaimSet.cshtml
+++ b/Application/EdFi.Ods.AdminApp.Web/Views/ClaimSets/_EditClaimSet.cshtml
@@ -86,6 +86,13 @@ else
 <script type="text/javascript">
     $('#edit-claim-set-form').submit(function (e) {
         e.preventDefault();
+        
+        // Trim the ClaimSetName input before submitting
+        var claimSetNameInput = $('#ClaimSetName');
+        if (claimSetNameInput.length) {
+            claimSetNameInput.val(claimSetNameInput.val().trim());
+        }
+        
         var postData = {
             'ClaimSetId': parseInt($("#ClaimSetId").val()),
             'ClaimSetName': $("#ClaimSetName").val()


### PR DESCRIPTION
Trim leading and trailing spaces in claim set names to ensure proper validation of existing claim sets

- Added validation in the client and server side